### PR TITLE
fix(scripts):Windows compatibility for validate-token-definitions

### DIFF
--- a/libs/ui/scripts/validate-token-definitions.js
+++ b/libs/ui/scripts/validate-token-definitions.js
@@ -13,7 +13,7 @@ import { existsSync } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { globSync } from 'glob'
 
 const ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..')
@@ -494,7 +494,10 @@ async function validateTokenDefinitions({ profile = false } = {}) {
   return false
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (
+  process.argv[1] &&
+  pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url
+) {
   const profile = process.argv.includes('--profile')
   validateTokenDefinitions({ profile })
     .then((ok) => process.exit(ok ? 0 : 1))


### PR DESCRIPTION
Fixed `validate-token-definitions.js` script failing to run on Windows due to path format mismatch in the execution check.        
Replaced platform-specific string comparison with `pathToFileURL()` for cross-platform compatibility, matching the pattern        
used in `validate-token-usage.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved reliability of the token validation script when run via a file path, ensuring consistent execution across environments.

- Chores
  - Internal maintenance to script tooling to align with modern Node.js module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->