### PR TITLE
feat(ui): add ColorSelect atom component

### DIFF
--- a/libs/ui/src/atoms/color-select.tsx
+++ b/libs/ui/src/atoms/color-select.tsx
@@ -1,0 +1,119 @@
+import { Button } from '@new-engine/ui/atoms/button'
+import { tv } from '@new-engine/ui/utils'
+import type { ButtonHTMLAttributes } from 'react'
+import type { VariantProps } from 'tailwind-variants'
+import { Icon } from './icon'
+
+const colorSelectVariants = tv({
+  slots: {
+    root: [
+      'relative cursor-pointer',
+      'aspect-square overflow-hidden',
+      'border-2 transition-all duration-200',
+      'border-color-selector-border hover:border-color-selector-border-hover shadow-color-selector',
+      'focus:outline-none focus:ring-2 focus:ring-color-selector-ring focus:ring-offset-2',
+      'data-[selected=true]:border-color-selector-selected data-[selected=true]:shadow-none',
+    ],
+    color: [
+      'absolute',
+      'w-full h-full hover:brightness-75',
+      'data-[selected=true]:brightness-75',
+    ],
+    icon: [
+      'absolute items-center hidden justify-center',
+      'text-color-selector-check drop-shadow-sm',
+      'pointer-events-none',
+      'data-[selected=true]:flex',
+    ],
+  },
+  variants: {
+    radius: {
+      sm: {
+        root: 'rounded-color-selector-sm',
+      },
+      md: {
+        root: 'rounded-color-selector-md',
+      },
+      lg: {
+        root: 'rounded-color-selector-lg',
+      },
+      full: {
+        root: 'rounded-color-selector-full',
+      },
+    },
+    size: {
+      sm: {
+        root: 'h-color-selector-sm',
+        icon: 'text-color-selector-sm',
+      },
+      md: {
+        root: 'h-color-selector-md',
+        icon: 'text-color-selector-md',
+      },
+      lg: {
+        root: 'h-color-selector-lg',
+        icon: 'text-color-selector-lg',
+      },
+      full: {
+        root: 'h-full',
+        icon: 'w-color-selector-size h-color-selector-size',
+      },
+    },
+    disabled: {
+      true: {
+        root: 'selector-disabled hover:border-color-selector-border',
+      },
+    },
+  },
+  defaultVariants: {
+    selected: false,
+    radius: 'full',
+    size: 'lg',
+  },
+})
+
+export interface ColorSelectorProps
+  extends ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof colorSelectVariants> {
+  color: string
+  selected?: boolean
+}
+
+export function ColorSelect({
+  className,
+  size,
+  selected = false,
+  disabled,
+  color,
+  radius,
+  ...props
+}: ColorSelectorProps) {
+  const styles = colorSelectVariants({ disabled, size, radius })
+
+  return (
+    <Button
+      theme="borderless"
+      className={styles.root({ className })}
+      disabled={disabled}
+      aria-label={`Select color ${color}`}
+      aria-checked={selected}
+      data-selected={selected}
+      {...props}
+    >
+      <span
+        className={styles.color()}
+        style={{ backgroundColor: color }}
+        aria-hidden="true"
+        data-selected={selected}
+      />
+
+      <Icon
+        icon="token-icon-color-selector-selected"
+        className={styles.icon()}
+        data-selected={selected}
+      />
+    </Button>
+  )
+}
+
+ColorSelect.displayName = 'ColorSelect'

--- a/libs/ui/src/tokens/components/atoms/_color-select.css
+++ b/libs/ui/src/tokens/components/atoms/_color-select.css
@@ -1,0 +1,37 @@
+@theme static {
+  /* === DERIVED COLORS === */
+  --color-color-selector-accent: var(--color-primary);
+  --color-color-selector-border: var(--color-highlight);
+  --color-color-selector-border-hover: var(--color-color-selector-accent);
+  --color-color-selector-selected: var(--color-color-selector-accent);
+  --color-color-selector-check: var(--color-white);
+  --color-color-selector-ring: var(--color-ring-primary);
+
+  /* === SPACING === */
+  --spacing-color-selector-sm: var(--spacing-250);
+  --spacing-color-selector-md: var(--spacing-350);
+  --spacing-color-selector-lg: var(--spacing-450);
+
+  /* === TYPOGRAPHY === */
+  --text-color-selector-sm: var(--text-xs);
+  --text-color-selector-md: var(--text-sm);
+  --text-color-selector-lg: var(--text-md);
+  --spacing-color-selector-size: 50%;
+
+  /* === BORDERS & RADIUS === */
+  --radius-color-selector-full: var(--radius-full);
+  --radius-color-selector-sm: var(--radius-sm);
+  --radius-color-selector-md: var(--radius-md);
+  --radius-color-selector-lg: var(--radius-2xl);
+
+  /* === SHADOWS === */
+  --shadow-color-selector: var(--shadow-sm);
+}
+
+@utility token-icon-color-selector-selected {
+  @apply token-icon-check-bold;
+}
+
+@utility selector-disabled {
+  @apply grayscale-75;
+}

--- a/libs/ui/src/tokens/components/atoms/_icon.css
+++ b/libs/ui/src/tokens/components/atoms/_icon.css
@@ -22,6 +22,14 @@
   @apply icon-[mdi-light--alert];
 }
 
+@utility token-icon-check {
+  @apply icon-[mdi--check];
+}
+
+@utility token-icon-check-bold {
+  @apply icon-[mdi--check-bold];
+}
+
 @utility token-icon-info {
   @apply icon-[mdi-light--information];
 }

--- a/libs/ui/src/tokens/components/components.css
+++ b/libs/ui/src/tokens/components/components.css
@@ -6,6 +6,7 @@
 @import "./atoms/_tabs.css";
 @import "./atoms/_textarea.css";
 @import "./atoms/_tooltip.css";
+@import "./atoms/_color-select.css";
 
 @import "./molecules/_accordion.css";
 @import "./molecules/_breadcrumb.css";

--- a/libs/ui/stories/atoms/color-select.stories.tsx
+++ b/libs/ui/stories/atoms/color-select.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { VariantContainer, VariantGroup } from '../../.storybook/decorator'
+import { ColorSelect } from '../../src/atoms/color-select'
+import { useState } from 'react'
+
+const meta: Meta<typeof ColorSelect> = {
+  title: 'Atoms/ColorSelect',
+  component: ColorSelect,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: 'ColorSelect is an atom component for selecting colors. It displays a color swatch with optional name and count, supporting various sizes and states including selected and disabled.'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    color: {
+      control: { type: 'color' },
+      description: 'The color to display (hex, rgb, hsl, or named color)'
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the color selector'
+    },
+    radius: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg', 'full'],
+      description: 'Border radius variant'
+    },
+    selected: {
+      control: { type: 'boolean' },
+      description: 'Whether the color is currently selected'
+    },
+    disabled: {
+      control: { type: 'boolean' },
+      description: 'Whether the color selector is disabled'
+    },
+    onClick: {
+      action: 'clicked',
+      description: 'Click handler for color selection'
+    }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    color: '#3b82f6',
+    colorName: 'Blue',
+    size: 'md',
+    radius: 'full',
+    selected: false,
+    disabled: false
+  }
+}
+
+export const States: Story = {
+  render: () => (
+    <VariantContainer>
+      <VariantGroup title="States">
+        <ColorSelect 
+          color="#3b82f6" 
+          aria-label="Select blue color for theme"
+        />
+        <ColorSelect 
+          color="#3b82f6" 
+          selected
+          aria-label="Success color currently selected"
+        />
+        <ColorSelect 
+          color="#3b82f6" 
+          disabled
+          aria-label="Error color (unavailable)"
+        />
+      </VariantGroup>
+    </VariantContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Accessibility features including proper ARIA labels, descriptions, and keyboard navigation support.'
+      }
+    }
+  }
+}
+
+export const AllVariants: Story = {
+  render: () => (
+    <VariantContainer>
+      <VariantGroup title="Radius Variants">
+        <ColorSelect color="#ef4444" radius="sm" size="lg" />
+        <ColorSelect color="#10b981" radius="md" size="lg" />
+        <ColorSelect color="#3b82f6" radius="lg" size="lg" />
+        <ColorSelect color="#f59e0b" radius="full" size="lg" selected />
+      </VariantGroup>
+      
+      <VariantGroup title="Size Variants - Full Radius">
+        <ColorSelect color="#8b5cf6" size="sm" radius="full" />
+        <ColorSelect color="#ec4899" size="md" radius="full" />
+        <ColorSelect color="#06b6d4" size="lg" radius="full" selected />
+      </VariantGroup>
+      
+      <VariantGroup title='Custom size'>
+        <div className='h-16'>
+          <ColorSelect color="#6366f1" radius='md' size="full" />
+        </div>
+      </VariantGroup>
+    </VariantContainer>
+  )
+}
+
+export const Interactive: Story = {
+  render: () => {
+    const [selectedColor, setSelectedColor] = useState<string | null>(null)
+    const [selectedColors, setSelectedColors] = useState<string[]>([])
+    const colors = [
+      { hex: '#ef4444', name: 'Red' },
+      { hex: '#f97316', name: 'Orange' },
+      { hex: '#f59e0b', name: 'Amber' },
+      { hex: '#84cc16', name: 'Lime' },
+      { hex: '#10b981', name: 'Emerald' },
+      { hex: '#06b6d4', name: 'Cyan' },
+    ]
+
+        const toggleColor = (colorHex: string) => {
+      setSelectedColors(prev => 
+        prev.includes(colorHex) 
+          ? prev.filter(c => c !== colorHex)
+          : [...prev, colorHex]
+      )
+    }
+    
+    return (
+      <div className="space-y-6">
+          <p className="text-fg-secondary text-sm mb-4">
+            Selected: {selectedColor ? colors.find(c => c.hex === selectedColor)?.name : 'None'}
+          </p>
+          <VariantGroup title="Interactive Color Selection">
+            {colors.map((color) => (
+              <ColorSelect
+                key={color.hex}
+                color={color.hex}
+                selected={selectedColor === color.hex}
+                onClick={() => setSelectedColor(color.hex === selectedColor ? null : color.hex)}
+              />
+            ))}
+          </VariantGroup>
+
+          <VariantGroup title="Multi-Select Color Palette">
+            {colors.map((color) => (
+              <ColorSelect
+                key={color.hex}
+                color={color.hex}
+                selected={selectedColors.includes(color.hex)}
+                onClick={() => toggleColor(color.hex)}
+              />
+            ))}
+          </VariantGroup>
+      </div>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Interactive example with useState for selection management. Click colors to select/deselect.'
+      }
+    }
+  }
+}
+
+


### PR DESCRIPTION
Add reusable ColorSelect component with comprehensive variants and design token integration.
Migrated and optimized from frontend-demo implementation.

This atomic component will replace custom ColorSwatch implementations in:
 - Color-palette templates
 - Future color selection UIs across the platform