### PR TITLE
ci: reuse storybook a11y workflow

### DIFF
--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   storybook-a11y:
-    uses: NMIT-WR/storybook-addons/.github/workflows/storybook-a11y.yml@storybook-a11y-workflow-v0.1.8
+    uses: NMIT-WR/storybook-addons/.github/workflows/storybook-a11y.yml@storybook-a11y-workflow-v0.1.9
     with:
       node-version: "22"
       pnpm-version: ""


### PR DESCRIPTION
Summary: switch Storybook a11y workflow to reusable workflow from storybook-addons; pin to storybook-a11y-workflow-v0.1.0. Testing: not run (workflow-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined Storybook accessibility CI by replacing multiple in-repo jobs with a single invocation of a centralized reusable workflow for improved maintainability and consistency.
  * Expanded and consolidated workflow configuration to make installation, build, Storybook paths, output/artifact and test settings more flexible.
  * Added baseline integration options to support comparative accessibility checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->