### PR TITLE
refactor(ui): standardize color-select imports

### DIFF
--- a/libs/ui/src/molecules/color-select.tsx
+++ b/libs/ui/src/molecules/color-select.tsx
@@ -1,6 +1,6 @@
-import { Button } from '@new-engine/ui/atoms/button'
-import { tv } from '@new-engine/ui/utils'
+import { Button } from '../atoms/button'
 import { Icon } from '../atoms/icon'
+import { tv } from '../utils'
 
 const colorSelectVariants = tv({
   slots: {
@@ -61,6 +61,8 @@ const colorSelectVariants = tv({
         icon: 'text-color-select-lg',
       },
       full: {
+        group: 'h-full',
+        cell: 'h-full',
         atom: 'h-full',
         icon: 'w-color-select-icon h-color-select-icon',
       },

--- a/libs/ui/stories/overview/color-palette.stories.tsx
+++ b/libs/ui/stories/overview/color-palette.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import '../../src/tokens/_colors.css'
 import '../../src/tokens/_semantic.css'
-import { ColorSelect } from '../../../../apps/frontend-demo/src/components/atoms/color-select'
+import {ColorSelect} from '../../src/molecules/color-select'
 
 const meta: Meta = {
   title: 'Overview/Color Palette',
@@ -76,9 +76,10 @@ export const Default: Story = {
                           >
                             <div className="h-16 w-16 flex-shrink-0">
                               <ColorSelect
-                                color={computedColor}
+                                colors={[{ color: computedColor }]}
                                 size="full"
                                 radius="md"
+                                layout="list"
                               />
                             </div>
                             <div className="w-full text-center">


### PR DESCRIPTION
- Switch from absolute to relative imports in color-select.tsx
- Migrate ColorSelect usage from old single-color to new colors array 
- Extend full size variant with group and cell height styles