### PR TITLE
fix(breadcrumb): replace array.at() with compatible array access

### DIFF
--- a/libs/ui/src/molecules/breadcrumb.tsx
+++ b/libs/ui/src/molecules/breadcrumb.tsx
@@ -164,7 +164,7 @@ export function Breadcrumb({
     maxItems <= 0 || items.length <= maxItems
       ? items
       : maxItems === 1
-        ? [items[items.length - 1]]
+        ? [items.at(-1)]
         : [items[0], 'ellipsis', ...items.slice(-(maxItems - 1))]
 
   return (

--- a/libs/ui/tsconfig.json
+++ b/libs/ui/tsconfig.json
@@ -5,7 +5,7 @@
     "noEmit": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "lib": ["DOM"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
     "jsx": "react-jsx"
   },
   "include": ["src"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal logic for selecting the last breadcrumb item when only one item is shown, improving code clarity and consistency.
  * No changes to the breadcrumb’s appearance or behavior; users will see the same output as before.
  * This refinement reduces reliance on less common language features, aiding long-term maintainability without impacting performance or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->