### PR TITLE
feat(ui): add container token group to validation lists

### DIFF
--- a/libs/ui/scripts/validate-token-definitions.js
+++ b/libs/ui/scripts/validate-token-definitions.js
@@ -104,6 +104,7 @@ function tokenToUtilityClasses(tokenName) {
       'fill',
       'stroke',
     ],
+    container: ['w', 'h', 'min-w', 'min-h', 'max-w', 'max-h'],
     spacing: [
       'p',
       'px',

--- a/libs/ui/scripts/validate-token-usage.js
+++ b/libs/ui/scripts/validate-token-usage.js
@@ -30,6 +30,7 @@ const NAMESPACE_MAPPINGS = {
     'caret',
     'decoration',
   ],
+  container: ['w', 'h', 'min-w', 'min-h', 'max-w', 'max-h'],
   spacing: [
     'p',
     'px',


### PR DESCRIPTION
Add the "container" token group to token usage and token definition
validation scripts. The group includes sizing-related tokens:
w, h, min-w, min-h, max, and max-hThis ensures container sizing tokens are recognized by the
validators and prevents false positives when those tokens are used
or defined.