### PR TITLE
fix(dialog): support configurable dialog positioning

### DIFF
--- a/libs/ui/src/molecules/dialog.tsx
+++ b/libs/ui/src/molecules/dialog.tsx
@@ -6,8 +6,8 @@ import { Button } from '../atoms/button'
 
 const dialogVariants = tv({
   slots: {
-    backdrop: ['fixed inset-0 z-(--z-dialog-backdrop)'],
-    positioner: ['fixed inset-0 z-(--z-dialog-positioner) flex'],
+    backdrop: ['inset-0 z-(--z-dialog-backdrop)'],
+    positioner: ['inset-0 z-(--z-dialog-positioner) flex'],
     content: [
       'relative flex flex-col p-dialog-content gap-dialog-content',
       'bg-dialog-content-bg text-dialog-content-fg',
@@ -51,6 +51,20 @@ const dialogVariants = tv({
       bottom: {
         positioner: 'items-end justify-stretch',
         content: 'w-full rounded-dialog-bottom border-b-0',
+      },
+    },
+    position: {
+      fixed: {
+        backdrop: 'fixed',
+        positioner: 'fixed',
+      },
+      absolute: {
+        backdrop: 'absolute',
+        positioner: 'absolute',
+      },
+      sticky: {
+        backdrop: 'sticky',
+        positioner: 'sticky',
       },
     },
     size: {
@@ -141,6 +155,7 @@ const dialogVariants = tv({
     placement: 'center',
     behavior: 'modal',
     size: 'md',
+    position: 'fixed',
   },
 })
 
@@ -174,6 +189,7 @@ export function Dialog({
   finalFocusEl,
   role = 'dialog',
   placement = 'center',
+  position = 'fixed',
   size = 'md',
   behavior = 'modal',
   closeOnEscape = true,
@@ -218,7 +234,7 @@ export function Dialog({
     description: descriptionSlot,
     closeTrigger,
     actions: actionsSlot,
-  } = dialogVariants({ placement, size, behavior })
+  } = dialogVariants({ placement, size, behavior, position })
 
   return (
     <>


### PR DESCRIPTION
Introduce a new "position" variant for the Dialog component and make
"fixed" the default. Move the fixed/absolute/sticky utility classes
from the hardcoded slot values into a reusable position variant so
backdrop and positioner can be toggled between fixed, absolute, and
sticky positioning.

- Remove global "fixed" from backdrop and positioner slot defaults so
  the variant controls positioning.
- Add position.variant with fixed/absolute/sticky mappings that apply
  the correct class to both backdrop and positioner.
- Set the initial config to position: "fixed" and accept a position
  prop in the Dialog component, passing it into dialogVariants.

This allows consumers to choose dialog positioning behavior without
tinkering with CSS classes directly and prepares for non-fixed 
layouts(submenu etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog now supports a configurable position option with fixed (default), absolute, and sticky values, giving you finer control over how dialogs are positioned on the page.
  * Backdrop and positioner behaviors adapt automatically based on the selected position for consistent layout across placements and sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->