### PR TITLE
feat(storefront-security): add shared Next storefront security config

### DIFF
--- a/libs/storefront-security/README.md
+++ b/libs/storefront-security/README.md
@@ -27,7 +27,7 @@ Use `createStorefrontSecurityConfig()` with:
 - `replace` for full overrides
 
 ```ts
-import { createStorefrontSecurityConfig } from "../../libs/storefront-security/next-security.mjs"
+import { createStorefrontSecurityConfig } from "../../libs/storefront-security/index.mjs"
 
 const storefrontSecurity = createStorefrontSecurityConfig({
   preset: "medusaStorefront",
@@ -89,8 +89,8 @@ const storefrontSecurity = createStorefrontSecurityConfig({
 
 ### `replace`
 
-Use `replace` when you want to override a whole directive or policy instead of
-extending it.
+Use `replace` when a project needs to take ownership of a full directive,
+policy, or header value.
 
 ```ts
 const storefrontSecurity = createStorefrontSecurityConfig({
@@ -190,7 +190,7 @@ import {
   buildStorefrontContentSecurityPolicy,
   buildDevHmrOrigins,
   storefrontSecurityPresets,
-} from "../../libs/storefront-security/next-security.mjs"
+} from "../../libs/storefront-security/index.mjs"
 ```
 
 ## Suggested rollout

--- a/libs/storefront-security/README.md
+++ b/libs/storefront-security/README.md
@@ -1,0 +1,201 @@
+# storefront-security
+
+Shared Next.js storefront security config for this monorepo.
+
+The library is intentionally narrow:
+- it provides a reusable storefront security baseline
+- it exposes a preset-based API with overrides
+- it does not hardcode app-specific integrations like analytics or checkout vendors
+
+## What it solves
+
+It centralizes the common parts of storefront hardening:
+- response security headers
+- CSP generation
+- production-only HSTS
+- public backend URL validation
+- dev HMR websocket origins
+
+The goal is that a new storefront can start from a safe shared preset and only
+declare what is unique to that project.
+
+## Recommended API
+
+Use `createStorefrontSecurityConfig()` with:
+- `preset` for the shared baseline
+- `extend` for additive changes
+- `replace` for full overrides
+
+```ts
+import { createStorefrontSecurityConfig } from "../../libs/storefront-security/next-security.mjs"
+
+const storefrontSecurity = createStorefrontSecurityConfig({
+  preset: "medusaStorefront",
+})
+
+const nextConfig = {
+  ...storefrontSecurity,
+  reactStrictMode: true,
+}
+
+export default nextConfig
+```
+
+## Available preset
+
+### `medusaStorefront`
+
+Use this for the standard Medusa + Next storefront case.
+
+It includes:
+- baseline response headers
+- CSP skeleton
+- validated public backend origin in `connect-src`
+- dev HMR websocket origins
+- common storefront defaults for images, fonts, workers, and manifests
+
+It does **not** include:
+- analytics hosts
+- checkout widget hosts
+- marketplace/integration-specific allowlists
+
+Those must be added per app.
+
+## Extend vs replace
+
+### `extend`
+
+Use `extend` when you want to add more sources or headers without throwing away
+the shared baseline.
+
+```ts
+const storefrontSecurity = createStorefrontSecurityConfig({
+  preset: "medusaStorefront",
+  extend: {
+    csp: {
+      scriptSrc: ["https://www.googletagmanager.com"],
+      connectSrc: ["https://www.google-analytics.com"],
+      frameSrc: ["https://www.ppl.cz"],
+      styleSrc: ["https://www.ppl.cz"],
+    },
+    headers: [
+      { key: "Cache-Control", value: "public, max-age=60" },
+    ],
+  },
+})
+```
+
+`extend.permissionsPolicy` adds directives on top of the preset baseline.
+
+### `replace`
+
+Use `replace` when you want to override a whole directive or policy instead of
+extending it.
+
+```ts
+const storefrontSecurity = createStorefrontSecurityConfig({
+  preset: "medusaStorefront",
+  replace: {
+    permissionsPolicy: [
+      "camera=()",
+      "microphone=()",
+      "geolocation=(self)",
+    ],
+    csp: {
+      frameSrc: ["'self'"],
+    },
+    headers: [
+      { key: "X-Frame-Options", value: "SAMEORIGIN" },
+    ],
+  },
+})
+```
+
+`replace.permissionsPolicy` replaces the entire policy list.
+
+## Common options
+
+### `allowedDevOrigins`
+
+Adds custom dev websocket origins for HMR.
+
+```ts
+createStorefrontSecurityConfig({
+  preset: "medusaStorefront",
+  allowedDevOrigins: ["shop.localhost"],
+})
+```
+
+### `publicBackendUrl`
+
+Overrides the backend URL source used by the preset. If omitted, the library
+reads `NEXT_PUBLIC_MEDUSA_BACKEND_URL`.
+
+In production:
+- missing URL throws
+- invalid absolute URL throws
+
+In development:
+- it falls back to `http://localhost:9000`
+
+### `source`
+
+Overrides the Next header matcher. Defaults to `/:path*`.
+
+## CSP behavior
+
+The library generates a baseline CSP with:
+- `default-src 'self'`
+- `frame-ancestors 'none'`
+- `object-src 'none'`
+- `base-uri 'self'`
+- `form-action 'self'`
+
+And storefront defaults for:
+- `script-src`
+- `style-src`
+- `img-src`
+- `font-src`
+- `connect-src`
+- `frame-src`
+- `worker-src`
+- `manifest-src`
+
+Notes:
+- `unsafe-inline` is still present for the current App Router baseline
+- `unsafe-eval` is added only in development
+- `upgrade-insecure-requests` is added only in production
+
+## Legacy compatibility
+
+The library still supports the older transition options:
+- `additionalScriptSrc`
+- `additionalStyleSrc`
+- `additionalConnectSrc`
+- `additionalFrameSrc`
+- `additionalImgSrc`
+- `additionalFontSrc`
+- `permissionsPolicyDirectives`
+
+These are treated as additive extensions. New consumers should prefer
+`preset + extend + replace`.
+
+## Public exports
+
+```ts
+import {
+  createStorefrontSecurityConfig,
+  resolvePublicBackendUrl,
+  resolvePublicBackendOrigin,
+  buildStorefrontContentSecurityPolicy,
+  buildDevHmrOrigins,
+  storefrontSecurityPresets,
+} from "../../libs/storefront-security/next-security.mjs"
+```
+
+## Suggested rollout
+
+1. Start every new storefront with `preset: "medusaStorefront"`.
+2. Add project-specific integrations through `extend.csp`.
+3. Use `replace` only when a project must intentionally diverge.
+4. Keep runtime SDK setup separate from this library.

--- a/libs/storefront-security/backend-url.mjs
+++ b/libs/storefront-security/backend-url.mjs
@@ -1,0 +1,53 @@
+const TRAILING_SLASH_PATTERN = /\/$/
+
+export const DEFAULT_PUBLIC_BACKEND_ENV_NAME =
+  "NEXT_PUBLIC_MEDUSA_BACKEND_URL"
+export const DEFAULT_DEVELOPMENT_BACKEND_URL = "http://localhost:9000"
+
+/**
+ * @param {{
+ *   isProduction?: boolean
+ *   publicBackendUrl?: string | undefined
+ *   envVarName?: string
+ *   defaultDevelopmentBackendUrl?: string
+ * }} [options]
+ * @returns {string}
+ */
+export function resolvePublicBackendUrl(options = {}) {
+  const {
+    isProduction = process.env.NODE_ENV === "production",
+    publicBackendUrl = process.env[DEFAULT_PUBLIC_BACKEND_ENV_NAME],
+    envVarName = DEFAULT_PUBLIC_BACKEND_ENV_NAME,
+    defaultDevelopmentBackendUrl = DEFAULT_DEVELOPMENT_BACKEND_URL,
+  } = options
+
+  const configuredUrl = publicBackendUrl?.trim()
+
+  if (!configuredUrl) {
+    if (isProduction) {
+      throw new Error(`Missing ${envVarName} in production.`)
+    }
+
+    return defaultDevelopmentBackendUrl
+  }
+
+  try {
+    return new URL(configuredUrl).toString().replace(TRAILING_SLASH_PATTERN, "")
+  } catch {
+    if (isProduction) {
+      throw new Error(
+        `Invalid ${envVarName}: expected an absolute URL, received "${configuredUrl}".`
+      )
+    }
+
+    return defaultDevelopmentBackendUrl
+  }
+}
+
+/**
+ * @param {Parameters<typeof resolvePublicBackendUrl>[0]} [options]
+ * @returns {string}
+ */
+export function resolvePublicBackendOrigin(options = {}) {
+  return new URL(resolvePublicBackendUrl(options)).origin
+}

--- a/libs/storefront-security/backend-url.mjs
+++ b/libs/storefront-security/backend-url.mjs
@@ -16,10 +16,11 @@ export const DEFAULT_DEVELOPMENT_BACKEND_URL = "http://localhost:9000"
 export function resolvePublicBackendUrl(options = {}) {
   const {
     isProduction = process.env.NODE_ENV === "production",
-    publicBackendUrl = process.env[DEFAULT_PUBLIC_BACKEND_ENV_NAME],
     envVarName = DEFAULT_PUBLIC_BACKEND_ENV_NAME,
     defaultDevelopmentBackendUrl = DEFAULT_DEVELOPMENT_BACKEND_URL,
   } = options
+  const publicBackendUrl =
+    options.publicBackendUrl ?? process.env[envVarName]
 
   const configuredUrl = publicBackendUrl?.trim()
 

--- a/libs/storefront-security/csp.mjs
+++ b/libs/storefront-security/csp.mjs
@@ -1,0 +1,179 @@
+/**
+ * @typedef {{
+ *   defaultSrc?: string[]
+ *   baseUri?: string[]
+ *   formAction?: string[]
+ *   frameAncestors?: string[]
+ *   objectSrc?: string[]
+ *   scriptSrc?: string[]
+ *   styleSrc?: string[]
+ *   imgSrc?: string[]
+ *   fontSrc?: string[]
+ *   connectSrc?: string[]
+ *   frameSrc?: string[]
+ *   workerSrc?: string[]
+ *   manifestSrc?: string[]
+ *   upgradeInsecureRequests?: boolean
+ * }} StorefrontCspDirectives
+ */
+
+const CSP_DIRECTIVE_ORDER = [
+  ["defaultSrc", "default-src"],
+  ["baseUri", "base-uri"],
+  ["formAction", "form-action"],
+  ["frameAncestors", "frame-ancestors"],
+  ["objectSrc", "object-src"],
+  ["scriptSrc", "script-src"],
+  ["styleSrc", "style-src"],
+  ["imgSrc", "img-src"],
+  ["fontSrc", "font-src"],
+  ["connectSrc", "connect-src"],
+  ["frameSrc", "frame-src"],
+  ["workerSrc", "worker-src"],
+  ["manifestSrc", "manifest-src"],
+]
+
+/**
+ * @param {Array<string | null | undefined>} sources
+ * @returns {string[]}
+ */
+export function uniquePolicySources(sources) {
+  return [...new Set(sources.filter(Boolean))]
+}
+
+/**
+ * @param {{
+ *   isProduction?: boolean
+ *   allowedDevOrigins?: string[]
+ *   devPort?: number
+ * }} [options]
+ * @returns {string[]}
+ */
+export function buildDevHmrOrigins(options = {}) {
+  const {
+    isProduction = process.env.NODE_ENV === "production",
+    allowedDevOrigins = [],
+    devPort = 3000,
+  } = options
+
+  if (isProduction) {
+    return []
+  }
+
+  return uniquePolicySources([
+    `ws://localhost:${devPort}`,
+    `ws://127.0.0.1:${devPort}`,
+    ...allowedDevOrigins.flatMap((origin) => [
+      `ws://${origin}`,
+      `wss://${origin}`,
+      `ws://${origin}:${devPort}`,
+      `wss://${origin}:${devPort}`,
+    ]),
+  ])
+}
+
+/**
+ * @param {{
+ *   isProduction?: boolean
+ *   publicBackendOrigin: string
+ *   allowedDevOrigins?: string[]
+ *   devPort?: number
+ * }} options
+ * @returns {StorefrontCspDirectives}
+ */
+export function createBaseStorefrontCsp(options) {
+  const {
+    isProduction = process.env.NODE_ENV === "production",
+    publicBackendOrigin,
+    allowedDevOrigins = [],
+    devPort = 3000,
+  } = options
+
+  return {
+    defaultSrc: ["'self'"],
+    baseUri: ["'self'"],
+    formAction: ["'self'"],
+    frameAncestors: ["'none'"],
+    objectSrc: ["'none'"],
+    scriptSrc: uniquePolicySources([
+      "'self'",
+      "'unsafe-inline'",
+      ...(isProduction ? [] : ["'unsafe-eval'"]),
+    ]),
+    styleSrc: ["'self'", "'unsafe-inline'"],
+    imgSrc: ["'self'", "data:", "blob:", "https:"],
+    fontSrc: ["'self'", "data:"],
+    connectSrc: uniquePolicySources([
+      "'self'",
+      publicBackendOrigin,
+      ...buildDevHmrOrigins({ isProduction, allowedDevOrigins, devPort }),
+    ]),
+    frameSrc: ["'self'"],
+    workerSrc: ["'self'", "blob:"],
+    manifestSrc: ["'self'"],
+    upgradeInsecureRequests: isProduction,
+  }
+}
+
+/**
+ * @param {{
+ *   base?: StorefrontCspDirectives
+ *   extend?: Partial<StorefrontCspDirectives>
+ *   replace?: Partial<StorefrontCspDirectives>
+ * }} [options]
+ * @returns {StorefrontCspDirectives}
+ */
+export function mergeStorefrontCsp(options = {}) {
+  const { base = {}, extend = {}, replace = {} } = options
+
+  /** @type {StorefrontCspDirectives} */
+  const merged = { ...base }
+
+  for (const [directiveKey] of CSP_DIRECTIVE_ORDER) {
+    const baseValues = Array.isArray(base[directiveKey]) ? base[directiveKey] : []
+    const extendValues = Array.isArray(extend[directiveKey])
+      ? extend[directiveKey]
+      : []
+    const replaceValues = replace[directiveKey]
+
+    if (Array.isArray(replaceValues)) {
+      merged[directiveKey] = uniquePolicySources(replaceValues)
+      continue
+    }
+
+    merged[directiveKey] = uniquePolicySources([...baseValues, ...extendValues])
+  }
+
+  merged.upgradeInsecureRequests =
+    typeof replace.upgradeInsecureRequests === "boolean"
+      ? replace.upgradeInsecureRequests
+      : typeof extend.upgradeInsecureRequests === "boolean"
+        ? extend.upgradeInsecureRequests
+        : Boolean(base.upgradeInsecureRequests)
+
+  return merged
+}
+
+/**
+ * @param {{ csp: StorefrontCspDirectives }} options
+ * @returns {string}
+ */
+export function buildStorefrontContentSecurityPolicy(options) {
+  const { csp } = options
+
+  const directives = CSP_DIRECTIVE_ORDER.flatMap(([directiveKey, headerName]) => {
+    const values = csp[directiveKey]
+
+    if (!Array.isArray(values) || values.length === 0) {
+      return []
+    }
+
+    return `${headerName} ${values.join(" ")}`
+  })
+
+  if (csp.upgradeInsecureRequests) {
+    directives.push("upgrade-insecure-requests")
+  }
+
+  return directives.join("; ")
+}

--- a/libs/storefront-security/csp.mjs
+++ b/libs/storefront-security/csp.mjs
@@ -42,6 +42,27 @@ export function uniquePolicySources(sources) {
 }
 
 /**
+ * @param {string} origin
+ * @returns {{ hostname: string, port: string | null }}
+ */
+function normalizeAllowedDevOrigin(origin) {
+  const normalizedOrigin = origin.trim()
+
+  if (!normalizedOrigin) {
+    throw new Error("allowedDevOrigins entries must not be empty.")
+  }
+
+  const parsedOrigin = normalizedOrigin.includes("://")
+    ? new URL(normalizedOrigin)
+    : new URL(`http://${normalizedOrigin}`)
+
+  return {
+    hostname: parsedOrigin.hostname,
+    port: parsedOrigin.port || null,
+  }
+}
+
+/**
  * @param {{
  *   isProduction?: boolean
  *   allowedDevOrigins?: string[]
@@ -63,12 +84,20 @@ export function buildDevHmrOrigins(options = {}) {
   return uniquePolicySources([
     `ws://localhost:${devPort}`,
     `ws://127.0.0.1:${devPort}`,
-    ...allowedDevOrigins.flatMap((origin) => [
-      `ws://${origin}`,
-      `wss://${origin}`,
-      `ws://${origin}:${devPort}`,
-      `wss://${origin}:${devPort}`,
-    ]),
+    ...allowedDevOrigins.flatMap((origin) => {
+      const { hostname, port } = normalizeAllowedDevOrigin(origin)
+
+      if (port) {
+        return [`ws://${hostname}:${port}`, `wss://${hostname}:${port}`]
+      }
+
+      return [
+        `ws://${hostname}`,
+        `wss://${hostname}`,
+        `ws://${hostname}:${devPort}`,
+        `wss://${hostname}:${devPort}`,
+      ]
+    }),
   ])
 }
 

--- a/libs/storefront-security/headers.mjs
+++ b/libs/storefront-security/headers.mjs
@@ -1,0 +1,74 @@
+export const DEFAULT_STRICT_TRANSPORT_SECURITY_VALUE = [
+  "max-age=31536000",
+  "includeSubDomains",
+].join("; ")
+
+export const DEFAULT_PERMISSIONS_POLICY_DIRECTIVES = [
+  "camera=()",
+  "microphone=()",
+  "geolocation=(self)",
+  "payment=()",
+  "usb=()",
+  "serial=()",
+  "browsing-topics=()",
+]
+
+/**
+ * @typedef {{ key: string, value: string | null }} ResponseHeaderOverride
+ */
+
+/**
+ * @param {{
+ *   isProduction?: boolean
+ *   contentSecurityPolicy: string
+ *   permissionsPolicyDirectives?: string[]
+ *   replaceHeaders?: ResponseHeaderOverride[]
+ *   extendHeaders?: Array<{ key: string, value: string }>
+ * }} options
+ * @returns {Array<{ key: string, value: string }>}
+ */
+export function buildStorefrontResponseHeaders(options) {
+  const {
+    isProduction = process.env.NODE_ENV === "production",
+    contentSecurityPolicy,
+    permissionsPolicyDirectives = DEFAULT_PERMISSIONS_POLICY_DIRECTIVES,
+    replaceHeaders = [],
+    extendHeaders = [],
+  } = options
+
+  const headerMap = new Map(
+    [
+      ["X-Frame-Options", "DENY"],
+      ["X-Content-Type-Options", "nosniff"],
+      ["Referrer-Policy", "strict-origin-when-cross-origin"],
+      ["Cross-Origin-Opener-Policy", "same-origin-allow-popups"],
+      ["Origin-Agent-Cluster", "?1"],
+      ["X-Permitted-Cross-Domain-Policies", "none"],
+      ["Permissions-Policy", permissionsPolicyDirectives.join(", ")],
+      ["Content-Security-Policy", contentSecurityPolicy],
+      ...(isProduction
+        ? [
+            [
+              "Strict-Transport-Security",
+              DEFAULT_STRICT_TRANSPORT_SECURITY_VALUE,
+            ],
+          ]
+        : []),
+    ].map(([key, value]) => [key, value])
+  )
+
+  for (const header of replaceHeaders) {
+    if (header.value === null) {
+      headerMap.delete(header.key)
+      continue
+    }
+
+    headerMap.set(header.key, header.value)
+  }
+
+  for (const header of extendHeaders) {
+    headerMap.set(header.key, header.value)
+  }
+
+  return [...headerMap.entries()].map(([key, value]) => ({ key, value }))
+}

--- a/libs/storefront-security/headers.mjs
+++ b/libs/storefront-security/headers.mjs
@@ -57,16 +57,16 @@ export function buildStorefrontResponseHeaders(options) {
     ].map(([key, value]) => [key, value])
   )
 
+  for (const header of extendHeaders) {
+    headerMap.set(header.key, header.value)
+  }
+
   for (const header of replaceHeaders) {
     if (header.value === null) {
       headerMap.delete(header.key)
       continue
     }
 
-    headerMap.set(header.key, header.value)
-  }
-
-  for (const header of extendHeaders) {
     headerMap.set(header.key, header.value)
   }
 

--- a/libs/storefront-security/index.mjs
+++ b/libs/storefront-security/index.mjs
@@ -1,5 +1,1 @@
-export * from "./backend-url.mjs"
-export * from "./csp.mjs"
-export * from "./headers.mjs"
 export * from "./next-security.mjs"
-export * from "./presets.mjs"

--- a/libs/storefront-security/index.mjs
+++ b/libs/storefront-security/index.mjs
@@ -1,0 +1,5 @@
+export * from "./backend-url.mjs"
+export * from "./csp.mjs"
+export * from "./headers.mjs"
+export * from "./next-security.mjs"
+export * from "./presets.mjs"

--- a/libs/storefront-security/next-security.mjs
+++ b/libs/storefront-security/next-security.mjs
@@ -1,0 +1,208 @@
+import {
+  DEFAULT_DEVELOPMENT_BACKEND_URL,
+  DEFAULT_PUBLIC_BACKEND_ENV_NAME,
+  resolvePublicBackendOrigin,
+} from "./backend-url.mjs"
+import {
+  buildStorefrontContentSecurityPolicy,
+  mergeStorefrontCsp,
+  uniquePolicySources,
+} from "./csp.mjs"
+import {
+  buildStorefrontResponseHeaders,
+  DEFAULT_PERMISSIONS_POLICY_DIRECTIVES,
+} from "./headers.mjs"
+import { resolveStorefrontSecurityPreset } from "./presets.mjs"
+
+/**
+ * @typedef {import("./csp.mjs").StorefrontCspDirectives} StorefrontCspDirectives
+ */
+
+/**
+ * @param {{
+ *   csp?: Partial<StorefrontCspDirectives>
+ *   permissionsPolicy?: string[]
+ *   headers?: Array<{ key: string, value: string }>
+ * }} [extend]
+ * @returns {{
+ *   csp: Partial<StorefrontCspDirectives>
+ *   permissionsPolicy?: string[]
+ *   headers: Array<{ key: string, value: string }>
+ * }}
+ */
+function normalizeExtend(extend = {}) {
+  return {
+    csp: extend.csp ?? {},
+    permissionsPolicy: extend.permissionsPolicy,
+    headers: extend.headers ?? [],
+  }
+}
+
+/**
+ * @param {{
+ *   csp?: Partial<StorefrontCspDirectives>
+ *   permissionsPolicy?: string[]
+ *   headers?: Array<{ key: string, value: string | null }>
+ * }} [replace]
+ * @returns {{
+ *   csp: Partial<StorefrontCspDirectives>
+ *   permissionsPolicy?: string[]
+ *   headers: Array<{ key: string, value: string | null }>
+ * }}
+ */
+function normalizeReplace(replace = {}) {
+  return {
+    csp: replace.csp ?? {},
+    permissionsPolicy: replace.permissionsPolicy,
+    headers: replace.headers ?? [],
+  }
+}
+
+/**
+ * Supports the pre-refactor option names so existing consumers can migrate
+ * incrementally to `preset + extend + replace`.
+ *
+ * @param {{
+ *   additionalScriptSrc?: string[]
+ *   additionalStyleSrc?: string[]
+ *   additionalConnectSrc?: string[]
+ *   additionalFrameSrc?: string[]
+ *   additionalImgSrc?: string[]
+ *   additionalFontSrc?: string[]
+ *   permissionsPolicyDirectives?: string[]
+ * }} options
+ */
+function normalizeLegacyOverrides(options) {
+  const {
+    additionalScriptSrc = [],
+    additionalStyleSrc = [],
+    additionalConnectSrc = [],
+    additionalFrameSrc = [],
+    additionalImgSrc = [],
+    additionalFontSrc = [],
+    permissionsPolicyDirectives,
+  } = options
+
+  return {
+    csp: {
+      scriptSrc: additionalScriptSrc,
+      styleSrc: additionalStyleSrc,
+      connectSrc: additionalConnectSrc,
+      frameSrc: additionalFrameSrc,
+      imgSrc: additionalImgSrc,
+      fontSrc: additionalFontSrc,
+    },
+    permissionsPolicy: permissionsPolicyDirectives,
+  }
+}
+
+/**
+ * @param {{
+ *   source?: string
+ *   preset?: "medusaStorefront" | null
+ *   isProduction?: boolean
+ *   allowedDevOrigins?: string[]
+ *   devPort?: number
+ *   publicBackendUrl?: string | undefined
+ *   envVarName?: string
+ *   defaultDevelopmentBackendUrl?: string
+ *   extend?: {
+ *     csp?: Partial<StorefrontCspDirectives>
+ *     permissionsPolicy?: string[]
+ *     headers?: Array<{ key: string, value: string }>
+ *   }
+ *   replace?: {
+ *     csp?: Partial<StorefrontCspDirectives>
+ *     permissionsPolicy?: string[]
+ *     headers?: Array<{ key: string, value: string | null }>
+ *   }
+ *   additionalScriptSrc?: string[]
+ *   additionalStyleSrc?: string[]
+ *   additionalConnectSrc?: string[]
+ *   additionalFrameSrc?: string[]
+ *   additionalImgSrc?: string[]
+ *   additionalFontSrc?: string[]
+ *   permissionsPolicyDirectives?: string[]
+ * }} [options]
+ * @returns {{
+ *   allowedDevOrigins: string[]
+ *   poweredByHeader: false
+ *   headers: () => Array<{ source: string, headers: Array<{ key: string, value: string }> }>
+ * }}
+ */
+export function createStorefrontSecurityConfig(options = {}) {
+  const {
+    source = "/:path*",
+    preset = "medusaStorefront",
+    isProduction = process.env.NODE_ENV === "production",
+    allowedDevOrigins = [],
+    devPort = 3000,
+    publicBackendUrl = process.env[DEFAULT_PUBLIC_BACKEND_ENV_NAME],
+    envVarName = DEFAULT_PUBLIC_BACKEND_ENV_NAME,
+    defaultDevelopmentBackendUrl = DEFAULT_DEVELOPMENT_BACKEND_URL,
+    extend,
+    replace,
+  } = options
+
+  const publicBackendOrigin = resolvePublicBackendOrigin({
+    isProduction,
+    publicBackendUrl,
+    envVarName,
+    defaultDevelopmentBackendUrl,
+  })
+
+  const presetConfig = resolveStorefrontSecurityPreset({
+    preset,
+    isProduction,
+    publicBackendOrigin,
+    allowedDevOrigins,
+    devPort,
+  })
+
+  const legacyExtend = normalizeLegacyOverrides(options)
+  const normalizedExtend = normalizeExtend(extend)
+  const normalizedReplace = normalizeReplace(replace)
+
+  const csp = mergeStorefrontCsp({
+    base: presetConfig.csp,
+    extend: mergeStorefrontCsp({
+      base: legacyExtend.csp,
+      extend: normalizedExtend.csp,
+    }),
+    replace: normalizedReplace.csp,
+  })
+
+  const permissionsPolicyDirectives =
+    normalizedReplace.permissionsPolicy ??
+    uniquePolicySources([
+      ...(presetConfig.permissionsPolicy ?? DEFAULT_PERMISSIONS_POLICY_DIRECTIVES),
+      ...(legacyExtend.permissionsPolicy ?? []),
+      ...(normalizedExtend.permissionsPolicy ?? []),
+    ])
+
+  const contentSecurityPolicy = buildStorefrontContentSecurityPolicy({ csp })
+
+  return {
+    allowedDevOrigins,
+    poweredByHeader: false,
+    headers() {
+      return [
+        {
+          source,
+          headers: buildStorefrontResponseHeaders({
+            isProduction,
+            contentSecurityPolicy,
+            permissionsPolicyDirectives,
+            replaceHeaders: normalizedReplace.headers,
+            extendHeaders: normalizedExtend.headers,
+          }),
+        },
+      ]
+    },
+  }
+}
+
+export * from "./backend-url.mjs"
+export * from "./csp.mjs"
+export * from "./headers.mjs"
+export * from "./presets.mjs"

--- a/libs/storefront-security/next-security.mjs
+++ b/libs/storefront-security/next-security.mjs
@@ -137,7 +137,7 @@ export function createStorefrontSecurityConfig(options = {}) {
     isProduction = process.env.NODE_ENV === "production",
     allowedDevOrigins = [],
     devPort = 3000,
-    publicBackendUrl = process.env[DEFAULT_PUBLIC_BACKEND_ENV_NAME],
+    publicBackendUrl,
     envVarName = DEFAULT_PUBLIC_BACKEND_ENV_NAME,
     defaultDevelopmentBackendUrl = DEFAULT_DEVELOPMENT_BACKEND_URL,
     extend,

--- a/libs/storefront-security/next-security.test.mjs
+++ b/libs/storefront-security/next-security.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import {
+  buildDevHmrOrigins,
+  buildStorefrontContentSecurityPolicy,
+  createStorefrontSecurityConfig,
+  resolvePublicBackendOrigin,
+  resolveStorefrontSecurityPreset,
+} from "./next-security.mjs"
+
+const MISSING_BACKEND_URL_PATTERN = /Missing NEXT_PUBLIC_MEDUSA_BACKEND_URL/
+const INVALID_BACKEND_URL_PATTERN = /Invalid NEXT_PUBLIC_MEDUSA_BACKEND_URL/
+const UNKNOWN_PRESET_PATTERN = /Unknown storefront security preset/
+
+test("resolvePublicBackendOrigin falls back to localhost in development", () => {
+  assert.equal(
+    resolvePublicBackendOrigin({
+      isProduction: false,
+      publicBackendUrl: undefined,
+    }),
+    "http://localhost:9000"
+  )
+})
+
+test("resolvePublicBackendOrigin fails fast in production when missing", () => {
+  assert.throws(
+    () =>
+      resolvePublicBackendOrigin({
+        isProduction: true,
+        publicBackendUrl: undefined,
+      }),
+    MISSING_BACKEND_URL_PATTERN
+  )
+})
+
+test("resolvePublicBackendOrigin fails fast in production when invalid", () => {
+  assert.throws(
+    () =>
+      resolvePublicBackendOrigin({
+        isProduction: true,
+        publicBackendUrl: "not-a-url",
+      }),
+    INVALID_BACKEND_URL_PATTERN
+  )
+})
+
+test("buildDevHmrOrigins includes explicit custom host and :3000 variants", () => {
+  const origins = buildDevHmrOrigins({
+    isProduction: false,
+    allowedDevOrigins: ["n1.medusa.localhost"],
+  })
+
+  assert.deepEqual(origins, [
+    "ws://localhost:3000",
+    "ws://127.0.0.1:3000",
+    "ws://n1.medusa.localhost",
+    "wss://n1.medusa.localhost",
+    "ws://n1.medusa.localhost:3000",
+    "wss://n1.medusa.localhost:3000",
+  ])
+})
+
+test("medusaStorefront preset includes backend origin and dev HMR in CSP", () => {
+  const preset = resolveStorefrontSecurityPreset({
+    preset: "medusaStorefront",
+    isProduction: false,
+    publicBackendOrigin: "https://demo-medusa.example.com",
+    allowedDevOrigins: ["n1.medusa.localhost"],
+  })
+
+  const csp = buildStorefrontContentSecurityPolicy({ csp: preset.csp })
+
+  assert.match(csp, /connect-src 'self' https:\/\/demo-medusa\.example\.com/)
+  assert.match(csp, /ws:\/\/n1\.medusa\.localhost:3000/)
+  assert.match(csp, /img-src 'self' data: blob: https:/)
+})
+
+test("unknown preset fails fast", () => {
+  assert.throws(
+    () =>
+      resolveStorefrontSecurityPreset({
+        preset: /** @type {never} */ ("unknown"),
+        publicBackendOrigin: "https://demo-medusa.example.com",
+      }),
+    UNKNOWN_PRESET_PATTERN
+  )
+})
+
+test("createStorefrontSecurityConfig supports preset + extend + replace", async () => {
+  const securityConfig = createStorefrontSecurityConfig({
+    preset: "medusaStorefront",
+    isProduction: false,
+    publicBackendUrl: "https://demo-medusa.example.com",
+    extend: {
+      csp: {
+        scriptSrc: ["https://www.googletagmanager.com"],
+        frameSrc: ["https://www.ppl.cz"],
+      },
+      headers: [{ key: "Cache-Control", value: "public, max-age=60" }],
+    },
+    replace: {
+      permissionsPolicy: ["camera=()", "microphone=()"],
+    },
+  })
+
+  const headerGroups = await securityConfig.headers()
+  const responseHeaders = headerGroups[0].headers
+  const cspHeader = responseHeaders.find(
+    (header) => header.key === "Content-Security-Policy"
+  )
+  const permissionsHeader = responseHeaders.find(
+    (header) => header.key === "Permissions-Policy"
+  )
+  const cacheControlHeader = responseHeaders.find(
+    (header) => header.key === "Cache-Control"
+  )
+
+  assert.equal(headerGroups[0].source, "/:path*")
+  assert.equal(securityConfig.poweredByHeader, false)
+  assert.match(
+    cspHeader?.value ?? "",
+    /script-src 'self' 'unsafe-inline' 'unsafe-eval' https:\/\/www\.googletagmanager\.com/
+  )
+  assert.match(cspHeader?.value ?? "", /frame-src 'self' https:\/\/www\.ppl\.cz/)
+  assert.equal(permissionsHeader?.value, "camera=(), microphone=()")
+  assert.equal(cacheControlHeader?.value, "public, max-age=60")
+})
+
+test("legacy additional* options still extend the preset", async () => {
+  const securityConfig = createStorefrontSecurityConfig({
+    isProduction: false,
+    publicBackendUrl: "https://demo-medusa.example.com",
+    additionalConnectSrc: ["https://www.google-analytics.com"],
+  })
+
+  const cspHeader = (await securityConfig.headers())[0].headers.find(
+    (header) => header.key === "Content-Security-Policy"
+  )
+
+  assert.match(cspHeader?.value ?? "", /https:\/\/www\.google-analytics\.com/)
+})

--- a/libs/storefront-security/next-security.test.mjs
+++ b/libs/storefront-security/next-security.test.mjs
@@ -6,7 +6,7 @@ import {
   createStorefrontSecurityConfig,
   resolvePublicBackendOrigin,
   resolveStorefrontSecurityPreset,
-} from "./next-security.mjs"
+} from "./index.mjs"
 
 const MISSING_BACKEND_URL_PATTERN = /Missing NEXT_PUBLIC_MEDUSA_BACKEND_URL/
 const INVALID_BACKEND_URL_PATTERN = /Invalid NEXT_PUBLIC_MEDUSA_BACKEND_URL/
@@ -44,6 +44,37 @@ test("resolvePublicBackendOrigin fails fast in production when invalid", () => {
   )
 })
 
+test("resolvePublicBackendOrigin honors envVarName overrides", () => {
+  const originalBackendUrl = process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL
+  const originalCustomBackendUrl = process.env.CUSTOM_MEDUSA_BACKEND_URL
+
+  process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL = "https://default.example.com"
+  process.env.CUSTOM_MEDUSA_BACKEND_URL = "https://custom.example.com"
+
+  try {
+    assert.equal(
+      resolvePublicBackendOrigin({
+        isProduction: false,
+        publicBackendUrl: undefined,
+        envVarName: "CUSTOM_MEDUSA_BACKEND_URL",
+      }),
+      "https://custom.example.com"
+    )
+  } finally {
+    if (originalBackendUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL
+    } else {
+      process.env.NEXT_PUBLIC_MEDUSA_BACKEND_URL = originalBackendUrl
+    }
+
+    if (originalCustomBackendUrl === undefined) {
+      delete process.env.CUSTOM_MEDUSA_BACKEND_URL
+    } else {
+      process.env.CUSTOM_MEDUSA_BACKEND_URL = originalCustomBackendUrl
+    }
+  }
+})
+
 test("buildDevHmrOrigins includes explicit custom host and :3000 variants", () => {
   const origins = buildDevHmrOrigins({
     isProduction: false,
@@ -57,6 +88,24 @@ test("buildDevHmrOrigins includes explicit custom host and :3000 variants", () =
     "wss://n1.medusa.localhost",
     "ws://n1.medusa.localhost:3000",
     "wss://n1.medusa.localhost:3000",
+  ])
+})
+
+test("buildDevHmrOrigins normalizes full origins and explicit ports", () => {
+  const origins = buildDevHmrOrigins({
+    isProduction: false,
+    allowedDevOrigins: ["https://shop.localhost", "shop.localhost:3100"],
+  })
+
+  assert.deepEqual(origins, [
+    "ws://localhost:3000",
+    "ws://127.0.0.1:3000",
+    "ws://shop.localhost",
+    "wss://shop.localhost",
+    "ws://shop.localhost:3000",
+    "wss://shop.localhost:3000",
+    "ws://shop.localhost:3100",
+    "wss://shop.localhost:3100",
   ])
 })
 
@@ -124,6 +173,25 @@ test("createStorefrontSecurityConfig supports preset + extend + replace", async 
   assert.match(cspHeader?.value ?? "", /frame-src 'self' https:\/\/www\.ppl\.cz/)
   assert.equal(permissionsHeader?.value, "camera=(), microphone=()")
   assert.equal(cacheControlHeader?.value, "public, max-age=60")
+})
+
+test("replace headers win over extend headers", async () => {
+  const securityConfig = createStorefrontSecurityConfig({
+    isProduction: false,
+    publicBackendUrl: "https://demo-medusa.example.com",
+    extend: {
+      headers: [{ key: "X-Frame-Options", value: "SAMEORIGIN" }],
+    },
+    replace: {
+      headers: [{ key: "X-Frame-Options", value: "DENY" }],
+    },
+  })
+
+  const frameOptionsHeader = (await securityConfig.headers())[0].headers.find(
+    (header) => header.key === "X-Frame-Options"
+  )
+
+  assert.equal(frameOptionsHeader?.value, "DENY")
 })
 
 test("legacy additional* options still extend the preset", async () => {

--- a/libs/storefront-security/presets.mjs
+++ b/libs/storefront-security/presets.mjs
@@ -1,0 +1,83 @@
+import {
+  createBaseStorefrontCsp,
+  mergeStorefrontCsp,
+  uniquePolicySources,
+} from "./csp.mjs"
+import { DEFAULT_PERMISSIONS_POLICY_DIRECTIVES } from "./headers.mjs"
+
+/**
+ * @typedef {{
+ *   csp: import("./csp.mjs").StorefrontCspDirectives
+ *   permissionsPolicy: string[]
+ * }} StorefrontSecurityPresetConfig
+ */
+
+/**
+ * @param {{
+ *   isProduction?: boolean
+ *   publicBackendOrigin: string
+ *   allowedDevOrigins?: string[]
+ *   devPort?: number
+ * }} context
+ * @returns {StorefrontSecurityPresetConfig}
+ */
+function createMedusaStorefrontPreset(context) {
+  return {
+    csp: createBaseStorefrontCsp(context),
+    permissionsPolicy: [...DEFAULT_PERMISSIONS_POLICY_DIRECTIVES],
+  }
+}
+
+export const storefrontSecurityPresets = {
+  medusaStorefront: createMedusaStorefrontPreset,
+}
+
+/**
+ * @param {{
+ *   preset?: keyof typeof storefrontSecurityPresets | null
+ *   isProduction?: boolean
+ *   publicBackendOrigin: string
+ *   allowedDevOrigins?: string[]
+ *   devPort?: number
+ * }} options
+ * @returns {StorefrontSecurityPresetConfig}
+ */
+export function resolveStorefrontSecurityPreset(options) {
+  const {
+    preset = "medusaStorefront",
+    isProduction = process.env.NODE_ENV === "production",
+    publicBackendOrigin,
+    allowedDevOrigins = [],
+    devPort = 3000,
+  } = options
+
+  if (preset === null) {
+    return {
+      csp: createBaseStorefrontCsp({
+        isProduction,
+        publicBackendOrigin,
+        allowedDevOrigins,
+        devPort,
+      }),
+      permissionsPolicy: [...DEFAULT_PERMISSIONS_POLICY_DIRECTIVES],
+    }
+  }
+
+  const presetFactory = storefrontSecurityPresets[preset]
+
+  if (!presetFactory) {
+    throw new Error(`Unknown storefront security preset: "${preset}".`)
+  }
+
+  const resolvedPreset = presetFactory({
+    isProduction,
+    publicBackendOrigin,
+    allowedDevOrigins,
+    devPort,
+  })
+
+  return {
+    csp: mergeStorefrontCsp({ base: resolvedPreset.csp }),
+    permissionsPolicy: uniquePolicySources(resolvedPreset.permissionsPolicy),
+  }
+}


### PR DESCRIPTION
This PR introduces a shared storefront security config for Next.js apps.

It extracts the common security baseline into a reusable library so new storefronts do not need to copy and maintain per-project header and CSP logic. The shared API is built around
presets plus overrides, so each app can keep its own integration-specific CSP allowances while reusing the same hardened defaults.

This PR only adds the shared foundation in `libs/storefront-security`. Consumer app migrations are intentionally left for follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Added comprehensive documentation for the storefront security library, including configuration guides, preset specifications, and recommended implementation sequence

* **New Features**
  - Introduced preset-based security configuration system for Next.js storefronts
  - Configurable Content Security Policy and HTTP response headers with extend and replace customisation patterns
  - Automatic backend URL origin resolution with intelligent development and production environment handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->