### PR TITLE
fix(ui): add true link-mode support to pagination

### DIFF
--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -1,6 +1,11 @@
 import * as pagination from "@zag-js/pagination"
 import { normalizeProps, useMachine } from "@zag-js/react"
-import { type ElementType, type HTMLAttributes, useId } from "react"
+import {
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+  useId,
+} from "react"
 import type { VariantProps } from "tailwind-variants"
 import { Button } from "../atoms/button"
 import { Icon } from "../atoms/icon"
@@ -86,6 +91,8 @@ const paginationVariants = tv({
   },
 })
 
+type HrefCapableElement = ElementType<{ href?: unknown }>
+
 type PaginationBaseProps = HTMLAttributes<HTMLElement> &
   VariantProps<typeof paginationVariants> & {
     page?: number
@@ -98,6 +105,10 @@ type PaginationBaseProps = HTMLAttributes<HTMLElement> &
     onPageChange?: (page: number) => void
     dir?: "ltr" | "rtl"
     compact?: boolean
+    compactLabel?: (details: {
+      page: number
+      totalPages: number
+    }) => ReactNode
     translations?: pagination.IntlTranslations
   }
 
@@ -110,7 +121,7 @@ type PaginationModeProps =
   | {
       type: "link"
       getPageUrl: (details: pagination.PageUrlDetails) => string
-      linkAs?: ElementType
+      linkAs?: HrefCapableElement
     }
 
 export type PaginationProps = PaginationBaseProps & PaginationModeProps
@@ -132,6 +143,7 @@ export function Pagination({
   linkAs,
   size,
   compact = false,
+  compactLabel,
   translations,
   ...props
 }: PaginationProps) {
@@ -189,7 +201,10 @@ export function Pagination({
         {compact ? (
           <li className={item()}>
             <span className={compactText()} data-part="compact-text">
-              {api.page} of {api.totalPages}
+              {compactLabel?.({
+                page: api.page,
+                totalPages: api.totalPages,
+              }) ?? `${api.page} of ${api.totalPages}`}
             </span>
           </li>
         ) : (

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -1,11 +1,8 @@
 import * as pagination from "@zag-js/pagination"
 import { normalizeProps, useMachine } from "@zag-js/react"
-import {
-  type ElementType,
-  type HTMLAttributes,
-  useId,
-} from "react"
+import { type ElementType, type HTMLAttributes, useId } from "react"
 import type { VariantProps } from "tailwind-variants"
+import { Button } from "../atoms/button"
 import { Icon } from "../atoms/icon"
 import { LinkButton } from "../atoms/link-button"
 import { tv } from "../utils"
@@ -48,7 +45,7 @@ const paginationVariants = tv({
       filled: {
         item: "bg-pagination-bg",
         link: [
-          "data-[current=true]:border-pagination-border-active data-[current=true]:bg-pagination-bg-active data-[current=true]:text-pagination-filled-fg-active",
+          "data-selected:border-pagination-border-active data-selected:bg-pagination-bg-active data-selected:text-pagination-filled-fg-active",
           "hover:border-pagination-border-hover hover:bg-pagination-bg-hover",
           "hover:text-pagination-filled-fg-active",
         ],
@@ -56,14 +53,14 @@ const paginationVariants = tv({
       outlined: {
         item: "bg-pagination-bg",
         link: [
-          "data-[current=true]:border-pagination-border-active data-[current=true]:text-pagination-outlined-fg-active",
+          "data-selected:border-pagination-border-active data-selected:text-pagination-outlined-fg-active",
           "hover:border-pagination-border-hover hover:text-pagination-outlined-fg-active",
         ],
       },
       minimal: {
         link: [
           "border-transparent",
-          "data-[current=true]:text-pagination-minimal-fg-active",
+          "data-selected:text-pagination-minimal-fg-active",
           "hover:text-pagination-minimal-fg-active",
         ],
       },
@@ -89,20 +86,34 @@ const paginationVariants = tv({
   },
 })
 
-export interface PaginationProps
-  extends HTMLAttributes<HTMLElement>,
-    VariantProps<typeof paginationVariants> {
-  page?: number
-  defaultPage?: number
-  count: number
-  pageSize?: number
-  siblingCount?: number
-  showPrevNext?: boolean
-  onPageChange?: (page: number) => void
-  dir?: "ltr" | "rtl"
-  linkAs?: ElementType
-  compact?: boolean
-}
+type PaginationBaseProps = HTMLAttributes<HTMLElement> &
+  VariantProps<typeof paginationVariants> & {
+    page?: number
+    defaultPage?: number
+    count: number
+    pageSize?: number
+    siblingCount?: number
+    boundaryCount?: number
+    showPrevNext?: boolean
+    onPageChange?: (page: number) => void
+    dir?: "ltr" | "rtl"
+    compact?: boolean
+    translations?: pagination.IntlTranslations
+  }
+
+type PaginationModeProps =
+  | {
+      type?: "button"
+      getPageUrl?: never
+      linkAs?: never
+    }
+  | {
+      type: "link"
+      getPageUrl: (details: pagination.PageUrlDetails) => string
+      linkAs?: ElementType
+    }
+
+export type PaginationProps = PaginationBaseProps & PaginationModeProps
 
 export function Pagination({
   page,
@@ -110,14 +121,18 @@ export function Pagination({
   count,
   pageSize = 10,
   siblingCount = 1,
+  boundaryCount = 1,
   showPrevNext = true,
   onPageChange,
   variant,
   className,
   dir = "ltr",
+  type = "button",
+  getPageUrl,
   linkAs,
   size,
   compact = false,
+  translations,
   ...props
 }: PaginationProps) {
   const uniqueId = useId()
@@ -127,9 +142,13 @@ export function Pagination({
     count,
     pageSize,
     siblingCount,
+    boundaryCount,
     page,
     dir,
     defaultPage,
+    type,
+    getPageUrl,
+    translations,
     onPageChange: ({ page }) => {
       onPageChange?.(page)
     },
@@ -143,17 +162,27 @@ export function Pagination({
 
   return (
     <nav className={base({ className })} {...api.getRootProps()} {...props}>
-      <ul aria-label="Pagination" className={list()}>
+      <ul className={list()}>
         {showPrevNext && (
           <li className={item()}>
-            <LinkButton
-              as={linkAs}
-              className={link()}
-              disabled={api.page === 1}
-              icon="token-icon-pagination-prev"
-              theme="borderless"
-              {...api.getPrevTriggerProps()}
-            />
+            {type === "link" ? (
+              <LinkButton
+                as={linkAs}
+                className={link()}
+                disabled={api.page === 1}
+                icon="token-icon-pagination-prev"
+                theme="borderless"
+                {...api.getPrevTriggerProps()}
+              />
+            ) : (
+              <Button
+                className={link()}
+                icon="token-icon-pagination-prev"
+                size="current"
+                theme="borderless"
+                {...api.getPrevTriggerProps()}
+              />
+            )}
           </li>
         )}
         {compact ? (
@@ -167,16 +196,25 @@ export function Pagination({
             if (page.type === "page") {
               return (
                 <li className={item()} key={page.value}>
-                  <LinkButton
-                    aria-current={api.page === page.value ? "page" : undefined}
-                    as={linkAs}
-                    className={link()}
-                    data-current={api.page === page.value}
-                    theme="borderless"
-                    {...api.getItemProps(page)}
-                  >
-                    {page.value}
-                  </LinkButton>
+                  {type === "link" ? (
+                    <LinkButton
+                      as={linkAs}
+                      className={link()}
+                      theme="borderless"
+                      {...api.getItemProps(page)}
+                    >
+                      {page.value}
+                    </LinkButton>
+                  ) : (
+                    <Button
+                      className={link()}
+                      size="current"
+                      theme="borderless"
+                      {...api.getItemProps(page)}
+                    >
+                      {page.value}
+                    </Button>
+                  )}
                 </li>
               )
             }
@@ -196,14 +234,24 @@ export function Pagination({
 
         {showPrevNext && (
           <li className={item()}>
-            <LinkButton
-              as={linkAs}
-              className={link()}
-              disabled={api.page === api.totalPages}
-              icon="token-icon-pagination-next"
-              theme="borderless"
-              {...api.getNextTriggerProps()}
-            />
+            {type === "link" ? (
+              <LinkButton
+                as={linkAs}
+                className={link()}
+                disabled={api.page === api.totalPages}
+                icon="token-icon-pagination-next"
+                theme="borderless"
+                {...api.getNextTriggerProps()}
+              />
+            ) : (
+              <Button
+                className={link()}
+                icon="token-icon-pagination-next"
+                size="current"
+                theme="borderless"
+                {...api.getNextTriggerProps()}
+              />
+            )}
           </li>
         )}
       </ul>

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -171,6 +171,7 @@ export function Pagination({
                 className={link()}
                 disabled={api.page === 1}
                 icon="token-icon-pagination-prev"
+                size="current"
                 theme="borderless"
                 {...api.getPrevTriggerProps()}
               />
@@ -200,6 +201,7 @@ export function Pagination({
                     <LinkButton
                       as={linkAs}
                       className={link()}
+                      size="current"
                       theme="borderless"
                       {...api.getItemProps(page)}
                     >
@@ -240,6 +242,7 @@ export function Pagination({
                 className={link()}
                 disabled={api.page === api.totalPages}
                 icon="token-icon-pagination-next"
+                size="current"
                 theme="borderless"
                 {...api.getNextTriggerProps()}
               />

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -1,24 +1,20 @@
 import * as pagination from "@zag-js/pagination"
-import { normalizeProps, useMachine } from "@zag-js/react"
-import {
-  type ElementType,
-  type HTMLAttributes,
-  type ReactNode,
-  useId,
-} from "react"
-import type { VariantProps } from "tailwind-variants"
-import { Button } from "../atoms/button"
+import { mergeProps, normalizeProps, useMachine } from "@zag-js/react"
+import { type ElementType, type HTMLAttributes, type ReactNode, useId } from "react"
 import { Icon } from "../atoms/icon"
-import { LinkButton } from "../atoms/link-button"
+import {
+  LinkButton,
+  type LinkButtonProps,
+} from "../atoms/link-button"
+import type { VariantProps } from "tailwind-variants"
 import { tv } from "../utils"
 
-const paginationVariants = tv({
+export const paginationVariants = tv({
   slots: {
     base: "",
     list: ["inline-flex items-center gap-pagination-list"],
     item: [
       "grid cursor-pointer",
-      // If item is ellipsis => bg-transparent
       'has-[[data-part="ellipsis"]]:bg-pagination-neutral-bg',
       'has-[[data-part="compact-text"]]:bg-pagination-neutral-bg',
     ],
@@ -91,9 +87,7 @@ const paginationVariants = tv({
   },
 })
 
-type HrefCapableElement = ElementType<{ href?: unknown }>
-
-type PaginationBaseProps = HTMLAttributes<HTMLElement> &
+export type PaginationBaseProps = HTMLAttributes<HTMLElement> &
   VariantProps<typeof paginationVariants> & {
     page?: number
     defaultPage?: number
@@ -102,7 +96,6 @@ type PaginationBaseProps = HTMLAttributes<HTMLElement> &
     siblingCount?: number
     boundaryCount?: number
     showPrevNext?: boolean
-    onPageChange?: (page: number) => void
     dir?: "ltr" | "rtl"
     compact?: boolean
     compactLabel?: (details: {
@@ -112,21 +105,35 @@ type PaginationBaseProps = HTMLAttributes<HTMLElement> &
     translations?: pagination.IntlTranslations
   }
 
-type PaginationModeProps =
-  | {
-      type?: "button"
-      getPageUrl?: never
-      linkAs?: never
-    }
-  | {
-      type: "link"
-      getPageUrl: (details: pagination.PageUrlDetails) => string
-      linkAs?: HrefCapableElement
-    }
+type PaginationLinkProps<T extends ElementType> = Omit<
+  LinkButtonProps<T>,
+  | "href"
+  | "children"
+  | "as"
+  | "className"
+  | "size"
+  | "theme"
+  | "disabled"
+  | "icon"
+  | "iconPosition"
+>
 
-export type PaginationProps = PaginationBaseProps & PaginationModeProps
+export type PaginationProps<T extends ElementType = "a"> =
+  PaginationBaseProps & {
+    getPageUrl: (details: pagination.PageUrlDetails) => string
+    linkAs?: T
+    linkProps?: PaginationLinkProps<T>
+  }
 
-export function Pagination({
+type PaginationTriggerProps = Record<string, unknown>
+
+function hasHref(
+  triggerProps: PaginationTriggerProps
+): triggerProps is PaginationTriggerProps & { href: unknown } {
+  return triggerProps.href != null
+}
+
+export function Pagination<T extends ElementType = "a">({
   page,
   defaultPage = 1,
   count,
@@ -134,19 +141,18 @@ export function Pagination({
   siblingCount = 1,
   boundaryCount = 1,
   showPrevNext = true,
-  onPageChange,
   variant,
   className,
   dir = "ltr",
-  type = "button",
   getPageUrl,
   linkAs,
+  linkProps,
   size,
   compact = false,
   compactLabel,
   translations,
   ...props
-}: PaginationProps) {
+}: PaginationProps<T>) {
   const uniqueId = useId()
 
   const service = useMachine(pagination.machine, {
@@ -158,12 +164,9 @@ export function Pagination({
     page,
     dir,
     defaultPage,
-    type,
+    type: "link",
     getPageUrl,
     translations,
-    onPageChange: ({ page }) => {
-      onPageChange?.(page)
-    },
   })
 
   const api = pagination.connect(service, normalizeProps)
@@ -171,31 +174,50 @@ export function Pagination({
     variant,
     size,
   })
+  const rootProps = mergeProps(props, api.getRootProps())
+
+  const sharedLinkProps =
+    linkProps && typeof linkProps === "object"
+      ? (({ href: _ignoredHref, ...rest }) => rest)(
+          linkProps as Record<string, unknown>
+        )
+      : undefined
+
+  const getTriggerButtonProps = (
+    triggerProps: PaginationTriggerProps,
+    overrides: Record<string, unknown> = {}
+  ) => {
+    const baseTriggerProps = mergeProps(triggerProps, {
+      className: link(),
+      size: "current" as const,
+      theme: "borderless" as const,
+      ...overrides,
+    })
+
+    if (!hasHref(triggerProps)) {
+      return mergeProps(baseTriggerProps, {
+        disabled: true,
+      }) as LinkButtonProps<T>
+    }
+
+    return mergeProps(sharedLinkProps, baseTriggerProps, {
+      ...(linkAs ? { as: linkAs } : {}),
+    }) as LinkButtonProps<T>
+  }
+
+  const prevTriggerProps = api.getPrevTriggerProps() as PaginationTriggerProps
+  const nextTriggerProps = api.getNextTriggerProps() as PaginationTriggerProps
 
   return (
-    <nav className={base({ className })} {...api.getRootProps()} {...props}>
+    <nav className={base({ className })} {...rootProps}>
       <ul className={list()}>
         {showPrevNext && (
           <li className={item()}>
-            {type === "link" ? (
-              <LinkButton
-                as={linkAs}
-                className={link()}
-                disabled={api.page === 1}
-                icon="token-icon-pagination-prev"
-                size="current"
-                theme="borderless"
-                {...api.getPrevTriggerProps()}
-              />
-            ) : (
-              <Button
-                className={link()}
-                icon="token-icon-pagination-prev"
-                size="current"
-                theme="borderless"
-                {...api.getPrevTriggerProps()}
-              />
-            )}
+            <LinkButton
+              {...getTriggerButtonProps(prevTriggerProps, {
+                icon: "token-icon-pagination-prev",
+              })}
+            />
           </li>
         )}
         {compact ? (
@@ -208,39 +230,27 @@ export function Pagination({
             </span>
           </li>
         ) : (
-          api.pages.map((page, i) => {
+          api.pages.map((page, index) => {
             if (page.type === "page") {
               return (
                 <li className={item()} key={page.value}>
-                  {type === "link" ? (
-                    <LinkButton
-                      as={linkAs}
-                      className={link()}
-                      size="current"
-                      theme="borderless"
-                      {...api.getItemProps(page)}
-                    >
-                      {page.value}
-                    </LinkButton>
-                  ) : (
-                    <Button
-                      className={link()}
-                      size="current"
-                      theme="borderless"
-                      {...api.getItemProps(page)}
-                    >
-                      {page.value}
-                    </Button>
-                  )}
+                  <LinkButton
+                    {...getTriggerButtonProps(
+                      api.getItemProps(page) as Record<string, unknown>
+                    )}
+                  >
+                    {page.value}
+                  </LinkButton>
                 </li>
               )
             }
+
             return (
-              <li className={item()} key={`ellipsis-${i}`}>
+              <li className={item()} key={`ellipsis-${index}`}>
                 <span
                   aria-hidden="true"
                   className={ellipsis()}
-                  {...api.getEllipsisProps({ index: i })}
+                  {...api.getEllipsisProps({ index })}
                 >
                   <Icon icon="token-icon-pagination-ellipsis" size="current" />
                 </span>
@@ -251,25 +261,11 @@ export function Pagination({
 
         {showPrevNext && (
           <li className={item()}>
-            {type === "link" ? (
-              <LinkButton
-                as={linkAs}
-                className={link()}
-                disabled={api.page === api.totalPages}
-                icon="token-icon-pagination-next"
-                size="current"
-                theme="borderless"
-                {...api.getNextTriggerProps()}
-              />
-            ) : (
-              <Button
-                className={link()}
-                icon="token-icon-pagination-next"
-                size="current"
-                theme="borderless"
-                {...api.getNextTriggerProps()}
-              />
-            )}
+            <LinkButton
+              {...getTriggerButtonProps(nextTriggerProps, {
+                icon: "token-icon-pagination-next",
+              })}
+            />
           </li>
         )}
       </ul>

--- a/libs/ui/stories/molecules/pagination.stories.tsx
+++ b/libs/ui/stories/molecules/pagination.stories.tsx
@@ -1,7 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 import { VariantContainer, VariantGroup } from '../../.storybook/decorator'
+import { Button } from '../../src/atoms/button'
 import { Pagination } from '../../src/molecules/pagination'
+
+const getStoryPageUrl = ({
+  page,
+  pageSize,
+}: {
+  page: number
+  pageSize: number
+}) => `#products?page=${page}&pageSize=${pageSize}`
 
 const meta: Meta<typeof Pagination> = {
   title: 'Molecules/Pagination',
@@ -36,11 +45,26 @@ const meta: Meta<typeof Pagination> = {
         'Number of sibling pages to show on each side of current page',
       defaultValue: 1,
     },
+    boundaryCount: {
+      control: { type: 'number', min: 0 },
+      description: 'Number of boundary pages to always show at each end',
+      defaultValue: 1,
+    },
     variant: {
       control: 'select',
       options: ['filled', 'outlined', 'minimal'],
       description: 'Visual style variant',
       defaultValue: 'filled',
+    },
+    type: {
+      control: 'radio',
+      options: ['button', 'link'],
+      description: 'Interaction mode: real buttons or real links',
+      defaultValue: 'button',
+    },
+    getPageUrl: {
+      control: false,
+      description: 'Required when type is set to "link"',
     },
     showPrevNext: {
       control: 'boolean',
@@ -152,9 +176,9 @@ export const CompactMode: Story = {
   render: () => (
     <VariantContainer>
       <VariantGroup title="Regular vs Compact">
-        <div className="space-y-4">
+        <div className="space-y-300">
           <div>
-            <p className="text-sm text-fg-secondary mb-2">Regular pagination:</p>
+            <p className="text-sm text-fg-secondary mb-100">Regular pagination:</p>
             <Pagination 
               count={250} 
               pageSize={10} 
@@ -164,7 +188,7 @@ export const CompactMode: Story = {
             />
           </div>
           <div>
-            <p className="text-sm text-fg-secondary mb-2">Compact mode:</p>
+            <p className="text-sm text-fg-secondary mb-100">Compact mode:</p>
             <Pagination 
               count={250} 
               pageSize={10} 
@@ -272,7 +296,7 @@ export const EdgeCases: Story = {
   render: () => (
     <VariantContainer>
       <VariantGroup title="Very few pages (1-3)">
-        <div className="space-y-4">
+        <div className="space-y-300">
           <Pagination count={5} pageSize={10} defaultPage={1} variant="filled" />
           <Pagination count={20} pageSize={10} defaultPage={1} variant="outlined" />
           <Pagination count={30} pageSize={10} defaultPage={2} variant="minimal" />
@@ -280,23 +304,23 @@ export const EdgeCases: Story = {
       </VariantGroup>
 
       <VariantGroup title="Many pages (1000+ items)">
-        <div className="space-y-4">
+        <div className="space-y-300">
           <Pagination count={1000} pageSize={10} defaultPage={50} variant="filled" />
           <Pagination count={5000} pageSize={20} defaultPage={125} variant="outlined" />
         </div>
       </VariantGroup>
 
       <VariantGroup title="Different sibling counts">
-        <div className="space-y-4">
-          <div className="flex items-center gap-4">
+        <div className="space-y-300">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-24">siblingCount=0</span>
             <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={0} variant="filled" />
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-24">siblingCount=2</span>
             <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={2} variant="filled" />
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-24">siblingCount=3</span>
             <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={3} variant="filled" />
           </div>
@@ -317,8 +341,8 @@ export const Controlled: Story = {
     const endItem = Math.min(page * pageSize, totalItems)
 
     return (
-      <div className="space-y-6">
-        <div className="text-center space-y-2">
+      <div className="space-y-400">
+        <div className="text-center space-y-150">
           <div className="text-lg font-medium">
             Page {page} of {totalPages}
           </div>
@@ -335,48 +359,87 @@ export const Controlled: Story = {
           variant="filled"
         />
 
-        <div className="flex gap-2 justify-center">
-          <button
+        <div className="flex gap-150 justify-center">
+          <Button
             onClick={() => setPage(1)}
             disabled={page === 1}
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+            size="sm"
+            theme="outlined"
           >
             First
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => setPage(Math.max(1, page - 5))}
             disabled={page <= 5}
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+            size="sm"
+            theme="outlined"
           >
             -5 Pages
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => setPage(Math.min(totalPages, page + 5))}
             disabled={page >= totalPages - 4}
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+            size="sm"
+            theme="outlined"
           >
             +5 Pages
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => setPage(totalPages)}
             disabled={page === totalPages}
-            className="px-3 py-1 text-sm border rounded disabled:opacity-50"
+            size="sm"
+            theme="outlined"
           >
             Last
-          </button>
+          </Button>
         </div>
       </div>
     )
   },
 }
 
+export const LinkMode: Story = {
+  render: () => (
+    <VariantContainer>
+      <VariantGroup title="True link-based pagination">
+        <div className="space-y-300">
+          <p className="text-sm text-fg-secondary">
+            Uses Zag link mode to generate real href values for each trigger.
+          </p>
+          <Pagination
+            count={500}
+            defaultPage={3}
+            pageSize={20}
+            type="link"
+            getPageUrl={getStoryPageUrl}
+            variant="filled"
+          />
+        </div>
+      </VariantGroup>
+
+      <VariantGroup title="Link mode with custom ranges">
+        <Pagination
+          count={500}
+          boundaryCount={2}
+          defaultPage={6}
+          pageSize={20}
+          siblingCount={2}
+          type="link"
+          getPageUrl={getStoryPageUrl}
+          variant="outlined"
+        />
+      </VariantGroup>
+    </VariantContainer>
+  ),
+}
+
 export const RealWorldScenarios: Story = {
   render: () => (
     <VariantContainer>
       <VariantGroup title="Table pagination (pageSize=20)">
-        <div className="space-y-4">
-          <div className="border rounded p-4 space-y-3">
-            <div className="h-32 bg-gray-50 rounded flex items-center justify-center text-sm text-gray-500">
+        <div className="space-y-300">
+          <div className="border rounded p-300 space-y-300">
+            <div className="h-32 bg-surface rounded flex items-center justify-center text-sm text-fg-primary">
               Table content area
             </div>
             <div className="flex justify-between items-center">
@@ -388,16 +451,16 @@ export const RealWorldScenarios: Story = {
       </VariantGroup>
 
       <VariantGroup title="Different page sizes">
-        <div className="space-y-4">
-          <div className="flex items-center gap-4">
+        <div className="space-y-300">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-32">5 items/page</span>
             <Pagination count={100} pageSize={5} defaultPage={3} variant="outlined" />
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-32">25 items/page</span>
             <Pagination count={100} pageSize={25} defaultPage={2} variant="outlined" />
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-300">
             <span className="text-sm w-32">50 items/page</span>
             <Pagination count={100} pageSize={50} defaultPage={1} variant="outlined" />
           </div>
@@ -405,7 +468,7 @@ export const RealWorldScenarios: Story = {
       </VariantGroup>
 
       <VariantGroup title="Without prev/next buttons">
-        <div className="space-y-4">
+        <div className="space-y-300">
           <Pagination 
             count={150} 
             pageSize={10} 

--- a/libs/ui/stories/molecules/pagination.stories.tsx
+++ b/libs/ui/stories/molecules/pagination.stories.tsx
@@ -57,10 +57,9 @@ const meta: Meta<typeof Pagination> = {
       defaultValue: 'filled',
     },
     type: {
-      control: 'radio',
-      options: ['button', 'link'],
-      description: 'Interaction mode: real buttons or real links',
-      defaultValue: 'button',
+      control: false,
+      description:
+        'Supports both button and link modes. See the LinkMode story for true link-based pagination.',
     },
     getPageUrl: {
       control: false,

--- a/libs/ui/stories/molecules/pagination.stories.tsx
+++ b/libs/ui/stories/molecules/pagination.stories.tsx
@@ -1,8 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/react'
-import { useState } from 'react'
-import { VariantContainer, VariantGroup } from '../../.storybook/decorator'
-import { Button } from '../../src/atoms/button'
-import { Pagination } from '../../src/molecules/pagination'
+import type { Meta, StoryObj } from "@storybook/react"
+import type { ComponentPropsWithoutRef } from "react"
+import { VariantContainer, VariantGroup } from "../../.storybook/decorator"
+import {
+  Pagination,
+  type PaginationProps,
+} from "../../src/molecules/pagination"
 
 const getStoryPageUrl = ({
   page,
@@ -12,159 +14,159 @@ const getStoryPageUrl = ({
   pageSize: number
 }) => `#products?page=${page}&pageSize=${pageSize}`
 
+type StoryPaginationProps = Omit<PaginationProps, "getPageUrl">
+
+function StoryPagination(props: StoryPaginationProps) {
+  return <Pagination {...props} getPageUrl={getStoryPageUrl} />
+}
+
+type StoryLinkProps = ComponentPropsWithoutRef<"a"> & {
+  replace?: boolean
+}
+
+function StoryLink({ replace, ...props }: StoryLinkProps) {
+  return <a data-replace={replace ? "true" : undefined} {...props} />
+}
+
 const meta: Meta<typeof Pagination> = {
-  title: 'Molecules/Pagination',
+  title: "Molecules/Pagination",
   component: Pagination,
   parameters: {
-    layout: 'centered',
+    layout: "centered",
   },
-  tags: ['autodocs'],
+  tags: ["autodocs"],
   argTypes: {
     page: {
-      control: { type: 'number', min: 1 },
-      description: 'Current active page (controlled)',
+      control: { type: "number", min: 1 },
+      description: "Current active page (controlled)",
     },
     defaultPage: {
-      control: { type: 'number', min: 1 },
-      description: 'Initial active page (uncontrolled)',
+      control: { type: "number", min: 1 },
+      description: "Initial active page (uncontrolled)",
       defaultValue: 1,
     },
     count: {
-      control: { type: 'number', min: 1 },
-      description: 'Total number of items',
+      control: { type: "number", min: 1 },
+      description: "Total number of items",
       defaultValue: 100,
     },
     pageSize: {
-      control: { type: 'number', min: 1 },
-      description: 'Number of items per page',
+      control: { type: "number", min: 1 },
+      description: "Number of items per page",
       defaultValue: 10,
     },
     siblingCount: {
-      control: { type: 'number', min: 0 },
+      control: { type: "number", min: 0 },
       description:
-        'Number of sibling pages to show on each side of current page',
+        "Number of sibling pages to show on each side of current page",
       defaultValue: 1,
     },
     boundaryCount: {
-      control: { type: 'number', min: 0 },
-      description: 'Number of boundary pages to always show at each end',
+      control: { type: "number", min: 0 },
+      description: "Number of boundary pages to always show at each end",
       defaultValue: 1,
-    },
-    variant: {
-      control: 'select',
-      options: ['filled', 'outlined', 'minimal'],
-      description: 'Visual style variant',
-      defaultValue: 'filled',
-    },
-    type: {
-      control: false,
-      description:
-        'Supports both button and link modes. See the LinkMode story for true link-based pagination.',
     },
     getPageUrl: {
       control: false,
-      description: 'Required when type is set to "link"',
+      description: "Required. Builds the href for each pagination trigger.",
+    },
+    linkAs: {
+      control: false,
+      description: "Optional custom link component used for navigable items.",
+    },
+    linkProps: {
+      control: false,
+      description:
+        "Optional props forwarded to the custom link component. `href` remains owned by Pagination.",
+    },
+    variant: {
+      control: "select",
+      options: ["filled", "outlined", "minimal"],
+      description: "Visual style variant",
+      defaultValue: "filled",
     },
     showPrevNext: {
-      control: 'boolean',
-      description: 'Show previous/next page buttons',
+      control: "boolean",
+      description: "Show previous/next page buttons",
       defaultValue: true,
     },
+  },
+  args: {
+    defaultPage: 5,
+    count: 100,
+    pageSize: 10,
+    siblingCount: 1,
+    variant: "filled",
+    showPrevNext: true,
+    getPageUrl: getStoryPageUrl,
   },
 }
 
 export default meta
 type Story = StoryObj<typeof Pagination>
 
-export const Default: Story = {
-  args: {
-    defaultPage: 5,
-    count: 100,
-    pageSize: 10,
-    siblingCount: 1,
-    variant: 'filled',
-    showPrevNext: true,
-  },
-}
+export const Default: Story = {}
 
 export const Sizes: Story = {
   render: () => (
     <VariantContainer>
       <VariantGroup title="Small (sm)">
-        <div className='space-y-300'>
-          <Pagination 
-            count={100} 
-            pageSize={10} 
-            defaultPage={5} 
+        <div className="space-y-300">
+          <StoryPagination count={100} defaultPage={5} pageSize={10} size="sm" />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
             size="sm"
-          variant="filled" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="sm"
-          variant="outlined" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="sm"
-          variant="minimal" 
-        />
+            variant="outlined"
+          />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
+            size="sm"
+            variant="minimal"
+          />
         </div>
       </VariantGroup>
-      
-      <VariantGroup title="Medium (md) - default">
-        <div className='space-y-300'>
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="md"
-          variant="filled" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="md"
-          variant="outlined" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="md"
-          variant="minimal" 
-        />
+
+      <VariantGroup title="Medium (md)">
+        <div className="space-y-300">
+          <StoryPagination count={100} defaultPage={5} pageSize={10} size="md" />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
+            size="md"
+            variant="outlined"
+          />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
+            size="md"
+            variant="minimal"
+          />
         </div>
       </VariantGroup>
-      
+
       <VariantGroup title="Large (lg)">
-        <div className='space-y-300'>
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="lg"
-          variant="filled" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="lg"
-          variant="outlined" 
-        />
-        <Pagination 
-          count={100} 
-          pageSize={10} 
-          defaultPage={5} 
-          size="lg"
-          variant="minimal" 
-        />
+        <div className="space-y-300">
+          <StoryPagination count={100} defaultPage={5} pageSize={10} size="lg" />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
+            size="lg"
+            variant="outlined"
+          />
+          <StoryPagination
+            count={100}
+            defaultPage={5}
+            pageSize={10}
+            size="lg"
+            variant="minimal"
+          />
         </div>
       </VariantGroup>
     </VariantContainer>
@@ -176,77 +178,32 @@ export const CompactMode: Story = {
     <VariantContainer>
       <VariantGroup title="Regular vs Compact">
         <div className="space-y-300">
-          <div>
-            <p className="text-sm text-fg-secondary mb-100">Regular pagination:</p>
-            <Pagination 
-              count={250} 
-              pageSize={10} 
-              defaultPage={5} 
-              variant="filled"
-              compact={false}
-            />
-          </div>
-          <div>
-            <p className="text-sm text-fg-secondary mb-100">Compact mode:</p>
-            <Pagination 
-              count={250} 
-              pageSize={10} 
-              defaultPage={5} 
-              variant="filled"
-              compact={true}
-            />
-          </div>
+          <StoryPagination count={250} defaultPage={5} pageSize={10} />
+          <StoryPagination compact count={250} defaultPage={5} pageSize={10} />
         </div>
       </VariantGroup>
 
-      <VariantGroup title="Compact with different variants">
-        <Pagination 
-          count={150} 
-          pageSize={10} 
-          defaultPage={8} 
-          variant="filled"
-          compact={true}
-        />
-        <Pagination 
-          count={150} 
-          pageSize={10} 
-          defaultPage={8} 
-          variant="outlined"
-          compact={true}
-        />
-        <Pagination 
-          count={150} 
-          pageSize={10} 
-          defaultPage={8} 
-          variant="minimal"
-          compact={true}
-        />
-      </VariantGroup>
-
       <VariantGroup title="Compact with sizes">
-        <Pagination 
-          count={200} 
-          pageSize={10} 
-          defaultPage={12} 
+        <StoryPagination
+          compact
+          count={200}
+          defaultPage={12}
+          pageSize={10}
           size="sm"
-          variant="filled"
-          compact={true}
         />
-        <Pagination 
-          count={200} 
-          pageSize={10} 
-          defaultPage={12} 
+        <StoryPagination
+          compact
+          count={200}
+          defaultPage={12}
+          pageSize={10}
           size="md"
-          variant="filled"
-          compact={true}
         />
-        <Pagination 
-          count={200} 
-          pageSize={10} 
-          defaultPage={12} 
+        <StoryPagination
+          compact
+          count={200}
+          defaultPage={12}
+          pageSize={10}
           size="lg"
-          variant="filled"
-          compact={true}
         />
       </VariantGroup>
     </VariantContainer>
@@ -256,34 +213,24 @@ export const CompactMode: Story = {
 export const StyleVariants: Story = {
   render: () => (
     <VariantContainer>
-      <VariantGroup title="Default (Filled)">
-        <Pagination
-          defaultPage={5}
-          count={100}
-          pageSize={10}
-          showPrevNext={true}
-          variant="filled"
-        />
+      <VariantGroup title="Filled">
+        <StoryPagination count={100} defaultPage={5} pageSize={10} />
       </VariantGroup>
 
       <VariantGroup title="Outlined">
-        <Pagination
-          defaultPage={5}
+        <StoryPagination
           count={100}
+          defaultPage={5}
           pageSize={10}
-          siblingCount={1}
-          showPrevNext={true}
           variant="outlined"
         />
       </VariantGroup>
 
       <VariantGroup title="Minimal">
-        <Pagination
-          defaultPage={5}
+        <StoryPagination
           count={100}
+          defaultPage={5}
           pageSize={10}
-          siblingCount={1}
-          showPrevNext={true}
           variant="minimal"
         />
       </VariantGroup>
@@ -294,139 +241,59 @@ export const StyleVariants: Story = {
 export const EdgeCases: Story = {
   render: () => (
     <VariantContainer>
-      <VariantGroup title="Very few pages (1-3)">
+      <VariantGroup title="Very few pages">
         <div className="space-y-300">
-          <Pagination count={5} pageSize={10} defaultPage={1} variant="filled" />
-          <Pagination count={20} pageSize={10} defaultPage={1} variant="outlined" />
-          <Pagination count={30} pageSize={10} defaultPage={2} variant="minimal" />
+          <StoryPagination count={5} defaultPage={1} pageSize={10} />
+          <StoryPagination
+            count={20}
+            defaultPage={1}
+            pageSize={10}
+            variant="outlined"
+          />
+          <StoryPagination
+            count={30}
+            defaultPage={2}
+            pageSize={10}
+            variant="minimal"
+          />
         </div>
       </VariantGroup>
 
-      <VariantGroup title="Many pages (1000+ items)">
+      <VariantGroup title="Many pages">
         <div className="space-y-300">
-          <Pagination count={1000} pageSize={10} defaultPage={50} variant="filled" />
-          <Pagination count={5000} pageSize={20} defaultPage={125} variant="outlined" />
-        </div>
-      </VariantGroup>
-
-      <VariantGroup title="Different sibling counts">
-        <div className="space-y-300">
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-24">siblingCount=0</span>
-            <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={0} variant="filled" />
-          </div>
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-24">siblingCount=2</span>
-            <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={2} variant="filled" />
-          </div>
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-24">siblingCount=3</span>
-            <Pagination count={200} pageSize={10} defaultPage={10} siblingCount={3} variant="filled" />
-          </div>
+          <StoryPagination count={1000} defaultPage={50} pageSize={10} />
+          <StoryPagination
+            count={5000}
+            defaultPage={125}
+            pageSize={20}
+            variant="outlined"
+          />
         </div>
       </VariantGroup>
     </VariantContainer>
   ),
 }
 
-export const Controlled: Story = {
-  render: () => {
-    const [page, setPage] = useState(1)
-    const totalItems = 250
-    const pageSize = 10
-    const totalPages = Math.ceil(totalItems / pageSize)
-    
-    const startItem = (page - 1) * pageSize + 1
-    const endItem = Math.min(page * pageSize, totalItems)
-
-    return (
-      <div className="space-y-400">
-        <div className="text-center space-y-150">
-          <div className="text-lg font-medium">
-            Page {page} of {totalPages}
-          </div>
-          <div className="text-sm text-fg-secondary">
-            Showing items {startItem}-{endItem} of {totalItems}
-          </div>
-        </div>
-
-        <Pagination
-          page={page}
-          count={totalItems}
-          pageSize={pageSize}
-          onPageChange={setPage}
-          variant="filled"
-        />
-
-        <div className="flex gap-150 justify-center">
-          <Button
-            onClick={() => setPage(1)}
-            disabled={page === 1}
-            size="sm"
-            theme="outlined"
-          >
-            First
-          </Button>
-          <Button
-            onClick={() => setPage(Math.max(1, page - 5))}
-            disabled={page <= 5}
-            size="sm"
-            theme="outlined"
-          >
-            -5 Pages
-          </Button>
-          <Button
-            onClick={() => setPage(Math.min(totalPages, page + 5))}
-            disabled={page >= totalPages - 4}
-            size="sm"
-            theme="outlined"
-          >
-            +5 Pages
-          </Button>
-          <Button
-            onClick={() => setPage(totalPages)}
-            disabled={page === totalPages}
-            size="sm"
-            theme="outlined"
-          >
-            Last
-          </Button>
-        </div>
-      </div>
-    )
-  },
-}
-
-export const LinkMode: Story = {
+export const CustomLinkComponent: Story = {
   render: () => (
     <VariantContainer>
-      <VariantGroup title="True link-based pagination">
+      <VariantGroup title="Custom polymorphic link">
         <div className="space-y-300">
-          <p className="text-sm text-fg-secondary">
-            Uses Zag link mode to generate real href values for each trigger.
+          <p className="text-fg-secondary text-sm">
+            `Pagination` stays navigation-only, but can forward extra props to a
+            custom link component.
           </p>
           <Pagination
             count={500}
-            defaultPage={3}
+            defaultPage={6}
             pageSize={20}
-            type="link"
+            siblingCount={2}
+            linkAs={StoryLink}
+            linkProps={{ replace: true }}
             getPageUrl={getStoryPageUrl}
-            variant="filled"
+            variant="outlined"
           />
         </div>
-      </VariantGroup>
-
-      <VariantGroup title="Link mode with custom ranges">
-        <Pagination
-          count={500}
-          boundaryCount={2}
-          defaultPage={6}
-          pageSize={20}
-          siblingCount={2}
-          type="link"
-          getPageUrl={getStoryPageUrl}
-          variant="outlined"
-        />
       </VariantGroup>
     </VariantContainer>
   ),
@@ -435,59 +302,41 @@ export const LinkMode: Story = {
 export const RealWorldScenarios: Story = {
   render: () => (
     <VariantContainer>
-      <VariantGroup title="Table pagination (pageSize=20)">
+      <VariantGroup title="Table navigation">
         <div className="space-y-300">
-          <div className="border rounded p-300 space-y-300">
-            <div className="h-32 bg-surface rounded flex items-center justify-center text-sm text-fg-primary">
+          <div className="space-y-300 rounded border bg-base p-300">
+            <div className="flex h-32 items-center justify-center rounded bg-surface text-fg-primary text-sm">
               Table content area
             </div>
-            <div className="flex justify-between items-center">
-              <span className="text-sm text-fg-secondary">20 items per page</span>
-              <Pagination count={456} pageSize={20} defaultPage={3} variant="filled" />
+            <div className="flex items-center justify-between">
+              <span className="text-fg-secondary text-sm">20 items per page</span>
+              <StoryPagination count={456} defaultPage={3} pageSize={20} />
             </div>
-          </div>
-        </div>
-      </VariantGroup>
-
-      <VariantGroup title="Different page sizes">
-        <div className="space-y-300">
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-32">5 items/page</span>
-            <Pagination count={100} pageSize={5} defaultPage={3} variant="outlined" />
-          </div>
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-32">25 items/page</span>
-            <Pagination count={100} pageSize={25} defaultPage={2} variant="outlined" />
-          </div>
-          <div className="flex items-center gap-300">
-            <span className="text-sm w-32">50 items/page</span>
-            <Pagination count={100} pageSize={50} defaultPage={1} variant="outlined" />
           </div>
         </div>
       </VariantGroup>
 
       <VariantGroup title="Without prev/next buttons">
         <div className="space-y-300">
-          <Pagination 
-            count={150} 
-            pageSize={10} 
-            defaultPage={5} 
-            showPrevNext={false} 
-            variant="filled" 
+          <StoryPagination
+            count={150}
+            defaultPage={5}
+            pageSize={10}
+            showPrevNext={false}
           />
-          <Pagination 
-            count={150} 
-            pageSize={10} 
-            defaultPage={5} 
-            showPrevNext={false} 
-            variant="outlined" 
+          <StoryPagination
+            count={150}
+            defaultPage={5}
+            pageSize={10}
+            showPrevNext={false}
+            variant="outlined"
           />
-          <Pagination 
-            count={150} 
-            pageSize={10} 
-            defaultPage={5} 
-            showPrevNext={false} 
-            variant="minimal" 
+          <StoryPagination
+            count={150}
+            defaultPage={5}
+            pageSize={10}
+            showPrevNext={false}
+            variant="minimal"
           />
         </div>
       </VariantGroup>

--- a/libs/ui/stories/overview/component-comparison.stories.tsx
+++ b/libs/ui/stories/overview/component-comparison.stories.tsx
@@ -564,7 +564,15 @@ function ComponentComparison() {
             <Menu items={menuItems} size="md" triggerText="Actions" />
           </ComponentCard>
           <ComponentCard title="Pagination" bodyClassName="w-full overflow-x-auto">
-            <Pagination compact count={12} pageSize={1} size="md" />
+            <Pagination
+              compact
+              count={12}
+              getPageUrl={({ page, pageSize }) =>
+                `#component-pagination?page=${page}&pageSize=${pageSize}`
+              }
+              pageSize={1}
+              size="md"
+            />
           </ComponentCard>
           <ComponentCard title="Popover">
             <Popover


### PR DESCRIPTION
Adds proper Zag link-mode support to the shared Pagination component so it can render true links when needed, while keeping the existing controlled button-based mode for non-URL pagination use cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination now supports link-mode navigation and a story demonstrating custom link components.
  * Added controls for boundary count, a customizable compact page label and localisation strings.

* **Improvements**
  * Active-page styling updated to match selection contract.
  * Storybook examples refreshed for link usage, spacing/layout consistency and simplified examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->