### PR TITLE
fix(ui): add style condition to exports for Tailwind CSS v4 compatibility

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -13,13 +13,16 @@
       "import": "./dist/types/zag.js"
     },
     "./tokens": {
-      "import": "./src/tokens/tokens-only.css"
+      "style": "./src/tokens/tokens-only.css",
+      "default": "./src/tokens/tokens-only.css"
     },
     "./tokens-with-tailwind": {
-      "import": "./src/tokens/index.css"
+      "style": "./src/tokens/index.css",
+      "default": "./src/tokens/index.css"
     },
     "./tokens/*": {
-      "import": "./src/tokens/*.css"
+      "style": "./src/tokens/*.css",
+      "default": "./src/tokens/*.css"
     },
     "./atoms/*": {
       "types": "./dist/src/atoms/*.d.ts",


### PR DESCRIPTION
PR Title & Description

Add "style" export condition for CSS token imports

## Problem
Tailwind CSS v4 PostCSS plugin requires explicit `style` export condition when resolving CSS imports from packages. Without it, importing `@techsio/ui-kit/tokens` fails with:
"./tokens" is not exported under the condition "style"

## Solution
Added `style` + `default` export conditions to all CSS exports in package.json:

```json
"./tokens": {
  "style": "./src/tokens/tokens-only.css",
  "default": "./src/tokens/tokens-only.css"
}
```

Technical Details

- style is a de facto standard supported by Tailwind v4, Sass, Vite, Webpack
- default serves as fallback for tools without style support
- Follows Sass RFC recommendation for CSS package exports
- Enables proper import resolution via package.json exports

Fixes consumption in Herbatika app with Tailwind CSS v4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated styling token export mappings to support improved module system compatibility across different import methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->