### PR TITLE
fix(ui): omit children in LinkButton types

### DIFF
--- a/libs/ui/src/atoms/link-button.tsx
+++ b/libs/ui/src/atoms/link-button.tsx
@@ -38,7 +38,7 @@ export type LinkButtonProps<T extends ElementType = 'a'> = VariantProps<
   ref?: Ref<HTMLAnchorElement>
 } & Omit<
     ComponentPropsWithoutRef<T>,
-    'as' | 'ref' | keyof VariantProps<typeof linkButton>
+    'as' | 'ref' | 'children' | keyof VariantProps<typeof linkButton>
   >
 
 export function LinkButton<T extends ElementType = 'a'>({


### PR DESCRIPTION
Add 'children' to Omit utility to prevent type conflicts between explicit children prop and ComponentPropsWithoutRef<T>. Consistent with existing 'as' and 'ref' pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined type definitions for the link button component to eliminate property conflicts and strengthen type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->