### PR TITLE
feat(storefront-data): export shared medusa error helpers

### DIFF
--- a/libs/storefront-data/package.json
+++ b/libs/storefront-data/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/src/shared/local-storage.d.ts",
       "import": "./dist/shared/local-storage.js"
     },
+    "./shared/medusa-errors": {
+      "types": "./dist/src/shared/medusa-errors.d.ts",
+      "import": "./dist/shared/medusa-errors.js"
+    },
     "./shared/medusa-client": {
       "types": "./dist/src/shared/medusa-client.d.ts",
       "import": "./dist/shared/medusa-client.js"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made the medusa-errors shared module publicly available as a package export for direct import and use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->