### PR TITLE
fix(n1): replace Button inside Link with LinkButton

### DIFF
--- a/apps/n1/src/app/ucet/profil/_components/orders/orders-empty.tsx
+++ b/apps/n1/src/app/ucet/profil/_components/orders/orders-empty.tsx
@@ -1,0 +1,17 @@
+import { Icon } from "@techsio/ui-kit/atoms/icon"
+import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
+
+export function OrdersEmpty() {
+  return (
+    <div className="rounded border border-border-secondary bg-base p-600 text-center">
+      <Icon className="text-2xl text-fg-secondary" icon="token-icon-archive" />
+      <p className="mb-100 font-medium text-fg-primary">Žádné objednávky</p>
+      <p className="mb-400 text-fg-secondary text-sm">
+        Zatím jste nevytvořili žádnou objednávku
+      </p>
+      <LinkButton href="/produkty" size="sm" theme="solid" variant="primary">
+        Začít nakupovat
+      </LinkButton>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaced nested `Button` inside `Link` with `LinkButton` component in orders-empty.tsx
- Fixed invalid HTML structure where interactive button was nested inside link
- Updated imports to use `LinkButton` from @techsio/ui-kit

## Changes
- Removed `Button` and `Link` imports
- Added `LinkButton` import
- Replaced `<Button><Link /></Button>` pattern with `<LinkButton />`
- Preserved all props (variant, theme, size)

## Testing
- Verified component maintains same visual appearance and functionality
- Validated proper import path for LinkButton component

Closes #68