### PR TITLE
feat(storybook): enable enhanced color-contrast a11y rule in preview.ts

### DIFF
--- a/libs/ui/.storybook/preview.ts
+++ b/libs/ui/.storybook/preview.ts
@@ -24,6 +24,11 @@ const preview: Preview = {
         ],
       },
     },
+    a11y: {
+      config: {
+        rules: [{ id: "color-contrast-enhanced", enabled: true }],
+      },
+    },
   },
   decorators: [
     withThemeByClassName({


### PR DESCRIPTION
**Note:** There's a minor UX glitch I wasn't able to resolve. The addon reports contrast 
violations at two thresholds instead of one:


- If contrast < 4.5: Reports "contrast less than 4.5" (WCAG AA fail)
- If 4.5 ≤ contrast < 7: Reports "contrast less than 7" (WCAG AAA fail only)

 Ideally, it would report all violations against the 7:1 AAA threshold directly. This happens because `color-contrast-enhanced` only checks elements that already pass the AA test (4.5:1) - probably it's designed as an extension, not a replacement for `color-contrast`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated accessibility testing configuration for the component library with enhanced colour contrast validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->