### PR TITLE
feat/dialog-improvments

### DIFF
--- a/libs/ui/src/molecules/dialog.tsx
+++ b/libs/ui/src/molecules/dialog.tsx
@@ -66,6 +66,10 @@ const dialogVariants = tv({
         backdrop: 'sticky',
         positioner: 'sticky',
       },
+      relative: {
+        backdrop: 'relative',
+        positioner: 'relative',
+      },
     },
     size: {
       xs: {},
@@ -179,6 +183,7 @@ export interface DialogProps extends VariantProps<typeof dialogVariants> {
   hideCloseButton?: boolean
   className?: string
   modal?: boolean
+  portal?: boolean
 }
 
 export function Dialog({
@@ -205,6 +210,7 @@ export function Dialog({
   actions,
   className,
   modal = true,
+  portal = true,
 }: DialogProps) {
   const generatedId = useId()
   const uniqueId = id || generatedId
@@ -236,6 +242,38 @@ export function Dialog({
     actions: actionsSlot,
   } = dialogVariants({ placement, size, behavior, position })
 
+  const dialogContent = () => {
+    return (
+      <>
+        <div className={backdrop()} {...api.getBackdropProps()} />
+        <div className={positioner()} {...api.getPositionerProps()}>
+          <div className={content({ className })} {...api.getContentProps()}>
+            {!hideCloseButton && (
+              <Button
+                theme="borderless"
+                className={closeTrigger()}
+                {...api.getCloseTriggerProps()}
+                icon="token-icon-dialog-close"
+              />
+            )}
+            {title && (
+              <h2 className={titleSlot()} {...api.getTitleProps()}>
+                {title}
+              </h2>
+            )}
+            {description && (
+              <div className={descriptionSlot()} {...api.getDescriptionProps()}>
+                {description}
+              </div>
+            )}
+            {children}
+            {actions && <div className={actionsSlot()}>{actions}</div>}
+          </div>
+        </div>
+      </>
+    )
+  }
+
   return (
     <>
       {!customTrigger && (
@@ -249,39 +287,8 @@ export function Dialog({
         </Button>
       )}
 
-      {api.open && (
-        <Portal>
-          <div className={backdrop()} {...api.getBackdropProps()} />
-          <div className={positioner()} {...api.getPositionerProps()}>
-            <div className={content({ className })} {...api.getContentProps()}>
-              {!hideCloseButton && (
-                <Button
-                  theme="borderless"
-                  className={closeTrigger()}
-                  {...api.getCloseTriggerProps()}
-                  icon="token-icon-dialog-close"
-                />
-              )}
-              {title && (
-                <h2 className={titleSlot()} {...api.getTitleProps()}>
-                  {title}
-                </h2>
-              )}
-              {description && (
-                <div
-                  className={descriptionSlot()}
-                  {...api.getDescriptionProps()}
-                >
-                  {description}
-                </div>
-              )}
-              <div className="flex-grow overflow-y-auto">{children}</div>
-
-              {actions && <div className={actionsSlot()}>{actions}</div>}
-            </div>
-          </div>
-        </Portal>
-      )}
+      {api.open &&
+        (portal ? <Portal>{dialogContent()}</Portal> : dialogContent())}
     </>
   )
 }

--- a/libs/ui/stories/molecules/dialog.stories.tsx
+++ b/libs/ui/stories/molecules/dialog.stories.tsx
@@ -681,3 +681,106 @@ export const MobileMenuDrawer: Story = {
     )
   },
 }
+
+// Portal vs No Portal comparison - demonstrates when to use each mode
+export const PortalComparison: Story = {
+  render: () => {
+    const [withPortal, setWithPortal] = useState(false)
+    const [withoutPortal, setWithoutPortal] = useState(false)
+
+    return (
+      <div className="flex flex-col gap-600 p-400">
+        <div className="space-y-200">
+          <h2 className="text-lg font-semibold">
+            Portal Behavior Comparison
+          </h2>
+          <p className="text-sm text-fg-muted">
+            This example demonstrates the difference between using Portal (default) and not using Portal.
+            The container below has overflow:hidden and fixed height to simulate a real-world scenario
+            like a dropdown menu in a scrollable list.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-400">
+          {/* With Portal (default) */}
+          <div className="space-y-200">
+            <h3 className="font-medium">With Portal (default)</h3>
+            <div className="relative h-[200px] overflow-hidden rounded-lg border-2 border-border-primary bg-surface-secondary p-300">
+              <p className="mb-200 text-sm text-fg-muted">
+                Container with overflow:hidden
+              </p>
+              <Dialog
+                open={withPortal}
+                onOpenChange={({ open }) => setWithPortal(open)}
+                triggerText="Open Dialog"
+                title="Dialog with Portal"
+                description="This dialog uses Portal and escapes the container's overflow constraints"
+                position="absolute"
+                placement="center"
+                size="sm"
+                usePortal={true}
+              >
+                <div className="space-y-200">
+                  <p className="text-sm">
+                    This dialog is rendered outside the container using Portal,
+                    so it's not affected by the parent's overflow:hidden.
+                  </p>
+                  <p className="text-sm text-fg-muted">
+                    Perfect for modals, tooltips, and dropdowns that need to
+                    escape container constraints.
+                  </p>
+                </div>
+              </Dialog>
+            </div>
+          </div>
+
+          {/* Without Portal */}
+          <div className="space-y-200">
+            <h3 className="font-medium">Without Portal</h3>
+            <div className="relative h-[200px] overflow-hidden rounded-lg border-2 border-border-primary bg-surface-secondary p-300">
+              <p className="mb-200 text-sm text-fg-muted">
+                Container with overflow:hidden
+              </p>
+              <Dialog
+                open={withoutPortal}
+                onOpenChange={({ open }) => setWithoutPortal(open)}
+                triggerText="Open Dialog"
+                title="Dialog without Portal"
+                description="This dialog stays within the container and respects overflow"
+                position="absolute"
+                placement="center"
+                size="sm"
+                portal={false}
+              >
+                <div className="space-y-200">
+                  <p className="text-sm">
+                    This dialog is rendered inside the container without Portal,
+                    so it gets clipped by the parent's overflow:hidden.
+                  </p>
+                  <p className="text-sm text-fg-muted">
+                    Useful for inline tooltips, context menus that should stay
+                    within their container, or navigation submenus.
+                  </p>
+                </div>
+              </Dialog>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg bg-surface-tertiary p-300">
+          <h4 className="mb-100 font-medium">When to use each:</h4>
+          <ul className="space-y-50 text-sm">
+            <li>
+              <strong>Use Portal (default):</strong> Modals, global notifications,
+              tooltips that need to escape container constraints
+            </li>
+            <li>
+              <strong>Use usePortal={false}:</strong> Navigation submenus,
+              inline context menus, hover cards that should respect DOM hierarchy
+            </li>
+          </ul>
+        </div>
+      </div>
+    )
+  },
+}


### PR DESCRIPTION
Summary
- Add a new "position" variant to the Dialog component (fixed / absolute / sticky) and make "fixed" the default.
- Remove hardcoded "fixed" utility classes from backdrop and positioner slots and let the position variant control positioning.
- Allow Dialog to accept a position prop and pass it into dialogVariants.
- Introduce optional portal mode and support relative positioning for non-fixed layouts (e.g., submenus).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dialog now supports a portal prop to render inline or via Portal (default: true).
  * Added position prop (fixed, absolute, sticky, relative) to control dialog/backdrop positioning (default: fixed).

* **Style**
  * Simplified backdrop and positioner styling for consistency and easier customization.

* **Documentation**
  * Added a story demonstrating Portal vs. non-Portal usage, including overflow behavior and recommended scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->