### PR TITLE
feat(ui): add TanStack Form bindings

### DIFF
--- a/libs/ui/README.md
+++ b/libs/ui/README.md
@@ -152,7 +152,7 @@ When overriding, create a file in the brand folder and map the semantic tokens t
 ## 7. Publishing and releases
 
 - Build + publint: `pnpm -C libs/ui build` runs `rsbuild-plugin-publint` after the build; if exports/entrypoints are wrong, this command fails.
-- Exports only, no barrel: import from explicit subpaths (e.g. `@techsio/ui-kit/atoms/button`, `@techsio/ui-kit/templates/accordion`, `@techsio/ui-kit/utils`). The package root is intentionally not exported.
+- Exports only, no barrel: import from explicit subpaths (e.g. `@techsio/ui-kit/atoms/button`, `@techsio/ui-kit/templates/accordion`, `@techsio/ui-kit/form/field-bindings`, `@techsio/ui-kit/utils`). The package root is intentionally not exported.
 - Automated releases: `libs/ui/release.config.mjs` uses semantic-release (tag format `ui-kit-v<version>`) to bump versions, update changelog, and publish to npm. While we are <1.0.0, `BREAKING CHANGE` commits are forced to “minor” bumps to stay in 0.x; remove that release rule when stabilizing for 1.0.0+ to restore SemVer majors.
 - Security posture: releases are restricted to GitHub Actions (`GITHUB_ACTIONS` required), npm publishes use provenance (`NPM_CONFIG_PROVENANCE=true`), and tokens live only in Actions secrets (`GH_TOKEN`, `NPM_TOKEN`). Keep secrets in a protected environment for extra safety.
 - CI workflow: `.github/workflows/ui-release.yml` builds `libs/ui` and runs semantic-release on `master`/`main` with `GH_TOKEN` and `NPM_TOKEN` secrets.

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/src/templates/*.d.ts",
       "import": "./dist/templates/*.js"
     },
+    "./form/*": {
+      "types": "./dist/src/form/*.d.ts",
+      "import": "./dist/form/*.js"
+    },
     "./utils": {
       "types": "./dist/src/utils.d.ts",
       "import": "./dist/utils.js"
@@ -105,6 +109,7 @@
     "@storybook/react": "^10.0.2",
     "@storybook/test-runner": "^0.24.2",
     "@tailwindcss/postcss": "^4.1.17",
+    "@tanstack/react-form": "^1.0.0",
     "@techsio/storybook-a11y-reporter": "0.1.3",
     "@techsio/storybook-better-a11y": "0.1.3",
     "@typescript-eslint/parser": "^8.47.0",
@@ -126,8 +131,14 @@
   "peerDependencies": {
     "@types/react": ">=19.2.0",
     "@types/react-dom": ">=19.2.0",
+    "@tanstack/react-form": "^1.0.0",
     "react": ">=19.2.0",
     "react-dom": ">=19.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@tanstack/react-form": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "access": "public"

--- a/libs/ui/src/form/checkbox-field.tsx
+++ b/libs/ui/src/form/checkbox-field.tsx
@@ -12,7 +12,7 @@ import {
 
 export type CheckboxFieldProps = Omit<
   FormCheckboxProps,
-  "checked" | "onCheckedChange" | "helpText" | "validateStatus" | "id" | "name"
+  "checked" | "onCheckedChange" | "validateStatus" | "id" | "name"
 > & {
   field: AnyFieldApi
   id?: string
@@ -35,13 +35,13 @@ export function CheckboxField({
     when: errorVisibility,
     externalError,
   })
+  const helpText = fieldStatus.errorMessage ?? props.helpText
 
   return (
     <FormCheckbox
       {...props}
-      aria-describedby={fieldStatus["aria-describedby"]}
+      helpText={helpText}
       checked={fieldProps.checked}
-      helpText={fieldStatus.errorMessage}
       id={fieldProps.id}
       name={fieldProps.name}
       onCheckedChange={fieldProps.onCheckedChange}

--- a/libs/ui/src/form/checkbox-field.tsx
+++ b/libs/ui/src/form/checkbox-field.tsx
@@ -1,0 +1,50 @@
+import type { AnyFieldApi } from "@tanstack/react-form"
+import type { ReactNode } from "react"
+import {
+  FormCheckbox,
+  type FormCheckboxProps,
+} from "../molecules/form-checkbox"
+import {
+  getCheckboxFieldProps,
+  getFieldStatus,
+  type FieldErrorVisibility,
+} from "./field-bindings"
+
+export type CheckboxFieldProps = Omit<
+  FormCheckboxProps,
+  "checked" | "onCheckedChange" | "helpText" | "validateStatus" | "id" | "name"
+> & {
+  field: AnyFieldApi
+  id?: string
+  name?: string
+  label?: ReactNode
+  errorVisibility?: FieldErrorVisibility
+  externalError?: string
+}
+
+export function CheckboxField({
+  field,
+  id,
+  name,
+  errorVisibility = "blurred",
+  externalError,
+  ...props
+}: CheckboxFieldProps) {
+  const fieldProps = getCheckboxFieldProps(field, { id, name })
+  const fieldStatus = getFieldStatus(field, {
+    when: errorVisibility,
+    externalError,
+  })
+
+  return (
+    <FormCheckbox
+      {...props}
+      checked={fieldProps.checked}
+      helpText={fieldStatus.errorMessage}
+      id={fieldProps.id}
+      name={fieldProps.name}
+      onCheckedChange={fieldProps.onCheckedChange}
+      validateStatus={fieldStatus.validateStatus}
+    />
+  )
+}

--- a/libs/ui/src/form/checkbox-field.tsx
+++ b/libs/ui/src/form/checkbox-field.tsx
@@ -39,6 +39,7 @@ export function CheckboxField({
   return (
     <FormCheckbox
       {...props}
+      aria-describedby={fieldStatus["aria-describedby"]}
       checked={fieldProps.checked}
       helpText={fieldStatus.errorMessage}
       id={fieldProps.id}

--- a/libs/ui/src/form/field-bindings.ts
+++ b/libs/ui/src/form/field-bindings.ts
@@ -218,7 +218,9 @@ export function getNumericFieldProps<TValue = number>(
   const formatValue =
     options?.formatValue ??
     ((value: TValue | null | undefined) => {
-      if (typeof value === "number") return value
+      if (typeof value === "number") {
+        return Number.isNaN(value) ? undefined : value
+      }
       if (value === null || value === undefined) return undefined
       const parsed = Number(value)
       return Number.isNaN(parsed) ? undefined : parsed
@@ -230,6 +232,10 @@ export function getNumericFieldProps<TValue = number>(
     ...baseProps,
     value: formatValue(field.state.value as TValue),
     onChange: (value) => {
+      if (Number.isNaN(value)) {
+        field.handleChange(undefined as TValue)
+        return
+      }
       field.handleChange(parseValue(value))
     },
   }

--- a/libs/ui/src/form/field-bindings.ts
+++ b/libs/ui/src/form/field-bindings.ts
@@ -55,6 +55,7 @@ export type FieldStatusOptions = FieldErrorOptions & {
 
 export type FieldStatus = {
   errorMessage?: string
+  helpText?: string
   errorId: string
   validateStatus: FieldValidateStatus
   "aria-invalid": boolean
@@ -66,6 +67,7 @@ export type SelectFieldOptions = FieldBaseOptions & {
   touchOnChange?: boolean
   allowEmpty?: boolean
   valueToString?: (value: unknown) => string
+  parseValue?: (value: string) => unknown
 }
 
 export type SelectFieldProps = FieldBaseProps & {
@@ -169,6 +171,7 @@ export function getSelectFieldProps(
   const touchOnChange = options?.touchOnChange ?? true
   const allowEmpty = options?.allowEmpty ?? false
   const valueToString = options?.valueToString ?? defaultFormatValue
+  const parseValue = options?.parseValue ?? ((value: string) => value)
   const rawValue = field.state.value
 
   const value = options?.multiple
@@ -185,7 +188,7 @@ export function getSelectFieldProps(
     onValueChange: (details) => {
       if (options?.multiple) {
         if (allowEmpty || details.value.length > 0) {
-          field.handleChange(details.value)
+          field.handleChange(details.value.map((value) => parseValue(value)))
           if (touchOnChange && !meta.isTouched) {
             field.handleBlur()
           }
@@ -195,7 +198,7 @@ export function getSelectFieldProps(
 
       const nextValue = details.value[0] ?? ""
       if (allowEmpty || nextValue) {
-        field.handleChange(nextValue)
+        field.handleChange(parseValue(nextValue))
         if (touchOnChange && !meta.isTouched) {
           field.handleBlur()
         }
@@ -276,6 +279,7 @@ export function getFieldStatus(
 
   return {
     errorMessage,
+    helpText: errorMessage,
     errorId,
     validateStatus: hasError ? "error" : "default",
     "aria-invalid": hasError,

--- a/libs/ui/src/form/field-bindings.ts
+++ b/libs/ui/src/form/field-bindings.ts
@@ -1,0 +1,284 @@
+import type { ChangeEvent, FocusEvent } from "react"
+import type { AnyFieldApi } from "@tanstack/react-form"
+
+export type FieldValidateStatus = "default" | "error" | "success" | "warning"
+export type FieldErrorVisibility = "always" | "touched" | "blurred" | "never"
+
+export type FieldBaseOptions = {
+  id?: string
+  name?: string
+}
+
+export type FieldBaseProps = {
+  id: string
+  name: string
+  onBlur: (event?: FocusEvent<HTMLElement>) => void
+}
+
+export type TextFieldOptions<TValue> = FieldBaseOptions & {
+  formatValue?: (value: TValue | null | undefined) => string
+  parseValue?: (value: string) => TValue
+}
+
+export type TextFieldProps = FieldBaseProps & {
+  value: string
+  onChange: (
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => void
+}
+
+export type CheckboxFieldOptions = FieldBaseOptions & {
+  isChecked?: (value: unknown) => boolean
+  touchOnChange?: boolean
+}
+
+export type CheckboxFieldProps = FieldBaseProps & {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}
+
+export type ValueFieldProps<TValue> = FieldBaseProps & {
+  value: TValue
+  onValueChange: (value: TValue) => void
+}
+
+export type FieldErrorOptions = {
+  when?: FieldErrorVisibility
+  pickError?: (errors: readonly unknown[]) => unknown | undefined
+  formatError?: (error: unknown) => string | undefined
+  externalError?: string
+}
+
+export type FieldStatusOptions = FieldErrorOptions & {
+  errorId?: string
+}
+
+export type FieldStatus = {
+  errorMessage?: string
+  errorId: string
+  validateStatus: FieldValidateStatus
+  "aria-invalid": boolean
+  "aria-describedby"?: string
+}
+
+export type SelectFieldOptions = FieldBaseOptions & {
+  multiple?: boolean
+  touchOnChange?: boolean
+  allowEmpty?: boolean
+  valueToString?: (value: unknown) => string
+}
+
+export type SelectFieldProps = FieldBaseProps & {
+  value: string[]
+  onValueChange: (details: { value: string[] }) => void
+}
+
+export type NumericFieldOptions<TValue> = FieldBaseOptions & {
+  formatValue?: (value: TValue | null | undefined) => number | undefined
+  parseValue?: (value: number) => TValue
+}
+
+export type NumericFieldProps = FieldBaseProps & {
+  value?: number
+  onChange: (value: number) => void
+}
+
+const defaultFormatValue = (value: unknown) =>
+  value === null || value === undefined ? "" : String(value)
+
+const defaultParseValue = (value: string) => value
+
+const defaultPickError = (errors: readonly unknown[]) => errors[0]
+
+const defaultFormatError = (error: unknown) =>
+  typeof error === "string" ? error : error ? String(error) : undefined
+
+type FieldMeta = AnyFieldApi["state"]["meta"] & { isBlurred?: boolean }
+
+export function getFieldBaseProps(
+  field: AnyFieldApi,
+  options?: FieldBaseOptions
+): FieldBaseProps {
+  const name = options?.name ?? field.name
+  const id = options?.id ?? name
+
+  return {
+    id,
+    name,
+    onBlur: field.handleBlur,
+  }
+}
+
+export function getTextFieldProps<TValue = string>(
+  field: AnyFieldApi,
+  options?: TextFieldOptions<TValue>
+): TextFieldProps {
+  const formatValue = options?.formatValue ?? defaultFormatValue
+  const parseValue = options?.parseValue ?? defaultParseValue
+  const baseProps = getFieldBaseProps(field, options)
+
+  return {
+    ...baseProps,
+    value: formatValue(field.state.value as TValue),
+    onChange: (event) => {
+      field.handleChange(parseValue(event.target.value))
+    },
+  }
+}
+
+export function getCheckboxFieldProps(
+  field: AnyFieldApi,
+  options?: CheckboxFieldOptions
+): CheckboxFieldProps {
+  const baseProps = getFieldBaseProps(field, options)
+  const meta = field.state.meta as FieldMeta
+  const isChecked = options?.isChecked ?? ((value) => value === true)
+  const touchOnChange = options?.touchOnChange ?? true
+
+  return {
+    ...baseProps,
+    checked: isChecked(field.state.value),
+    onCheckedChange: (checked) => {
+      field.handleChange(checked)
+      if (touchOnChange && !meta.isTouched) {
+        field.handleBlur()
+      }
+    },
+  }
+}
+
+export function getValueFieldProps<TValue = unknown>(
+  field: AnyFieldApi,
+  options?: FieldBaseOptions
+): ValueFieldProps<TValue> {
+  const baseProps = getFieldBaseProps(field, options)
+
+  return {
+    ...baseProps,
+    value: field.state.value as TValue,
+    onValueChange: field.handleChange as (value: TValue) => void,
+  }
+}
+
+export function getSelectFieldProps(
+  field: AnyFieldApi,
+  options?: SelectFieldOptions
+): SelectFieldProps {
+  const baseProps = getFieldBaseProps(field, options)
+  const meta = field.state.meta as FieldMeta
+  const touchOnChange = options?.touchOnChange ?? true
+  const allowEmpty = options?.allowEmpty ?? false
+  const valueToString = options?.valueToString ?? defaultFormatValue
+  const rawValue = field.state.value
+
+  const value = options?.multiple
+    ? Array.isArray(rawValue)
+      ? rawValue.map(valueToString)
+      : rawValue === null || rawValue === undefined
+        ? []
+        : [valueToString(rawValue)]
+    : [rawValue === null || rawValue === undefined ? "" : valueToString(rawValue)]
+
+  return {
+    ...baseProps,
+    value,
+    onValueChange: (details) => {
+      if (options?.multiple) {
+        if (allowEmpty || details.value.length > 0) {
+          field.handleChange(details.value)
+          if (touchOnChange && !meta.isTouched) {
+            field.handleBlur()
+          }
+        }
+        return
+      }
+
+      const nextValue = details.value[0] ?? ""
+      if (allowEmpty || nextValue) {
+        field.handleChange(nextValue)
+        if (touchOnChange && !meta.isTouched) {
+          field.handleBlur()
+        }
+      }
+    },
+  }
+}
+
+export function getNumericFieldProps<TValue = number>(
+  field: AnyFieldApi,
+  options?: NumericFieldOptions<TValue>
+): NumericFieldProps {
+  const baseProps = getFieldBaseProps(field, options)
+  const formatValue =
+    options?.formatValue ??
+    ((value: TValue | null | undefined) => {
+      if (typeof value === "number") return value
+      if (value === null || value === undefined) return undefined
+      const parsed = Number(value)
+      return Number.isNaN(parsed) ? undefined : parsed
+    })
+  const parseValue =
+    options?.parseValue ?? ((value: number) => value as TValue)
+
+  return {
+    ...baseProps,
+    value: formatValue(field.state.value as TValue),
+    onChange: (value) => {
+      field.handleChange(parseValue(value))
+    },
+  }
+}
+
+export function getFieldErrors(field: AnyFieldApi): readonly unknown[] {
+  return Array.isArray(field.state.meta.errors)
+    ? field.state.meta.errors
+    : []
+}
+
+export function getFieldError(
+  field: AnyFieldApi,
+  options?: FieldErrorOptions
+): string | undefined {
+  if (options?.externalError) return options.externalError
+  const errors = getFieldErrors(field)
+  if (errors.length === 0) return undefined
+
+  const when = options?.when ?? "blurred"
+  if (when === "never") return undefined
+
+  const meta = field.state.meta as FieldMeta
+  const isTouched = meta.isTouched ?? false
+  const isBlurred = meta.isBlurred ?? isTouched
+
+  if (when === "touched" && !isTouched) return undefined
+  if (when === "blurred" && !isBlurred) return undefined
+
+  const pickError = options?.pickError ?? defaultPickError
+  const formatError = options?.formatError ?? defaultFormatError
+
+  return formatError(pickError(errors))
+}
+
+export function getFieldValidateStatus(
+  field: AnyFieldApi,
+  options?: FieldErrorOptions
+): FieldValidateStatus {
+  return getFieldError(field, options) ? "error" : "default"
+}
+
+export function getFieldStatus(
+  field: AnyFieldApi,
+  options?: FieldStatusOptions
+): FieldStatus {
+  const errorMessage = getFieldError(field, options)
+  const errorId = options?.errorId ?? `${field.name}-error`
+  const hasError = !!errorMessage
+
+  return {
+    errorMessage,
+    errorId,
+    validateStatus: hasError ? "error" : "default",
+    "aria-invalid": hasError,
+    "aria-describedby": hasError ? errorId : undefined,
+  }
+}

--- a/libs/ui/src/form/field-bindings.ts
+++ b/libs/ui/src/form/field-bindings.ts
@@ -95,6 +95,9 @@ const defaultPickError = (errors: readonly unknown[]) => errors[0]
 const defaultFormatError = (error: unknown) =>
   typeof error === "string" ? error : error ? String(error) : undefined
 
+// FieldMeta extends AnyFieldApi["state"]["meta"] with optional isBlurred.
+// isBlurred is not in TanStack Form; consumers can set it on explicit blur or UI transitions
+// to drive conditional validation/styling in FieldMeta-aware components.
 type FieldMeta = AnyFieldApi["state"]["meta"] & { isBlurred?: boolean }
 
 export function getFieldBaseProps(
@@ -251,6 +254,7 @@ export function getFieldError(
 
   const meta = field.state.meta as FieldMeta
   const isTouched = meta.isTouched ?? false
+  // FieldMeta.isBlurred is not populated by TanStack Form; "blurred" equals "touched" until blur tracking is implemented.
   const isBlurred = meta.isBlurred ?? isTouched
 
   if (when === "touched" && !isTouched) return undefined

--- a/libs/ui/src/form/field-bindings.ts
+++ b/libs/ui/src/form/field-bindings.ts
@@ -55,7 +55,6 @@ export type FieldStatusOptions = FieldErrorOptions & {
 
 export type FieldStatus = {
   errorMessage?: string
-  helpText?: string
   errorId: string
   validateStatus: FieldValidateStatus
   "aria-invalid": boolean
@@ -289,7 +288,6 @@ export function getFieldStatus(
 
   return {
     errorMessage,
-    helpText: errorMessage,
     errorId,
     validateStatus: hasError ? "error" : "default",
     "aria-invalid": hasError,

--- a/libs/ui/src/form/input-field.tsx
+++ b/libs/ui/src/form/input-field.tsx
@@ -1,0 +1,7 @@
+import { TextField, type TextFieldProps } from "./text-field"
+
+export type InputFieldProps = TextFieldProps
+
+export function InputField(props: TextFieldProps) {
+  return <TextField {...props} />
+}

--- a/libs/ui/src/form/input-field.tsx
+++ b/libs/ui/src/form/input-field.tsx
@@ -1,7 +1,0 @@
-import { TextField, type TextFieldProps } from "./text-field"
-
-export type InputFieldProps = TextFieldProps
-
-export function InputField(props: TextFieldProps) {
-  return <TextField {...props} />
-}

--- a/libs/ui/src/form/numeric-field.tsx
+++ b/libs/ui/src/form/numeric-field.tsx
@@ -29,6 +29,7 @@ export type NumericFieldProps = Omit<
   externalError?: string
   onExternalErrorClear?: () => void
   showHelpTextIcon?: boolean
+  helpText?: ReactNode
   formatValue?: (value: number | null | undefined) => number | undefined
   parseValue?: (value: number) => number
 }
@@ -51,6 +52,7 @@ export function NumericField({
   externalError,
   onExternalErrorClear,
   showHelpTextIcon,
+  helpText,
   formatValue,
   parseValue,
   ...numericInputProps
@@ -65,6 +67,7 @@ export function NumericField({
     when: errorVisibility,
     externalError,
   })
+  const resolvedHelpText = fieldStatus.errorMessage ?? helpText
 
   const handleChange = (value: number) => {
     fieldProps.onChange(value)
@@ -90,7 +93,7 @@ export function NumericField({
     <FormNumericInput
       className={className}
       disabled={disabled}
-      helpText={fieldStatus.errorMessage}
+      helpText={resolvedHelpText}
       id={fieldProps.id}
       label={label}
       name={fieldProps.name}
@@ -100,7 +103,6 @@ export function NumericField({
       size={size}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
-      describedBy={fieldStatus["aria-describedby"]}
       {...numericInputProps}
     >
       {controlsPosition === "sides" ? (

--- a/libs/ui/src/form/numeric-field.tsx
+++ b/libs/ui/src/form/numeric-field.tsx
@@ -91,6 +91,7 @@ export function NumericField({
       size={size}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
+      describedBy={fieldStatus["aria-describedby"]}
       {...numericInputProps}
     >
       {controlsPosition === "sides" ? (

--- a/libs/ui/src/form/numeric-field.tsx
+++ b/libs/ui/src/form/numeric-field.tsx
@@ -27,6 +27,7 @@ export type NumericFieldProps = Omit<
   decrementIcon?: IconType
   errorVisibility?: FieldErrorVisibility
   externalError?: string
+  onExternalErrorClear?: () => void
   showHelpTextIcon?: boolean
   formatValue?: (value: number | null | undefined) => number | undefined
   parseValue?: (value: number) => number
@@ -48,6 +49,7 @@ export function NumericField({
   decrementIcon = "token-icon-numeric-input-decrement",
   errorVisibility = "blurred",
   externalError,
+  onExternalErrorClear,
   showHelpTextIcon,
   formatValue,
   parseValue,
@@ -63,6 +65,13 @@ export function NumericField({
     when: errorVisibility,
     externalError,
   })
+
+  const handleChange = (value: number) => {
+    fieldProps.onChange(value)
+    if (externalError && onExternalErrorClear) {
+      onExternalErrorClear()
+    }
+  }
 
   const controlContent = (
     <NumericInput.Control className={controlsPosition === "sides" ? "flex-1" : undefined}>
@@ -85,7 +94,7 @@ export function NumericField({
       id={fieldProps.id}
       label={label}
       name={fieldProps.name}
-      onChange={fieldProps.onChange}
+      onChange={handleChange}
       required={required}
       showHelpTextIcon={showHelpTextIcon}
       size={size}

--- a/libs/ui/src/form/numeric-field.tsx
+++ b/libs/ui/src/form/numeric-field.tsx
@@ -1,0 +1,111 @@
+import type { AnyFieldApi } from "@tanstack/react-form"
+import type { ReactNode } from "react"
+import type { IconType } from "../atoms/icon"
+import {
+  NumericInput,
+  type NumericInputProps,
+} from "../atoms/numeric-input"
+import { FormNumericInput } from "../molecules/form-numeric-input"
+import {
+  getFieldStatus,
+  getNumericFieldProps,
+  type FieldErrorVisibility,
+} from "./field-bindings"
+
+export type NumericFieldProps = Omit<
+  NumericInputProps,
+  "children" | "value" | "defaultValue" | "onChange" | "id" | "name"
+> & {
+  field: AnyFieldApi
+  label: ReactNode
+  id?: string
+  name?: string
+  showControls?: boolean
+  showScrubber?: boolean
+  controlsPosition?: "right" | "sides"
+  incrementIcon?: IconType
+  decrementIcon?: IconType
+  errorVisibility?: FieldErrorVisibility
+  externalError?: string
+  showHelpTextIcon?: boolean
+  formatValue?: (value: number | null | undefined) => number | undefined
+  parseValue?: (value: number) => number
+}
+
+export function NumericField({
+  field,
+  label,
+  id,
+  name,
+  size = "md",
+  required,
+  disabled,
+  className,
+  showControls = true,
+  showScrubber = false,
+  controlsPosition = "right",
+  incrementIcon = "token-icon-numeric-input-increment",
+  decrementIcon = "token-icon-numeric-input-decrement",
+  errorVisibility = "blurred",
+  externalError,
+  showHelpTextIcon,
+  formatValue,
+  parseValue,
+  ...numericInputProps
+}: NumericFieldProps) {
+  const fieldProps = getNumericFieldProps(field, {
+    id,
+    name,
+    formatValue,
+    parseValue,
+  })
+  const fieldStatus = getFieldStatus(field, {
+    when: errorVisibility,
+    externalError,
+  })
+
+  const controlContent = (
+    <NumericInput.Control className={controlsPosition === "sides" ? "flex-1" : undefined}>
+      {showScrubber && <NumericInput.Scrubber />}
+      <NumericInput.Input />
+      {showControls && controlsPosition === "right" && (
+        <NumericInput.TriggerContainer>
+          <NumericInput.IncrementTrigger icon={incrementIcon} />
+          <NumericInput.DecrementTrigger icon={decrementIcon} />
+        </NumericInput.TriggerContainer>
+      )}
+    </NumericInput.Control>
+  )
+
+  return (
+    <FormNumericInput
+      className={className}
+      disabled={disabled}
+      helpText={fieldStatus.errorMessage}
+      id={fieldProps.id}
+      label={label}
+      name={fieldProps.name}
+      onChange={fieldProps.onChange}
+      required={required}
+      showHelpTextIcon={showHelpTextIcon}
+      size={size}
+      validateStatus={fieldStatus.validateStatus}
+      value={fieldProps.value}
+      {...numericInputProps}
+    >
+      {controlsPosition === "sides" ? (
+        <div className="flex items-center gap-50">
+          {showControls && (
+            <NumericInput.DecrementTrigger icon={decrementIcon} />
+          )}
+          {controlContent}
+          {showControls && (
+            <NumericInput.IncrementTrigger icon={incrementIcon} />
+          )}
+        </div>
+      ) : (
+        controlContent
+      )}
+    </FormNumericInput>
+  )
+}

--- a/libs/ui/src/form/numeric-field.tsx
+++ b/libs/ui/src/form/numeric-field.tsx
@@ -1,16 +1,21 @@
 import type { AnyFieldApi } from "@tanstack/react-form"
 import type { ReactNode } from "react"
 import type { IconType } from "../atoms/icon"
-import {
-  NumericInput,
-  type NumericInputProps,
-} from "../atoms/numeric-input"
+import { NumericInput, type NumericInputProps } from "../atoms/numeric-input"
 import { FormNumericInput } from "../molecules/form-numeric-input"
+import { tv } from "../utils"
 import {
+  type FieldErrorVisibility,
   getFieldStatus,
   getNumericFieldProps,
-  type FieldErrorVisibility,
 } from "./field-bindings"
+
+const numericFieldVariants = tv({
+  slots: {
+    sidesControl: "flex-1",
+    sidesWrapper: "flex items-center gap-50",
+  },
+})
 
 export type NumericFieldProps = Omit<
   NumericInputProps,
@@ -68,6 +73,7 @@ export function NumericField({
     externalError,
   })
   const resolvedHelpText = fieldStatus.errorMessage ?? helpText
+  const { sidesControl, sidesWrapper } = numericFieldVariants()
 
   const handleChange = (value: number) => {
     fieldProps.onChange(value)
@@ -77,7 +83,9 @@ export function NumericField({
   }
 
   const controlContent = (
-    <NumericInput.Control className={controlsPosition === "sides" ? "flex-1" : undefined}>
+    <NumericInput.Control
+      className={controlsPosition === "sides" ? sidesControl() : undefined}
+    >
       {showScrubber && <NumericInput.Scrubber />}
       <NumericInput.Input />
       {showControls && controlsPosition === "right" && (
@@ -106,7 +114,7 @@ export function NumericField({
       {...numericInputProps}
     >
       {controlsPosition === "sides" ? (
-        <div className="flex items-center gap-50">
+        <div className={sidesWrapper()}>
           {showControls && (
             <NumericInput.DecrementTrigger icon={decrementIcon} />
           )}

--- a/libs/ui/src/form/select-field.tsx
+++ b/libs/ui/src/form/select-field.tsx
@@ -1,0 +1,67 @@
+import type { AnyFieldApi } from "@tanstack/react-form"
+import { Select, type SelectItem, type SelectSize } from "../molecules/select"
+import { getFieldStatus, getSelectFieldProps } from "./field-bindings"
+
+export type SelectFieldProps = {
+  field: AnyFieldApi
+  label: string
+  options: SelectItem[]
+  required?: boolean
+  disabled?: boolean
+  placeholder?: string
+  className?: string
+  size?: SelectSize
+}
+
+export function SelectField({
+  field,
+  label,
+  options,
+  required,
+  disabled,
+  placeholder,
+  className,
+  size = "lg",
+}: SelectFieldProps) {
+  const fieldProps = getSelectFieldProps(field)
+  const fieldStatus = getFieldStatus(field, { when: "blurred" })
+
+  return (
+    <Select
+      aria-describedby={fieldStatus["aria-describedby"]}
+      aria-invalid={fieldStatus["aria-invalid"]}
+      items={options}
+      disabled={disabled}
+      id={fieldProps.id}
+      name={fieldProps.name}
+      onValueChange={fieldProps.onValueChange}
+      required={required}
+      size={size}
+      validateStatus={fieldStatus.validateStatus}
+      value={fieldProps.value}
+      className={className}
+    >
+      <Select.Label>{label}</Select.Label>
+      <Select.Control>
+        <Select.Trigger>
+          <Select.ValueText placeholder={placeholder} />
+        </Select.Trigger>
+      </Select.Control>
+      <Select.Positioner>
+        <Select.Content>
+          {options.map((item) => (
+            <Select.Item key={item.value} item={item}>
+              <Select.ItemText />
+              <Select.ItemIndicator />
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Positioner>
+      {fieldStatus.errorMessage && (
+        <Select.StatusText id={fieldStatus.errorId}>
+          {fieldStatus.errorMessage}
+        </Select.StatusText>
+      )}
+    </Select>
+  )
+}

--- a/libs/ui/src/form/select-field.tsx
+++ b/libs/ui/src/form/select-field.tsx
@@ -1,4 +1,5 @@
 import type { AnyFieldApi } from "@tanstack/react-form"
+import type { ReactNode } from "react"
 import { Select, type SelectItem, type SelectSize } from "../molecules/select"
 import { getFieldStatus, getSelectFieldProps } from "./field-bindings"
 
@@ -13,6 +14,8 @@ export type SelectFieldProps = {
   size?: SelectSize
   externalError?: string
   onExternalErrorClear?: () => void
+  helpText?: ReactNode
+  showHelpTextIcon?: boolean
 }
 
 export function SelectField({
@@ -26,12 +29,16 @@ export function SelectField({
   size = "lg",
   externalError,
   onExternalErrorClear,
+  helpText,
+  showHelpTextIcon,
 }: SelectFieldProps) {
   const fieldProps = getSelectFieldProps(field)
   const fieldStatus = getFieldStatus(field, {
     when: "blurred",
     externalError,
   })
+  const resolvedHelpText = fieldStatus.errorMessage ?? helpText
+  const helpTextId = resolvedHelpText ? `${fieldProps.id}-helptext` : undefined
 
   const handleValueChange = (details: { value: string[] }) => {
     fieldProps.onValueChange(details)
@@ -56,7 +63,7 @@ export function SelectField({
       <Select.Label>{label}</Select.Label>
       <Select.Control>
         <Select.Trigger
-          aria-describedby={fieldStatus["aria-describedby"]}
+          aria-describedby={helpTextId}
           aria-invalid={fieldStatus["aria-invalid"]}
         >
           <Select.ValueText placeholder={placeholder} />
@@ -72,9 +79,13 @@ export function SelectField({
           ))}
         </Select.Content>
       </Select.Positioner>
-      {fieldStatus.errorMessage && (
-        <Select.StatusText id={fieldStatus.errorId}>
-          {fieldStatus.errorMessage}
+      {resolvedHelpText && (
+        <Select.StatusText
+          id={helpTextId}
+          status={fieldStatus.errorMessage ? "error" : "default"}
+          showIcon={showHelpTextIcon}
+        >
+          {resolvedHelpText}
         </Select.StatusText>
       )}
     </Select>

--- a/libs/ui/src/form/select-field.tsx
+++ b/libs/ui/src/form/select-field.tsx
@@ -11,6 +11,8 @@ export type SelectFieldProps = {
   placeholder?: string
   className?: string
   size?: SelectSize
+  externalError?: string
+  onExternalErrorClear?: () => void
 }
 
 export function SelectField({
@@ -22,19 +24,29 @@ export function SelectField({
   placeholder,
   className,
   size = "lg",
+  externalError,
+  onExternalErrorClear,
 }: SelectFieldProps) {
   const fieldProps = getSelectFieldProps(field)
-  const fieldStatus = getFieldStatus(field, { when: "blurred" })
+  const fieldStatus = getFieldStatus(field, {
+    when: "blurred",
+    externalError,
+  })
+
+  const handleValueChange = (details: { value: string[] }) => {
+    fieldProps.onValueChange(details)
+    if (externalError && onExternalErrorClear) {
+      onExternalErrorClear()
+    }
+  }
 
   return (
     <Select
-      aria-describedby={fieldStatus["aria-describedby"]}
-      aria-invalid={fieldStatus["aria-invalid"]}
       items={options}
       disabled={disabled}
       id={fieldProps.id}
       name={fieldProps.name}
-      onValueChange={fieldProps.onValueChange}
+      onValueChange={handleValueChange}
       required={required}
       size={size}
       validateStatus={fieldStatus.validateStatus}
@@ -43,7 +55,10 @@ export function SelectField({
     >
       <Select.Label>{label}</Select.Label>
       <Select.Control>
-        <Select.Trigger>
+        <Select.Trigger
+          aria-describedby={fieldStatus["aria-describedby"]}
+          aria-invalid={fieldStatus["aria-invalid"]}
+        >
           <Select.ValueText placeholder={placeholder} />
         </Select.Trigger>
       </Select.Control>

--- a/libs/ui/src/form/select-field.tsx
+++ b/libs/ui/src/form/select-field.tsx
@@ -5,7 +5,7 @@ import { getFieldStatus, getSelectFieldProps } from "./field-bindings"
 
 export type SelectFieldProps = {
   field: AnyFieldApi
-  label: string
+  label: ReactNode
   options: SelectItem[]
   required?: boolean
   disabled?: boolean
@@ -49,16 +49,16 @@ export function SelectField({
 
   return (
     <Select
-      items={options}
+      className={className}
       disabled={disabled}
       id={fieldProps.id}
+      items={options}
       name={fieldProps.name}
       onValueChange={handleValueChange}
       required={required}
       size={size}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
-      className={className}
     >
       <Select.Label>{label}</Select.Label>
       <Select.Control>
@@ -72,7 +72,7 @@ export function SelectField({
       <Select.Positioner>
         <Select.Content>
           {options.map((item) => (
-            <Select.Item key={item.value} item={item}>
+            <Select.Item item={item} key={item.value}>
               <Select.ItemText />
               <Select.ItemIndicator />
             </Select.Item>
@@ -82,8 +82,8 @@ export function SelectField({
       {resolvedHelpText && (
         <Select.StatusText
           id={helpTextId}
-          status={fieldStatus.errorMessage ? "error" : "default"}
           showIcon={showHelpTextIcon}
+          status={fieldStatus.errorMessage ? "error" : "default"}
         >
           {resolvedHelpText}
         </Select.StatusText>

--- a/libs/ui/src/form/text-field.tsx
+++ b/libs/ui/src/form/text-field.tsx
@@ -1,19 +1,25 @@
 import type { AnyFieldApi } from "@tanstack/react-form"
-import type { InputHTMLAttributes } from "react"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
 import { FormInput } from "../molecules/form-input"
 import { getFieldStatus, getTextFieldProps } from "./field-bindings"
 
-export type TextFieldProps = {
+type TextFieldBaseProps = Omit<
+  ComponentPropsWithoutRef<typeof FormInput>,
+  | "id"
+  | "name"
+  | "value"
+  | "defaultValue"
+  | "onChange"
+  | "onBlur"
+  | "label"
+  | "helpText"
+  | "validateStatus"
+>
+
+export type TextFieldProps = TextFieldBaseProps & {
   field: AnyFieldApi
-  label: string
-  type?: InputHTMLAttributes<HTMLInputElement>["type"]
-  placeholder?: string
-  required?: boolean
-  disabled?: boolean
+  label: ReactNode
   transform?: (value: string) => string
-  className?: string
-  autoComplete?: string
-  maxLength?: number
   externalError?: string
   onExternalErrorClear?: () => void
 }
@@ -21,16 +27,11 @@ export type TextFieldProps = {
 export function TextField({
   field,
   label,
-  type = "text",
-  placeholder,
-  required,
-  disabled,
   transform,
-  autoComplete,
-  maxLength,
-  className,
   externalError,
   onExternalErrorClear,
+  type = "text",
+  ...inputProps
 }: TextFieldProps) {
   const fieldProps = getTextFieldProps(field, {
     parseValue: (value) => (transform ? transform(value) : value),
@@ -44,13 +45,9 @@ export function TextField({
     <FormInput
       aria-describedby={fieldStatus["aria-describedby"]}
       aria-invalid={fieldStatus["aria-invalid"]}
-      autoComplete={autoComplete}
-      className={className}
-      disabled={disabled}
       helpText={fieldStatus.errorMessage}
       id={fieldProps.id}
       label={label}
-      maxLength={maxLength}
       name={fieldProps.name}
       onBlur={fieldProps.onBlur}
       onChange={(event) => {
@@ -59,11 +56,10 @@ export function TextField({
           onExternalErrorClear()
         }
       }}
-      placeholder={placeholder}
-      required={required}
       type={type}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
+      {...inputProps}
     />
   )
 }

--- a/libs/ui/src/form/text-field.tsx
+++ b/libs/ui/src/form/text-field.tsx
@@ -12,7 +12,6 @@ type TextFieldBaseProps = Omit<
   | "onChange"
   | "onBlur"
   | "label"
-  | "helpText"
   | "validateStatus"
 >
 
@@ -31,6 +30,7 @@ export function TextField({
   externalError,
   onExternalErrorClear,
   type = "text",
+  helpText,
   ...inputProps
 }: TextFieldProps) {
   const fieldProps = getTextFieldProps(field, {
@@ -43,9 +43,8 @@ export function TextField({
 
   return (
     <FormInput
-      aria-describedby={fieldStatus["aria-describedby"]}
       aria-invalid={fieldStatus["aria-invalid"]}
-      helpText={fieldStatus.errorMessage}
+      helpText={fieldStatus.errorMessage ?? helpText}
       id={fieldProps.id}
       label={label}
       name={fieldProps.name}

--- a/libs/ui/src/form/text-field.tsx
+++ b/libs/ui/src/form/text-field.tsx
@@ -28,6 +28,7 @@ export function TextField({
   transform,
   autoComplete,
   maxLength,
+  className,
   externalError,
   onExternalErrorClear,
 }: TextFieldProps) {
@@ -44,6 +45,7 @@ export function TextField({
       aria-describedby={fieldStatus["aria-describedby"]}
       aria-invalid={fieldStatus["aria-invalid"]}
       autoComplete={autoComplete}
+      className={className}
       disabled={disabled}
       helpText={fieldStatus.errorMessage}
       id={fieldProps.id}
@@ -62,7 +64,6 @@ export function TextField({
       type={type}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
-      variant={fieldStatus.validateStatus === "error" ? "error" : "default"}
     />
   )
 }

--- a/libs/ui/src/form/text-field.tsx
+++ b/libs/ui/src/form/text-field.tsx
@@ -1,0 +1,68 @@
+import type { AnyFieldApi } from "@tanstack/react-form"
+import type { InputHTMLAttributes } from "react"
+import { FormInput } from "../molecules/form-input"
+import { getFieldStatus, getTextFieldProps } from "./field-bindings"
+
+export type TextFieldProps = {
+  field: AnyFieldApi
+  label: string
+  type?: InputHTMLAttributes<HTMLInputElement>["type"]
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  transform?: (value: string) => string
+  className?: string
+  autoComplete?: string
+  maxLength?: number
+  externalError?: string
+  onExternalErrorClear?: () => void
+}
+
+export function TextField({
+  field,
+  label,
+  type = "text",
+  placeholder,
+  required,
+  disabled,
+  transform,
+  autoComplete,
+  maxLength,
+  externalError,
+  onExternalErrorClear,
+}: TextFieldProps) {
+  const fieldProps = getTextFieldProps(field, {
+    parseValue: (value) => (transform ? transform(value) : value),
+  })
+  const fieldStatus = getFieldStatus(field, {
+    externalError,
+    when: "blurred",
+  })
+
+  return (
+    <FormInput
+      aria-describedby={fieldStatus["aria-describedby"]}
+      aria-invalid={fieldStatus["aria-invalid"]}
+      autoComplete={autoComplete}
+      disabled={disabled}
+      helpText={fieldStatus.errorMessage}
+      id={fieldProps.id}
+      label={label}
+      maxLength={maxLength}
+      name={fieldProps.name}
+      onBlur={fieldProps.onBlur}
+      onChange={(event) => {
+        fieldProps.onChange(event)
+        if (externalError && onExternalErrorClear) {
+          onExternalErrorClear()
+        }
+      }}
+      placeholder={placeholder}
+      required={required}
+      type={type}
+      validateStatus={fieldStatus.validateStatus}
+      value={fieldProps.value}
+      variant={fieldStatus.validateStatus === "error" ? "error" : "default"}
+    />
+  )
+}

--- a/libs/ui/src/form/textarea-field.tsx
+++ b/libs/ui/src/form/textarea-field.tsx
@@ -1,21 +1,24 @@
 import type { AnyFieldApi } from "@tanstack/react-form"
-import type { ReactNode } from "react"
-import type { TextareaProps } from "../atoms/textarea"
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
 import { FormTextarea } from "../molecules/form-textarea"
 import { getFieldStatus, getTextFieldProps } from "./field-bindings"
 
-export type TextareaFieldProps = {
+type TextareaFieldBaseProps = Omit<
+  ComponentPropsWithoutRef<typeof FormTextarea>,
+  | "id"
+  | "name"
+  | "value"
+  | "defaultValue"
+  | "onChange"
+  | "onBlur"
+  | "label"
+  | "helpText"
+  | "validateStatus"
+>
+
+export type TextareaFieldProps = TextareaFieldBaseProps & {
   field: AnyFieldApi
   label: ReactNode
-  placeholder?: string
-  required?: boolean
-  disabled?: boolean
-  className?: string
-  rows?: number
-  minLength?: number
-  maxLength?: number
-  resize?: TextareaProps["resize"]
-  size?: TextareaProps["size"]
   externalError?: string
   onExternalErrorClear?: () => void
 }
@@ -23,17 +26,9 @@ export type TextareaFieldProps = {
 export function TextareaField({
   field,
   label,
-  placeholder,
-  required,
-  disabled,
-  className,
-  rows,
-  minLength,
-  maxLength,
-  resize,
-  size,
   externalError,
   onExternalErrorClear,
+  ...textareaProps
 }: TextareaFieldProps) {
   const fieldProps = getTextFieldProps(field)
   const fieldStatus = getFieldStatus(field, {
@@ -45,13 +40,9 @@ export function TextareaField({
     <FormTextarea
       aria-describedby={fieldStatus["aria-describedby"]}
       aria-invalid={fieldStatus["aria-invalid"]}
-      className={className}
-      disabled={disabled}
       helpText={fieldStatus.errorMessage}
       id={fieldProps.id}
       label={label}
-      maxLength={maxLength}
-      minLength={minLength}
       name={fieldProps.name}
       onBlur={fieldProps.onBlur}
       onChange={(event) => {
@@ -60,13 +51,9 @@ export function TextareaField({
           onExternalErrorClear()
         }
       }}
-      placeholder={placeholder}
-      required={required}
-      resize={resize}
-      rows={rows}
-      size={size}
       validateStatus={fieldStatus.validateStatus}
       value={fieldProps.value}
+      {...textareaProps}
     />
   )
 }

--- a/libs/ui/src/form/textarea-field.tsx
+++ b/libs/ui/src/form/textarea-field.tsx
@@ -12,7 +12,6 @@ type TextareaFieldBaseProps = Omit<
   | "onChange"
   | "onBlur"
   | "label"
-  | "helpText"
   | "validateStatus"
 >
 
@@ -28,6 +27,7 @@ export function TextareaField({
   label,
   externalError,
   onExternalErrorClear,
+  helpText,
   ...textareaProps
 }: TextareaFieldProps) {
   const fieldProps = getTextFieldProps(field)
@@ -38,9 +38,8 @@ export function TextareaField({
 
   return (
     <FormTextarea
-      aria-describedby={fieldStatus["aria-describedby"]}
       aria-invalid={fieldStatus["aria-invalid"]}
-      helpText={fieldStatus.errorMessage}
+      helpText={fieldStatus.errorMessage ?? helpText}
       id={fieldProps.id}
       label={label}
       name={fieldProps.name}

--- a/libs/ui/src/form/textarea-field.tsx
+++ b/libs/ui/src/form/textarea-field.tsx
@@ -1,0 +1,72 @@
+import type { AnyFieldApi } from "@tanstack/react-form"
+import type { ReactNode } from "react"
+import type { TextareaProps } from "../atoms/textarea"
+import { FormTextarea } from "../molecules/form-textarea"
+import { getFieldStatus, getTextFieldProps } from "./field-bindings"
+
+export type TextareaFieldProps = {
+  field: AnyFieldApi
+  label: ReactNode
+  placeholder?: string
+  required?: boolean
+  disabled?: boolean
+  className?: string
+  rows?: number
+  minLength?: number
+  maxLength?: number
+  resize?: TextareaProps["resize"]
+  size?: TextareaProps["size"]
+  externalError?: string
+  onExternalErrorClear?: () => void
+}
+
+export function TextareaField({
+  field,
+  label,
+  placeholder,
+  required,
+  disabled,
+  className,
+  rows,
+  minLength,
+  maxLength,
+  resize,
+  size,
+  externalError,
+  onExternalErrorClear,
+}: TextareaFieldProps) {
+  const fieldProps = getTextFieldProps(field)
+  const fieldStatus = getFieldStatus(field, {
+    externalError,
+    when: "blurred",
+  })
+
+  return (
+    <FormTextarea
+      aria-describedby={fieldStatus["aria-describedby"]}
+      aria-invalid={fieldStatus["aria-invalid"]}
+      className={className}
+      disabled={disabled}
+      helpText={fieldStatus.errorMessage}
+      id={fieldProps.id}
+      label={label}
+      maxLength={maxLength}
+      minLength={minLength}
+      name={fieldProps.name}
+      onBlur={fieldProps.onBlur}
+      onChange={(event) => {
+        fieldProps.onChange(event)
+        if (externalError && onExternalErrorClear) {
+          onExternalErrorClear()
+        }
+      }}
+      placeholder={placeholder}
+      required={required}
+      resize={resize}
+      rows={rows}
+      size={size}
+      validateStatus={fieldStatus.validateStatus}
+      value={fieldProps.value}
+    />
+  )
+}

--- a/libs/ui/src/molecules/form-checkbox.tsx
+++ b/libs/ui/src/molecules/form-checkbox.tsx
@@ -70,6 +70,7 @@ export type FormCheckboxProps = {
   label?: ReactNode
   helpText?: ReactNode
   validateStatus?: "default" | "error" | "success" | "warning"
+  "aria-describedby"?: string
   showHelpTextIcon?: boolean
   size?: "sm" | "md" | "lg"
   className?: string
@@ -94,6 +95,7 @@ export function FormCheckbox({
   size = "md",
   className,
   onCheckedChange,
+  "aria-describedby": ariaDescribedBy,
 }: FormCheckboxProps) {
   const generatedId = useId()
   const uniqueId = id || generatedId
@@ -127,6 +129,7 @@ export function FormCheckbox({
         </div>
         <input
           className={styles.hiddenInput()}
+          aria-describedby={ariaDescribedBy}
           {...api.getHiddenInputProps()}
         />
         {labelContent && (

--- a/libs/ui/src/molecules/form-checkbox.tsx
+++ b/libs/ui/src/molecules/form-checkbox.tsx
@@ -99,6 +99,10 @@ export function FormCheckbox({
 }: FormCheckboxProps) {
   const generatedId = useId()
   const uniqueId = id || generatedId
+  const helpTextId = helpText ? `${uniqueId}-helptext` : undefined
+  const mergedDescribedBy = [ariaDescribedBy, helpTextId]
+    .filter(Boolean)
+    .join(" ") || undefined
 
   const service = useMachine(machine, {
     id: uniqueId,
@@ -130,7 +134,7 @@ export function FormCheckbox({
         <input
           className={styles.hiddenInput()}
           {...api.getHiddenInputProps()}
-          aria-describedby={ariaDescribedBy}
+          aria-describedby={mergedDescribedBy}
         />
         {labelContent && (
           <span className={styles.label()} {...api.getLabelProps()}>
@@ -140,7 +144,11 @@ export function FormCheckbox({
         )}
       </label>
       {helpText && (
-        <div className={styles.textIndented()} data-icon={showHelpTextIcon}>
+        <div
+          className={styles.textIndented()}
+          data-icon={showHelpTextIcon}
+          id={helpTextId}
+        >
           <StatusText
             status={validateStatus}
             showIcon={showHelpTextIcon}

--- a/libs/ui/src/molecules/form-checkbox.tsx
+++ b/libs/ui/src/molecules/form-checkbox.tsx
@@ -129,8 +129,8 @@ export function FormCheckbox({
         </div>
         <input
           className={styles.hiddenInput()}
-          aria-describedby={ariaDescribedBy}
           {...api.getHiddenInputProps()}
+          aria-describedby={ariaDescribedBy}
         />
         {labelContent && (
           <span className={styles.label()} {...api.getLabelProps()}>

--- a/libs/ui/src/molecules/form-input.tsx
+++ b/libs/ui/src/molecules/form-input.tsx
@@ -1,4 +1,9 @@
-import type { ReactNode } from "react"
+import {
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 import { Input, type InputProps } from "../atoms/input"
 import { Label } from "../atoms/label"
 import { StatusText } from "../atoms/status-text"
@@ -23,9 +28,31 @@ export function FormInputRaw({
   className,
   ...props
 }: FormInputRawProps) {
+  const { ["aria-describedby"]: ariaDescribedBy, ...inputProps } = props
+  const helpTextElement = isValidElement(helpText)
+    ? (helpText as ReactElement<{ id?: string }>)
+    : null
+  const resolvedHelpTextId =
+    helpTextElement?.props?.id ?? (helpText ? `${id}-helptext` : undefined)
+  const mergedDescribedBy = [ariaDescribedBy, resolvedHelpTextId]
+    .filter(Boolean)
+    .join(" ") || undefined
   const inputClassName = className
     ? `p-input-sm md:p-input-md ${className}`
     : "p-input-sm md:p-input-md"
+  const helpTextContent = helpText
+    ? helpTextElement
+      ? helpTextElement.props.id
+        ? helpTextElement
+        : cloneElement(helpTextElement, {
+            id: resolvedHelpTextId,
+          })
+      : (
+          <div id={resolvedHelpTextId}>
+            {helpText}
+          </div>
+        )
+    : null
 
   return (
     <div className="flex flex-col gap-form-field-gap">
@@ -38,11 +65,12 @@ export function FormInputRaw({
         required={required}
         size={size}
         variant={validateStatus}
-        {...props}
+        aria-describedby={mergedDescribedBy}
+        {...inputProps}
         className={inputClassName}
       />
 
-      {helpText}
+      {helpTextContent}
     </div>
   )
 }

--- a/libs/ui/src/molecules/form-input.tsx
+++ b/libs/ui/src/molecules/form-input.tsx
@@ -20,8 +20,13 @@ export function FormInputRaw({
   size = "md",
   required,
   disabled,
+  className,
   ...props
 }: FormInputRawProps) {
+  const inputClassName = className
+    ? `p-input-sm md:p-input-md ${className}`
+    : "p-input-sm md:p-input-md"
+
   return (
     <div className="flex flex-col gap-form-field-gap">
       <Label disabled={disabled} htmlFor={id} required={required} size={size}>
@@ -34,7 +39,7 @@ export function FormInputRaw({
         size={size}
         variant={validateStatus}
         {...props}
-        className="p-input-sm md:p-input-md"
+        className={inputClassName}
       />
 
       {helpText}

--- a/libs/ui/src/molecules/form-input.tsx
+++ b/libs/ui/src/molecules/form-input.tsx
@@ -7,6 +7,13 @@ import {
 import { Input, type InputProps } from "../atoms/input"
 import { Label } from "../atoms/label"
 import { StatusText } from "../atoms/status-text"
+import { tv } from "../utils"
+
+const formInputVariants = tv({
+  slots: {
+    input: "p-input-sm md:p-input-md",
+  },
+})
 
 type ValidateStatus = "default" | "error" | "success" | "warning"
 
@@ -28,31 +35,29 @@ export function FormInputRaw({
   className,
   ...props
 }: FormInputRawProps) {
-  const { ["aria-describedby"]: ariaDescribedBy, ...inputProps } = props
+  const { "aria-describedby": ariaDescribedBy, ...inputProps } = props
   const helpTextElement = isValidElement(helpText)
     ? (helpText as ReactElement<{ id?: string }>)
     : null
   const resolvedHelpTextId =
     helpTextElement?.props?.id ?? (helpText ? `${id}-helptext` : undefined)
-  const mergedDescribedBy = [ariaDescribedBy, resolvedHelpTextId]
-    .filter(Boolean)
-    .join(" ") || undefined
-  const inputClassName = className
-    ? `p-input-sm md:p-input-md ${className}`
-    : "p-input-sm md:p-input-md"
-  const helpTextContent = helpText
-    ? helpTextElement
-      ? helpTextElement.props.id
-        ? helpTextElement
-        : cloneElement(helpTextElement, {
-            id: resolvedHelpTextId,
-          })
-      : (
-          <div id={resolvedHelpTextId}>
-            {helpText}
-          </div>
-        )
-    : null
+  const mergedDescribedBy =
+    [ariaDescribedBy, resolvedHelpTextId].filter(Boolean).join(" ") || undefined
+  const { input } = formInputVariants()
+  const inputClassName = input({ className })
+  let helpTextContent: ReactNode = null
+
+  if (helpText) {
+    if (helpTextElement?.props.id) {
+      helpTextContent = helpTextElement
+    } else if (helpTextElement) {
+      helpTextContent = cloneElement(helpTextElement, {
+        id: resolvedHelpTextId,
+      })
+    } else {
+      helpTextContent = <div id={resolvedHelpTextId}>{helpText}</div>
+    }
+  }
 
   return (
     <div className="flex flex-col gap-form-field-gap">
@@ -60,12 +65,12 @@ export function FormInputRaw({
         {label}
       </Label>
       <Input
+        aria-describedby={mergedDescribedBy}
         disabled={disabled}
         id={id}
         required={required}
         size={size}
         variant={validateStatus}
-        aria-describedby={mergedDescribedBy}
         {...inputProps}
         className={inputClassName}
       />
@@ -92,9 +97,9 @@ export function FormInput({
       helpText={
         helpText && (
           <StatusText
-            status={validateStatus}
             showIcon={showHelpTextIcon}
             size={size}
+            status={validateStatus}
           >
             {helpText}
           </StatusText>

--- a/libs/ui/src/molecules/form-numeric-input.tsx
+++ b/libs/ui/src/molecules/form-numeric-input.tsx
@@ -26,6 +26,11 @@ export function FormNumericInput({
   children,
   ...numericInputProps
 }: FormNumericInputProps) {
+  const { describedBy, ...inputProps } = numericInputProps
+  const helpTextId = helpText ? `${id}-helptext` : undefined
+  const mergedDescribedBy = [describedBy, helpTextId]
+    .filter(Boolean)
+    .join(" ") || undefined
   return (
     <div
       className="flex flex-col gap-form-field-gap"
@@ -40,13 +45,15 @@ export function FormNumericInput({
         invalid={validateStatus === "error"}
         required={required}
         size={size}
-        {...numericInputProps}
+        describedBy={mergedDescribedBy}
+        {...inputProps}
       >
         {children}
       </NumericInput>
 
       {helpText && (
         <StatusText
+          id={helpTextId}
           status={validateStatus}
           showIcon={showHelpTextIcon}
           size={size}

--- a/libs/ui/src/molecules/form-textarea.tsx
+++ b/libs/ui/src/molecules/form-textarea.tsx
@@ -1,4 +1,9 @@
-import type { ReactNode } from "react"
+import {
+  cloneElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from "react"
 import { Label } from "../atoms/label"
 import { StatusText } from "../atoms/status-text"
 import { Textarea, type TextareaProps } from "../atoms/textarea"
@@ -22,6 +27,28 @@ export function FormTextareaRaw({
   disabled,
   ...props
 }: FormTextareaRawProps) {
+  const { ["aria-describedby"]: ariaDescribedBy, ...textareaProps } = props
+  const helpTextElement = isValidElement(helpText)
+    ? (helpText as ReactElement<{ id?: string }>)
+    : null
+  const resolvedHelpTextId =
+    helpTextElement?.props?.id ?? (helpText ? `${id}-helptext` : undefined)
+  const mergedDescribedBy = [ariaDescribedBy, resolvedHelpTextId]
+    .filter(Boolean)
+    .join(" ") || undefined
+  const helpTextContent = helpText
+    ? helpTextElement
+      ? helpTextElement.props.id
+        ? helpTextElement
+        : cloneElement(helpTextElement, {
+            id: resolvedHelpTextId,
+          })
+      : (
+          <div id={resolvedHelpTextId}>
+            {helpText}
+          </div>
+        )
+    : null
   return (
     <div className="flex flex-col gap-form-field-gap">
       <Label disabled={disabled} htmlFor={id} required={required} size={size}>
@@ -33,10 +60,11 @@ export function FormTextareaRaw({
         required={required}
         size={size}
         variant={validateStatus}
-        {...props}
+        aria-describedby={mergedDescribedBy}
+        {...textareaProps}
       />
 
-      {helpText}
+      {helpTextContent}
     </div>
   )
 }

--- a/libs/ui/src/molecules/form-textarea.tsx
+++ b/libs/ui/src/molecules/form-textarea.tsx
@@ -27,40 +27,39 @@ export function FormTextareaRaw({
   disabled,
   ...props
 }: FormTextareaRawProps) {
-  const { ["aria-describedby"]: ariaDescribedBy, ...textareaProps } = props
+  const { "aria-describedby": ariaDescribedBy, ...textareaProps } = props
   const helpTextElement = isValidElement(helpText)
     ? (helpText as ReactElement<{ id?: string }>)
     : null
   const resolvedHelpTextId =
     helpTextElement?.props?.id ?? (helpText ? `${id}-helptext` : undefined)
-  const mergedDescribedBy = [ariaDescribedBy, resolvedHelpTextId]
-    .filter(Boolean)
-    .join(" ") || undefined
-  const helpTextContent = helpText
-    ? helpTextElement
-      ? helpTextElement.props.id
-        ? helpTextElement
-        : cloneElement(helpTextElement, {
-            id: resolvedHelpTextId,
-          })
-      : (
-          <div id={resolvedHelpTextId}>
-            {helpText}
-          </div>
-        )
-    : null
+  const mergedDescribedBy =
+    [ariaDescribedBy, resolvedHelpTextId].filter(Boolean).join(" ") || undefined
+  const helpTextContent = helpText ? (
+    helpTextElement ? (
+      helpTextElement.props.id ? (
+        helpTextElement
+      ) : (
+        cloneElement(helpTextElement, {
+          id: resolvedHelpTextId,
+        })
+      )
+    ) : (
+      <div id={resolvedHelpTextId}>{helpText}</div>
+    )
+  ) : null
   return (
     <div className="flex flex-col gap-form-field-gap">
       <Label disabled={disabled} htmlFor={id} required={required} size={size}>
         {label}
       </Label>
       <Textarea
+        aria-describedby={mergedDescribedBy}
         disabled={disabled}
         id={id}
         required={required}
         size={size}
         variant={validateStatus}
-        aria-describedby={mergedDescribedBy}
         {...textareaProps}
       />
 
@@ -84,14 +83,15 @@ export function FormTextarea({
   return (
     <FormTextareaRaw
       helpText={
-        helpText && 
+        helpText && (
           <StatusText
-            status={validateStatus}
             showIcon={showHelpTextIcon}
             size={size}
+            status={validateStatus}
           >
             {helpText}
           </StatusText>
+        )
       }
       id={id}
       size={size}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4.1.17
         version: 4.1.17
+      '@tanstack/react-form':
+        specifier: ^1.0.0
+        version: 1.27.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@techsio/storybook-a11y-reporter':
         specifier: 0.1.3
         version: 0.1.3(@storybook/test-runner@0.24.2(@swc/helpers@0.5.17)(@types/node@25.0.3)(babel-plugin-macros@3.1.0)(storybook@10.1.11(@testing-library/dom@10.4.1)(prettier@3.5.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)))
@@ -6462,11 +6465,31 @@ packages:
   '@tailwindcss/postcss@4.1.17':
     resolution: {integrity: sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw==}
 
+  '@tanstack/devtools-event-client@0.4.0':
+    resolution: {integrity: sha512-RPfGuk2bDZgcu9bAJodvO2lnZeHuz4/71HjZ0bGb/SPg8+lyTA+RLSKQvo7fSmPSi8/vcH3aKQ8EM9ywf1olaw==}
+    engines: {node: '>=18'}
+
+  '@tanstack/form-core@1.27.7':
+    resolution: {integrity: sha512-nvogpyE98fhb0NDw1Bf2YaCH+L7ZIUgEpqO9TkHucDn6zg3ni521boUpv0i8HKIrmmFwDYjWZoCnrgY4HYWTkw==}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.64.2':
     resolution: {integrity: sha512-hdO8SZpWXoADNTWXV9We8CwTkXU88OVWRBcsiFrk7xJQnhm6WRlweDzMD+uH+GnuieTBVSML6xFa17C2cNV8+g==}
 
   '@tanstack/query-core@5.90.10':
     resolution: {integrity: sha512-EhZVFu9rl7GfRNuJLJ3Y7wtbTnENsvzp+YpcAV7kCYiXni1v8qZh++lpw4ch4rrwC0u/EZRnBHIehzCGzwXDSQ==}
+
+  '@tanstack/react-form@1.27.7':
+    resolution: {integrity: sha512-xTg4qrUY0fuLaSnkATLZcK3BWlnwLp7IuAb6UTbZKngiDEvvDCNTvVvHgPlgef1O2qN4klZxInRyRY6oEkXZ2A==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-query@5.64.2':
     resolution: {integrity: sha512-3pakNscZNm8KJkxmovvtZ4RaXLyiYYobwleTMvpIGUoKRa8j8VlrQKNl5W8VUEfVfZKkikvXVddLuWMbcSCA1Q==}
@@ -6496,6 +6519,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.7.7':
+    resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
 
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
@@ -20765,9 +20791,27 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.17
 
+  '@tanstack/devtools-event-client@0.4.0': {}
+
+  '@tanstack/form-core@1.27.7':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.0
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.7.7
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
   '@tanstack/query-core@5.64.2': {}
 
   '@tanstack/query-core@5.90.10': {}
+
+  '@tanstack/react-form@1.27.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/form-core': 1.27.7
+      '@tanstack/react-store': 0.8.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-query@5.64.2(react@18.3.1)':
     dependencies:
@@ -20797,6 +20841,8 @@ snapshots:
       '@tanstack/virtual-core': 3.13.17
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/store@0.7.7': {}
 
   '@tanstack/store@0.8.0': {}
 


### PR DESCRIPTION
## Summary
- add TanStack Form field binding helpers under `@techsio/ui-kit/form/*`
- add reusable field components: text, input, textarea, select, checkbox, numeric
- expose new form entrypoint and optional peer dependency
- update UI kit docs and lockfile

## Testing
- `pnpm -C libs/ui build`
- `pnpm install` (previously triggered `pnpm -C libs/ui build` and `pnpm -C libs/ui build:storybook`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive form support: field-binding utilities plus Text, Textarea, Checkbox, Select and Numeric form components with consistent props and error/status handling.
  * Improved ARIA accessibility and help-text associations across form controls.

* **Chores**
  * Published new form export path and added TanStack React Form as an optional peer dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->