### PR TITLE
refactor(ui): add custom content support and optional controls to Steps c…

### DIFF
--- a/libs/ui/src/molecules/steps.tsx
+++ b/libs/ui/src/molecules/steps.tsx
@@ -72,6 +72,7 @@ export type StepItem = {
   value: number
   title: ReactNode
   description?: ReactNode
+  content?: ReactNode
   icon?: ReactNode
 }
 
@@ -86,6 +87,7 @@ export interface StepsProps extends VariantProps<typeof stepsVariants> {
   onStepChange?: (step: number) => void
   onStepComplete?: () => void
   className?: string
+  showControls?: boolean
 }
 
 export function Steps({
@@ -94,6 +96,7 @@ export function Steps({
   currentStep = 0,
   orientation = 'horizontal',
   linear = false,
+  showControls = true,
   completeText,
   onStepChange,
   onStepComplete,
@@ -155,13 +158,15 @@ export function Steps({
       {items.map((step, index) => (
         <div
           className={content()}
-          key={index}
+          key={`step-content-${index}`}
           {...api.getContentProps({ index })}
         >
-          <article className="h-fit">
-            <h3>{step.title}</h3>
-            {step.description && <p>{step.description}</p>}
-          </article>
+          {step.content || (
+            <article className="h-fit">
+              <h3>{step.title}</h3>
+              {step.description && <p>{step.description}</p>}
+            </article>
+          )}
         </div>
       ))}
       <div
@@ -171,24 +176,26 @@ export function Steps({
         {completeText}
       </div>
 
-      <div className={containerButtons()} data-orientation={orientation}>
-        <Button
-          theme="solid"
-          size="sm"
-          className={stepButton()}
-          {...api.getPrevTriggerProps()}
-        >
-          Back
-        </Button>
-        <Button
-          size="sm"
-          theme="solid"
-          className={stepButton()}
-          {...api.getNextTriggerProps()}
-        >
-          Next
-        </Button>
-      </div>
+      {showControls && (
+        <div className={containerButtons()} data-orientation={orientation}>
+          <Button
+            theme="solid"
+            size="sm"
+            className={stepButton()}
+            {...api.getPrevTriggerProps()}
+          >
+            Back
+          </Button>
+          <Button
+            size="sm"
+            theme="solid"
+            className={stepButton()}
+            {...api.getNextTriggerProps()}
+          >
+            Next
+          </Button>
+        </div>
+      )}
     </div>
   )
 }

--- a/libs/ui/stories/molecules/steps.stories.tsx
+++ b/libs/ui/stories/molecules/steps.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 import { Steps } from '../../src/molecules/steps'
+import { Select } from '../../src/molecules/select'
+import { Button } from '../../src/atoms/button'
 
 const meta: Meta<typeof Steps> = {
   title: 'Molecules/Steps',
@@ -117,8 +119,62 @@ export const ResponsiveOrientation: Story = {
             currentStep={currentStep}
             orientation="horizontal"
             onStepChange={setCurrentStep}
+            completeText={completeText}
           />
         </div>
+      </div>
+    )
+  },
+}
+
+// Example with custom content
+const stepsWithCustomContent = [
+  {
+    value: 0,
+    title: 'Account',
+    content: (
+      <div className="p-4 rounded-lg">
+        <h3 className="text-lg font-semibold mb-2">Create your account</h3>
+        <p>This is custom content for the account step.</p>
+        <button className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+          Custom Action
+        </button>
+      </div>
+    ),
+  },
+  {
+    value: 1,
+    title: 'Profile',
+    description: 'Complete your profile',
+    // No custom content, will use default rendering
+  },
+  {
+    value: 2,
+    title: 'Settings',
+    content: (
+      <div className="p-4 border border-gray-200 rounded">
+        <h3 className="font-semibold">Custom Settings Form</h3>
+        <label className="block mt-2">
+          <span className="text-gray-700">Preference</span>
+          <Select label="options" options={[{label: "first", value:"first"}, {label: "second", value: "second"}]} size='xs' />
+        </label>
+      </div>
+    ),
+  },
+]
+
+export const WithCustomContent: Story = {
+  render: () => {
+    const [currentStep, setCurrentStep] = useState(0)
+
+    return (
+      <div className="w-[700px]">
+        <Steps
+          items={stepsWithCustomContent}
+          currentStep={currentStep}
+          onStepChange={setCurrentStep}
+          completeText="All steps completed!"
+        />
       </div>
     )
   },


### PR DESCRIPTION
## PR Description

  ### Enhancement: Steps Component Flexibility

  While implementing the payment page in `frontend-demo`, I encountered the need for more
  flexible control over the Steps component:

  1. **Hide navigation controls** - The payment flow requires custom navigation logic, so the
  built-in "Back/Next" buttons needed to be optional
  2. **Custom content rendering** - Instead of just title and description, I needed to embed
  complete React components (forms, selectors, etc.) within each step

  ### Changes
  - Added `showControls` prop (default: `true`) to optionally hide the navigation buttons
  - Added `content` property to `StepItem` type to allow custom ReactNode content
  - When `content` is provided, it replaces the default title/description rendering
  - Updated Storybook with example showing custom content usage

  ### Usage Example
  ```tsx
  const steps = [
    {
      value: 0,
      title: 'Payment Method',
      content: <Component /> // Custom component
    }
  ]

  <Steps
    items={steps}
    showControls={false} // Hide default navigation
  />

  This allows full control over step content and navigation, making the Steps component more
  versatile for complex workflows like checkout processes.
  ```