### PR TITLE
feat(ui): add loading state with spinner and custom text to button component

### DIFF
--- a/libs/ui/src/atoms/button.tsx
+++ b/libs/ui/src/atoms/button.tsx
@@ -260,13 +260,17 @@ export function Button({
   size,
   block,
   isLoading,
+  loadingText,
   icon,
   iconPosition = 'left',
   uppercase = false,
   children,
   className,
+  disabled: disabledProp,
   ...props
 }: ButtonProps & { ref?: Ref<HTMLButtonElement> }) {
+  const disabled = isLoading || disabledProp
+
   return (
     <button
       className={buttonVariants({
@@ -277,12 +281,21 @@ export function Button({
         uppercase,
         className,
       })}
-      disabled={isLoading}
+      disabled={disabled}
       {...props}
     >
-      {icon && iconPosition === 'left' && <Icon icon={icon} />}
-      {children}
-      {icon && iconPosition === 'right' && <Icon icon={icon} />}
+      {isLoading ? (
+        <>
+          <Icon icon="icon-[svg-spinners--ring-resize]" className="mr-2" />
+          {loadingText || children}
+        </>
+      ) : (
+        <>
+          {icon && iconPosition === 'left' && <Icon icon={icon} />}
+          {children}
+          {icon && iconPosition === 'right' && <Icon icon={icon} />}
+        </>
+      )}
     </button>
   )
 }

--- a/libs/ui/stories/atoms/button.stories.tsx
+++ b/libs/ui/stories/atoms/button.stories.tsx
@@ -1,32 +1,129 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { VariantContainer, VariantGroup } from '../../.storybook/decorator'
 import { Button } from '../../src/atoms/button'
+import { fn } from 'storybook/test'
+import { iconLabels, iconOptions } from '../helpers/icon-options'
 
 const meta: Meta<typeof Button> = {
   title: 'Atoms/Button',
   component: Button,
+  tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',
       options: ['primary', 'secondary', 'tertiary', 'warning', 'danger'],
+      description: 'Controls the semantic style of the button',
+      table: {
+        defaultValue: { summary: 'primary' },
+      },
+    },
+    theme: {
+      control: 'select',
+      options: ['solid', 'light', 'outlined', 'borderless', 'unstyled'],
+      description: 'Controls the visual weight/theme of the button',
+      table: {
+        defaultValue: { summary: 'solid' },
+      },
     },
     size: {
       control: 'select',
-      options: ['sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'current'],
+      description: 'Controls the size of the button',
+      table: {
+        defaultValue: { summary: 'md' },
+      },
     },
+    type: {
+      control: 'radio',
+      options: ['button', 'submit', 'reset'],
+      description: 'The HTML type of the button',
+      table: {
+        defaultValue: { summary: 'button' },
+      },
+    },
+    block: {
+      control: 'boolean',
+      description: 'Whether the button should take up the full width of its container',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    uppercase: {
+      control: 'boolean',
+      description: 'Whether the button text should be uppercase',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    isLoading: {
+      control: 'boolean',
+      description: 'Whether the button is in a loading state',
+      table: {
+        defaultValue: { summary: 'false' },
+      },
+    },
+    loadingText: {
+      control: 'text',
+      description: 'Text to display when isLoading is true',
+    },
+    icon: {
+      control: {
+        type: 'select',
+        labels: iconLabels,
+      },
+      options: iconOptions,
+      description: 'Icon to display in the button',
+    },
+    iconPosition: {
+      control: 'radio',
+      options: ['left', 'right'],
+      description: 'Position of the icon relative to the text',
+      table: {
+        defaultValue: { summary: 'left' },
+      },
+    },
+    children: {
+      control: 'text',
+      description: 'Content of the button',
+    },
+    onClick: {
+      description: 'Click handler',
+    },
+  },
+  args: {
+    variant: 'primary',
+    theme: 'solid',
+    size: 'md',
+    type: 'button',
+    block: false,
+    uppercase: false,
+    disabled: false,
+    isLoading: false,
+    loadingText: 'Loading...',
+    children: 'Button',
+    iconPosition: 'left',
+    onClick: fn(),
   },
   parameters: {
     layout: 'centered',
-    docs: {
-      description: {
-        component: '',
-      },
-    },
   },
 }
 
 export default meta
 type Story = StoryObj<typeof Button>
+
+export const Playground: Story = {
+  args: {
+    children: 'Playground Button',
+  },
+}
 
 export const Variants: Story = {
   render: () => (

--- a/libs/ui/stories/helpers/icon-options.ts
+++ b/libs/ui/stories/helpers/icon-options.ts
@@ -1,0 +1,27 @@
+import type { IconType } from "../../src/atoms/icon"
+
+export const iconOptions: (IconType | undefined)[] = [
+  undefined,
+  "icon-[mdi--plus]",
+  "icon-[mdi--pencil]",
+  "icon-[mdi--delete]",
+  "icon-[mdi--send]",
+  "icon-[mdi--magnify]",
+  "icon-[mdi--thumb-up]",
+  "icon-[mdi--cart]",
+  "icon-[mdi--check]",
+  "icon-[mdi--close]",
+]
+
+export const iconLabels: Record<string, string> = {
+  undefined: "None",
+  "icon-[mdi--plus]": "Plus",
+  "icon-[mdi--pencil]": "Pencil",
+  "icon-[mdi--delete]": "Delete",
+  "icon-[mdi--send]": "Send",
+  "icon-[mdi--magnify]": "Search",
+  "icon-[mdi--thumb-up]": "Thumb Up",
+  "icon-[mdi--cart]": "Cart",
+  "icon-[mdi--check]": "Check",
+  "icon-[mdi--close]": "Close",
+}


### PR DESCRIPTION
- Add loadingText prop to display custom text during loading state
- Show spinner icon when isLoading is true
- Disable button when either isLoading or disabled prop is true
- Hide regular icon when in loading state
- Add comprehensive Storybook documentation with autodocs
- Add Playground story for interactive testing
- Create icon-options helper for consistent icon selection in stories
- Document all button props with descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Button component now supports a loading state that displays a spinner and customisable loading text whilst automatically disabling interaction.

* **Documentation**
  * Enhanced Storybook stories with comprehensive configuration options, interactive playground, and improved documentation coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->