### PR TITLE
Stabilize N1/frontend-demo builds and pagination links

### DIFF
--- a/apps/frontend-demo/scripts/generate-categories.mjs
+++ b/apps/frontend-demo/scripts/generate-categories.mjs
@@ -125,6 +125,89 @@ const ROOT_CATEGORY_ORDER = [
   'Ski',
 ]
 
+function createStaticCategoryModule(dataToSave) {
+  return `// Auto-generated file - DO NOT EDIT
+// Generated at: ${dataToSave.generatedAt}
+// Run 'node scripts/generate-categories.mjs' to regenerate
+// This version filters out categories without products
+
+import type { Category, CategoryTreeNode } from '@/lib/server/categories'
+
+export interface LeafCategory {
+  id: string
+  name: string
+  handle: string
+  parent_category_id: string | null
+}
+
+export interface LeafParent {
+  id: string
+  name: string
+  handle: string
+  children: string[] // Array of direct child category IDs
+  leafs: string[] // Array of ALL nested leaf category IDs
+}
+
+export interface FilteringStats {
+  totalCategoriesBeforeFiltering: number
+  totalCategoriesAfterFiltering: number
+  categoriesWithDirectProducts: number
+  filteredOutCount: number
+}
+
+export interface StaticCategoryData {
+  allCategories: Category[]
+  categoryTree: CategoryTreeNode[]
+  rootCategories: Category[]
+  categoryMap: Record<string, Category>
+  leafCategories: LeafCategory[]
+  leafParents: LeafParent[]
+  generatedAt: string
+  filteringStats: FilteringStats
+}
+
+const data: StaticCategoryData = ${JSON.stringify(dataToSave, null, 2)}
+
+export default data
+export const { allCategories, categoryTree, rootCategories, categoryMap, leafCategories, leafParents, filteringStats } = data
+`
+}
+
+function createFallbackCategoryData(generatedAt) {
+  return {
+    allCategories: [],
+    categoryTree: [],
+    rootCategories: [],
+    categoryMap: {},
+    leafCategories: [],
+    leafParents: [],
+    generatedAt,
+    filteringStats: {
+      totalCategoriesBeforeFiltering: 0,
+      totalCategoriesAfterFiltering: 0,
+      categoriesWithDirectProducts: 0,
+      filteredOutCount: 0,
+    },
+  }
+}
+
+function getStaticCategoryModulePath() {
+  return path.join(__dirname, '../src/lib/static-data/categories.ts')
+}
+
+function writeStaticCategoryModule(dataToSave) {
+  const tsOutputPath = getStaticCategoryModulePath()
+  const tsDir = path.dirname(tsOutputPath)
+
+  if (!fs.existsSync(tsDir)) {
+    fs.mkdirSync(tsDir, { recursive: true })
+  }
+
+  fs.writeFileSync(tsOutputPath, createStaticCategoryModule(dataToSave))
+
+  return tsOutputPath
+}
+
 function buildCategoryTree(categories) {
   const categoryMap = new Map()
   const rootNodes = []
@@ -402,6 +485,7 @@ async function generateCategories() {
       categoryMap
     )
 
+    const generatedAt = new Date().toISOString()
     const dataToSave = {
       allCategories,
       categoryTree,
@@ -409,7 +493,7 @@ async function generateCategories() {
       categoryMap,
       leafCategories,
       leafParents,
-      generatedAt: new Date().toISOString(),
+      generatedAt,
       filteringStats: {
         totalCategoriesBeforeFiltering: allCategoriesRaw.length,
         totalCategoriesAfterFiltering: allCategories.length,
@@ -428,64 +512,8 @@ async function generateCategories() {
     const outputPath = path.join(dataDir, 'categories-test.json')
     fs.writeFileSync(outputPath, JSON.stringify(dataToSave, null, 2))
 
-    // Generate TypeScript module to categories-test.ts
-    const tsOutputPath = path.join(
-      __dirname,
-      '../src/lib/static-data/categories.ts'
-    )
-    const tsDir = path.dirname(tsOutputPath)
-
-    if (!fs.existsSync(tsDir)) {
-      fs.mkdirSync(tsDir, { recursive: true })
-    }
-
-    const tsContent = `// Auto-generated file - DO NOT EDIT
-// Generated at: ${new Date().toISOString()}
-// Run 'node scripts/generate-categories-2.mjs' to regenerate
-// This version filters out categories without products
-
-import type { Category, CategoryTreeNode } from '@/lib/server/categories'
-
-export interface LeafCategory {
-  id: string
-  name: string
-  handle: string
-  parent_category_id: string | null
-}
-
-export interface LeafParent {
-  id: string
-  name: string
-  handle: string
-  children: string[] // Array of direct child category IDs
-  leafs: string[] // Array of ALL nested leaf category IDs
-}
-
-export interface FilteringStats {
-  totalCategoriesBeforeFiltering: number
-  totalCategoriesAfterFiltering: number
-  categoriesWithDirectProducts: number
-  filteredOutCount: number
-}
-
-export interface StaticCategoryData {
-  allCategories: Category[]
-  categoryTree: CategoryTreeNode[]
-  rootCategories: Category[]
-  categoryMap: Record<string, Category>
-  leafCategories: LeafCategory[]
-  leafParents: LeafParent[]
-  generatedAt: string
-  filteringStats: FilteringStats
-}
-
-const data: StaticCategoryData = ${JSON.stringify(dataToSave, null, 2)}
-
-export default data
-export const { allCategories, categoryTree, rootCategories, categoryMap, leafCategories, leafParents, filteringStats } = data
-`
-
-    fs.writeFileSync(tsOutputPath, tsContent)
+    // Generate TypeScript module used by the Next.js build
+    const tsOutputPath = writeStaticCategoryModule(dataToSave)
 
     console.log(
       '✅ Category data V2 with product filtering generated successfully!'
@@ -519,8 +547,25 @@ export const { allCategories, categoryTree, rootCategories, categoryMap, leafCat
       `\n   - File size: ${(fs.statSync(outputPath).size / 1024).toFixed(2)} KB`
     )
   } catch (error) {
-    console.error('❌ Error generating categories:', error)
-    process.exit(1)
+    console.error('❌ Category generation failed:', error)
+
+    const tsOutputPath = getStaticCategoryModulePath()
+    const moduleExists = fs.existsSync(tsOutputPath)
+
+    if (!moduleExists && !process.env.CI) {
+      const fallbackData = createFallbackCategoryData(new Date().toISOString())
+      const writtenPath = writeStaticCategoryModule(fallbackData)
+      console.warn(`📁 Empty fallback TypeScript module saved to: ${writtenPath}`)
+      return
+    }
+
+    if (moduleExists) {
+      console.warn(
+        `ℹ️ Keeping existing module at ${tsOutputPath}; not overwriting it with an empty fallback.`
+      )
+    }
+
+    process.exitCode = 1
   }
 }
 

--- a/apps/frontend-demo/src/app/api/contact/route.ts
+++ b/apps/frontend-demo/src/app/api/contact/route.ts
@@ -2,7 +2,6 @@ import { type NextRequest, NextResponse } from "next/server"
 import { Resend } from "resend"
 import { ContactFormEmail } from "@/components/emails/contact-form-email"
 
-const resend = new Resend(process.env.RESEND_API_KEY)
 const contactEmail = process.env.CONTACT_EMAIL || "your-email@example.com"
 const fromEmail = process.env.RESEND_FROM_EMAIL || "onboarding@resend.dev"
 
@@ -18,6 +17,15 @@ export async function POST(req: NextRequest) {
         { status: 400 }
       )
     }
+
+    if (!process.env.RESEND_API_KEY) {
+      return NextResponse.json(
+        { error: "Email service is not configured" },
+        { status: 500 }
+      )
+    }
+
+    const resend = new Resend(process.env.RESEND_API_KEY)
 
     // Send email
     const { data, error } = await resend.emails.send({

--- a/apps/frontend-demo/src/app/checkout/page.tsx
+++ b/apps/frontend-demo/src/app/checkout/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@techsio/ui-kit/atoms/button"
 import { Icon } from "@techsio/ui-kit/atoms/icon"
 import { Steps } from "@techsio/ui-kit/molecules/steps"
 import Link from "next/link"
-import { useEffect, useState } from "react"
+import { type ReactNode, useEffect, useState } from "react"
 import { LoadingPage } from "@/components/loading-page"
 import { OrderSummary } from "@/components/order-summary"
 import { useCart } from "@/hooks/use-cart"
@@ -16,6 +16,28 @@ import { PaymentSelection } from "../../components/molecules/payment-selection"
 import { ShippingSelection } from "../../components/molecules/shipping-selection"
 import { AddressForm } from "../../components/organisms/address-form"
 import { OrderPreview } from "../../components/organisms/order-preview"
+
+type CheckoutStep = {
+  content: ReactNode
+  title: string
+  value: number
+}
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query)
+    const updateMatches = () => setMatches(mediaQuery.matches)
+
+    updateMatches()
+    mediaQuery.addEventListener("change", updateMatches)
+
+    return () => mediaQuery.removeEventListener("change", updateMatches)
+  }, [query])
+
+  return matches
+}
 
 export default function CheckoutPage() {
   const { cart, isLoading } = useCart()
@@ -40,6 +62,7 @@ export default function CheckoutPage() {
   const [isOrderComplete, setIsOrderComplete] = useState(false)
   const [orderNumber, setOrderNumber] = useState<string>("")
   const [showOrderSummary, setShowOrderSummary] = useState(false)
+  const isDesktopSteps = useMediaQuery("(min-width: 640px)")
 
   // Redirect if cart is empty and no completed order
   useEffect(() => {
@@ -59,12 +82,14 @@ export default function CheckoutPage() {
   }, [cart, isLoading, isOrderComplete])
 
   // Show loading state while cart is loading
-  if (isLoading) return <LoadingPage />
+  if (isLoading) {
+    return <LoadingPage />
+  }
 
   // Get order data (either from cart or saved completed order)
   const orderData = orderHelpers.getOrderData(cart)
 
-  if (!(orderData && orderData.items) || orderData.items.length === 0) {
+  if (!orderData?.items || orderData.items.length === 0) {
     return null
   }
 
@@ -90,12 +115,12 @@ export default function CheckoutPage() {
         setIsOrderComplete(true)
         setCurrentStep(3)
       }
-    } catch (error) {
+    } catch (_error) {
       // Error already handled in hook
     }
   }
 
-  const steps = [
+  const steps: CheckoutStep[] = [
     {
       value: 0,
       title: "Adresa",
@@ -105,7 +130,7 @@ export default function CheckoutPage() {
             try {
               await updateAddresses(data)
               setCurrentStep(1)
-            } catch (err) {
+            } catch (_err) {
               // Error already handled in hook
             }
           }}
@@ -123,7 +148,7 @@ export default function CheckoutPage() {
             setSelectedShipping(method)
             try {
               await addShippingMethod(method)
-            } catch (error) {
+            } catch (_error) {
               // Error already handled in hook
             }
           }}
@@ -181,6 +206,38 @@ export default function CheckoutPage() {
     setCurrentStep(step)
   }
 
+  const renderSteps = (orientation: "horizontal" | "vertical") => (
+    <Steps
+      count={steps.length}
+      linear={false}
+      onStepChange={(details) => handleStepChange(details.step)}
+      orientation={orientation}
+      step={currentStep}
+    >
+      <Steps.List>
+        {steps.map((step) => (
+          <Steps.Item index={step.value} key={step.value}>
+            <Steps.Trigger>
+              <Steps.Indicator />
+              <Steps.ItemText>
+                <Steps.Title>{step.title}</Steps.Title>
+              </Steps.ItemText>
+            </Steps.Trigger>
+            <Steps.Separator />
+          </Steps.Item>
+        ))}
+      </Steps.List>
+
+      <Steps.Panels>
+        {steps.map((step) => (
+          <Steps.Content index={step.value} key={step.value}>
+            {step.content}
+          </Steps.Content>
+        ))}
+      </Steps.Panels>
+    </Steps>
+  )
+
   return (
     <div className="container mx-auto max-w-[80rem] px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
       {/* Mobile/Tablet: Sticky progress bar */}
@@ -235,28 +292,7 @@ export default function CheckoutPage() {
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[1fr_400px] lg:gap-8">
-        <div className="hidden sm:block">
-          <Steps
-            currentStep={currentStep}
-            items={steps}
-            linear={false}
-            onStepChange={handleStepChange}
-            onStepComplete={handleComplete}
-            orientation="horizontal"
-            showControls={false}
-          />
-        </div>
-        <div className="sm:hidden">
-          <Steps
-            currentStep={currentStep}
-            items={steps}
-            linear={false}
-            onStepChange={handleStepChange}
-            onStepComplete={handleComplete}
-            orientation="vertical"
-            showControls={false}
-          />
-        </div>
+        {renderSteps(isDesktopSteps ? "horizontal" : "vertical")}
 
         {/* Desktop: Sticky sidebar */}
         <div className="hidden lg:block lg:pl-8">

--- a/apps/frontend-demo/src/app/products/[handle]/product-detail.tsx
+++ b/apps/frontend-demo/src/app/products/[handle]/product-detail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ErrorText } from "@techsio/ui-kit/atoms/error-text"
+import { StatusText } from "@techsio/ui-kit/atoms/status-text"
 import { Breadcrumb } from "@techsio/ui-kit/molecules/breadcrumb"
 import Link from "next/link"
 import { useEffect, useState } from "react"
@@ -72,9 +72,9 @@ export default function ProductDetail({ handle }: ProductDetailProps) {
       <div className="min-h-screen bg-product-detail-bg">
         <div className="mx-auto max-w-product-detail-max-w px-product-detail-container-x py-product-detail-container-y text-center">
           <h1 className="mb-4 font-semibold text-2xl">Product not found</h1>
-          <ErrorText showIcon>
+          <StatusText showIcon status="error">
             {error || "The product you are looking for does not exist."}
-          </ErrorText>
+          </StatusText>
         </div>
       </div>
     )

--- a/apps/frontend-demo/src/app/products/[handle]/product-detail.tsx
+++ b/apps/frontend-demo/src/app/products/[handle]/product-detail.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import type { BadgeProps } from "@techsio/ui-kit/atoms/badge"
-import { StatusText } from "@techsio/ui-kit/atoms/status-text"
+import type { BadgeProps } from "@ui/atoms/badge"
+import { StatusText } from "@ui/atoms/status-text"
 import { BreadcrumbTemplate } from "@ui/templates/breadcrumb"
 import Link from "next/link"
 import { useEffect, useState } from "react"

--- a/apps/frontend-demo/src/app/products/page.tsx
+++ b/apps/frontend-demo/src/app/products/page.tsx
@@ -11,10 +11,7 @@ import { useInfiniteProducts } from "@/hooks/use-infinite-products"
 import { usePrefetchPages } from "@/hooks/use-prefetch-pages"
 import { useProducts } from "@/hooks/use-products"
 import { useRegions } from "@/hooks/use-region"
-import {
-  type ExtendedSortOption,
-  useUrlFilters,
-} from "@/hooks/use-url-filters"
+import { type ExtendedSortOption, useUrlFilters } from "@/hooks/use-url-filters"
 
 const SORT_OPTIONS: Array<{ value: ExtendedSortOption; label: string }> = [
   { value: "newest", label: "Nejnovější" },
@@ -177,7 +174,7 @@ function ProductsContent() {
             <div>
               <ProductGrid
                 currentPage={currentPage}
-                onPageChange={urlFilters.setPage}
+                getPageUrl={urlFilters.getPageUrl}
                 pageSize={pageSize}
                 products={products}
                 totalCount={totalCount}

--- a/apps/frontend-demo/src/components/auth/login-form.tsx
+++ b/apps/frontend-demo/src/components/auth/login-form.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Button } from "@techsio/ui-kit/atoms/button"
-import { ErrorText } from "@techsio/ui-kit/atoms/error-text"
 import { FormCheckbox } from "@techsio/ui-kit/molecules/form-checkbox"
 import { FormInput } from "@techsio/ui-kit/molecules/form-input"
 import Link from "next/link"
@@ -69,11 +68,7 @@ export function LoginForm() {
             }),
             isFormLoading
           )}
-          helpText={
-            getFieldError("email") && (
-              <ErrorText showIcon>{getFieldError("email")}</ErrorText>
-            )
-          }
+          helpText={getFieldError("email")}
           validateStatus={getFieldError("email") ? "error" : "default"}
         />
 
@@ -88,11 +83,7 @@ export function LoginForm() {
             }),
             isFormLoading
           )}
-          helpText={
-            getFieldError("password") && (
-              <ErrorText>{getFieldError("password")}</ErrorText>
-            )
-          }
+          helpText={getFieldError("password")}
           validateStatus={getFieldError("password") ? "error" : "default"}
         />
 

--- a/apps/frontend-demo/src/components/auth/register-form.tsx
+++ b/apps/frontend-demo/src/components/auth/register-form.tsx
@@ -1,6 +1,5 @@
 "use client"
 import { Button } from "@techsio/ui-kit/atoms/button"
-import { ErrorText } from "@techsio/ui-kit/atoms/error-text"
 import { FormCheckbox } from "@techsio/ui-kit/molecules/form-checkbox"
 import { FormInput } from "@techsio/ui-kit/molecules/form-input"
 import { type FormEvent, useState } from "react"
@@ -125,11 +124,7 @@ export function RegisterForm() {
             }),
             isFormLoading
           )}
-          helpText={
-            getFieldError("email") && (
-              <ErrorText showIcon>{getFieldError("email")}</ErrorText>
-            )
-          }
+          helpText={getFieldError("email")}
           validateStatus={getFieldError("email") ? "error" : "default"}
         />
 
@@ -146,11 +141,7 @@ export function RegisterForm() {
               }),
               isFormLoading
             )}
-            helpText={
-              getFieldError("password") && (
-                <ErrorText showIcon>{getFieldError("password")}</ErrorText>
-              )
-            }
+            helpText={getFieldError("password")}
             validateStatus={getFieldError("password") ? "error" : "default"}
           />
           <PasswordRequirements password={password} />
@@ -168,11 +159,7 @@ export function RegisterForm() {
             }),
             isFormLoading
           )}
-          helpText={
-            getFieldError("confirmPassword") ? (
-              <ErrorText showIcon>{getFieldError("confirmPassword")}</ErrorText>
-            ) : undefined
-          }
+          helpText={getFieldError("confirmPassword")}
           validateStatus={
             getFieldError("confirmPassword") ? "error" : "default"
           }

--- a/apps/frontend-demo/src/components/organisms/address-form.tsx
+++ b/apps/frontend-demo/src/components/organisms/address-form.tsx
@@ -1,8 +1,8 @@
 "use client"
 import { Button } from "@techsio/ui-kit/atoms/button"
-import { ErrorText } from "@techsio/ui-kit/atoms/error-text"
 import { Link } from "@techsio/ui-kit/atoms/link"
 import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
+import { StatusText } from "@techsio/ui-kit/atoms/status-text"
 import { FormCheckbox } from "@techsio/ui-kit/molecules/form-checkbox"
 import { FormInputRaw as FormInput } from "@techsio/ui-kit/molecules/form-input"
 import { SelectTemplate } from "@techsio/ui-kit/templates/select"
@@ -117,7 +117,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingFirstName && (
-                <ErrorText>{errors.shippingFirstName}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingFirstName}
+                </StatusText>
               )
             }
             id="shipping-first-name"
@@ -136,7 +138,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingLastName && (
-                <ErrorText>{errors.shippingLastName}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingLastName}
+                </StatusText>
               )
             }
             id="shipping-last-name"
@@ -170,7 +174,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingEmail && (
-                <ErrorText>{errors.shippingEmail}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingEmail}
+                </StatusText>
               )
             }
             id="shipping-email"
@@ -198,7 +204,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingPhone && (
-                <ErrorText>{errors.shippingPhone}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingPhone}
+                </StatusText>
               )
             }
             id="shipping-phone"
@@ -218,7 +226,9 @@ export function AddressForm({
         <FormInput
           helpText={
             errors.shippingStreet && (
-              <ErrorText>{errors.shippingStreet}</ErrorText>
+              <StatusText showIcon size="sm" status="error">
+                {errors.shippingStreet}
+              </StatusText>
             )
           }
           id="shipping-street"
@@ -235,7 +245,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingCity && (
-                <ErrorText>{errors.shippingCity}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingCity}
+                </StatusText>
               )
             }
             id="shipping-city"
@@ -251,7 +263,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.shippingPostalCode && (
-                <ErrorText>{errors.shippingPostalCode}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.shippingPostalCode}
+                </StatusText>
               )
             }
             id="shipping-postal-code"
@@ -305,7 +319,9 @@ export function AddressForm({
             <FormInput
               helpText={
                 errors.billingFirstName && (
-                  <ErrorText>{errors.billingFirstName}</ErrorText>
+                  <StatusText showIcon size="sm" status="error">
+                    {errors.billingFirstName}
+                  </StatusText>
                 )
               }
               id="billing-first-name"
@@ -324,7 +340,9 @@ export function AddressForm({
             <FormInput
               helpText={
                 errors.billingLastName && (
-                  <ErrorText>{errors.billingLastName}</ErrorText>
+                  <StatusText showIcon size="sm" status="error">
+                    {errors.billingLastName}
+                  </StatusText>
                 )
               }
               id="billing-last-name"
@@ -353,7 +371,9 @@ export function AddressForm({
           <FormInput
             helpText={
               errors.billingStreet && (
-                <ErrorText>{errors.billingStreet}</ErrorText>
+                <StatusText showIcon size="sm" status="error">
+                  {errors.billingStreet}
+                </StatusText>
               )
             }
             id="billing-street"
@@ -370,7 +390,9 @@ export function AddressForm({
             <FormInput
               helpText={
                 errors.billingCity && (
-                  <ErrorText>{errors.billingCity}</ErrorText>
+                  <StatusText showIcon size="sm" status="error">
+                    {errors.billingCity}
+                  </StatusText>
                 )
               }
               id="billing-city"
@@ -386,7 +408,9 @@ export function AddressForm({
             <FormInput
               helpText={
                 errors.billingPostalCode && (
-                  <ErrorText>{errors.billingPostalCode}</ErrorText>
+                  <StatusText showIcon size="sm" status="error">
+                    {errors.billingPostalCode}
+                  </StatusText>
                 )
               }
               id="billing-postal-code"

--- a/apps/frontend-demo/src/components/organisms/gallery.tsx
+++ b/apps/frontend-demo/src/components/organisms/gallery.tsx
@@ -12,7 +12,7 @@ import type { VariantProps } from "tailwind-variants"
 const galleryStyles = tv({
   slots: {
     root: "",
-    mainCarousel: "relative flex h-fit",
+    mainCarousel: "relative flex h-fit w-full",
     container: "flex-shrink-0",
     scrollArea: "scrollbar-thin max-h-[60svh]",
     list: "flex gap-gallery-sm",
@@ -81,6 +81,7 @@ export function Gallery({
     // we'll just update our state to show which is active
     setCurrentPage(index)
   }
+  const carouselWidth = `min(100%, ${carouselSize}px)`
 
   return (
     <div className={root({ className })}>
@@ -121,8 +122,7 @@ export function Gallery({
           page={currentPage}
           size={size}
           slideCount={images.length}
-          height={carouselSize}
-          width={carouselSize}
+          width={carouselWidth}
         >
           <Carousel.Slides slides={images} />
         </Carousel>

--- a/apps/frontend-demo/src/components/organisms/gallery.tsx
+++ b/apps/frontend-demo/src/components/organisms/gallery.tsx
@@ -121,12 +121,10 @@ export function Gallery({
           page={currentPage}
           size={size}
           slideCount={images.length}
+          height={carouselSize}
+          width={carouselSize}
         >
-          <Carousel.Slides
-            height={carouselSize}
-            slides={images}
-            width={carouselSize}
-          />
+          <Carousel.Slides slides={images} />
         </Carousel>
       </div>
     </div>

--- a/apps/frontend-demo/src/components/organisms/product-grid.tsx
+++ b/apps/frontend-demo/src/components/organisms/product-grid.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { Pagination } from "@techsio/ui-kit/molecules/pagination"
+import {
+  Pagination,
+  type PaginationProps as UIPaginationProps,
+} from "@techsio/ui-kit/molecules/pagination"
 import Link from "next/link"
 import { useState } from "react"
 import { AddToCartDialog } from "@/components/molecules/add-to-cart-dialog"
@@ -11,12 +14,12 @@ import type { Product } from "@/types/product"
 import { formatPrice } from "@/utils/price-utils"
 import { extractProductData } from "@/utils/product-utils"
 
-interface ProductGridProps {
+type ProductGridProps = {
   products: Product[]
   totalCount?: number
   currentPage?: number
   pageSize?: number
-  onPageChange?: (page: number) => void
+  getPageUrl?: NonNullable<UIPaginationProps["getPageUrl"]>
 }
 
 export function ProductGrid({
@@ -24,7 +27,7 @@ export function ProductGrid({
   totalCount,
   currentPage = 1,
   pageSize = 12,
-  onPageChange,
+  getPageUrl,
 }: ProductGridProps) {
   const { selectedRegion } = useRegions()
   const prefetchProduct = usePrefetchProduct()
@@ -98,13 +101,14 @@ export function ProductGrid({
         })}
       </div>
 
-      {totalPages > 1 && onPageChange && (
+      {totalPages > 1 && getPageUrl && (
         <div className="mt-product-grid-pagination-margin flex justify-center">
           {/* Mobile pagination with no siblings */}
           <Pagination
             className="sm:hidden"
             count={totalCount || products.length}
-            onPageChange={onPageChange}
+            getPageUrl={getPageUrl}
+            linkAs={Link}
             page={currentPage}
             pageSize={pageSize}
             siblingCount={0}
@@ -113,7 +117,8 @@ export function ProductGrid({
           <Pagination
             className="hidden sm:flex"
             count={totalCount || products.length}
-            onPageChange={onPageChange}
+            getPageUrl={getPageUrl}
+            linkAs={Link}
             page={currentPage}
             pageSize={pageSize}
             siblingCount={1}

--- a/apps/frontend-demo/src/components/organisms/profile-form.tsx
+++ b/apps/frontend-demo/src/components/organisms/profile-form.tsx
@@ -1,7 +1,7 @@
 "use client"
 import type { HttpTypes } from "@medusajs/types"
 import { Button } from "@techsio/ui-kit/atoms/button"
-import { ExtraText } from "@techsio/ui-kit/atoms/extra-text"
+import { StatusText } from "@techsio/ui-kit/atoms/status-text"
 import { FormInputRaw as FormInput } from "@techsio/ui-kit/molecules/form-input"
 import { SelectTemplate } from "@techsio/ui-kit/templates/select"
 import { useState } from "react"
@@ -108,7 +108,7 @@ export function ProfileForm({ initialAddress, user }: ProfileFormProps) {
           </div>
           <FormInput
             disabled
-            helpText={<ExtraText size="sm">E-mail nelze změnit</ExtraText>}
+            helpText={<StatusText size="sm">E-mail nelze změnit</StatusText>}
             id="email"
             label="E-mail"
             size="sm"

--- a/apps/frontend-demo/src/hooks/use-url-filters.ts
+++ b/apps/frontend-demo/src/hooks/use-url-filters.ts
@@ -15,7 +15,9 @@ export type PageRange = {
 
 function parsePageRange(pageParam: string): PageRange {
   const parsedSinglePage = Number.parseInt(pageParam, 10)
-  const singlePage = Number.isNaN(parsedSinglePage) ? 1 : parsedSinglePage
+  const singlePage = Number.isNaN(parsedSinglePage)
+    ? 1
+    : Math.max(parsedSinglePage, 1)
 
   if (!pageParam.includes("-")) {
     return { start: singlePage, end: singlePage, isRange: false }
@@ -23,7 +25,12 @@ function parsePageRange(pageParam: string): PageRange {
 
   const [start, end] = pageParam.split("-").map((p) => Number.parseInt(p, 10))
 
-  if (!(Number.isNaN(start) || Number.isNaN(end)) && start <= end) {
+  if (
+    !(Number.isNaN(start) || Number.isNaN(end)) &&
+    start >= 1 &&
+    end >= 1 &&
+    start <= end
+  ) {
     return { start, end, isRange: true }
   }
 

--- a/apps/frontend-demo/src/hooks/use-url-filters.ts
+++ b/apps/frontend-demo/src/hooks/use-url-filters.ts
@@ -1,167 +1,143 @@
 "use client"
 
-// Default filter state
-const DEFAULT_FILTER_STATE = {
-  categories: new Set<string>(),
-  sizes: new Set<string>(),
-}
-
+import { createPaginationGetPageUrl } from "@techsio/ui-kit/molecules/pagination"
 import { useRouter, useSearchParams } from "next/navigation"
-import { useCallback, useMemo } from "react"
 import type { FilterState } from "@/components/organisms/product-filters"
 import type { SortOption } from "@/utils/product-filters"
 
 export type ExtendedSortOption = SortOption | "relevance"
 
-export interface PageRange {
+export type PageRange = {
   start: number
   end: number
   isRange: boolean
 }
 
+function parsePageRange(pageParam: string): PageRange {
+  const parsedSinglePage = Number.parseInt(pageParam, 10)
+  const singlePage = Number.isNaN(parsedSinglePage) ? 1 : parsedSinglePage
+
+  if (!pageParam.includes("-")) {
+    return { start: singlePage, end: singlePage, isRange: false }
+  }
+
+  const [start, end] = pageParam.split("-").map((p) => Number.parseInt(p, 10))
+
+  if (!(Number.isNaN(start) || Number.isNaN(end)) && start <= end) {
+    return { start, end, isRange: true }
+  }
+
+  return { start: singlePage, end: singlePage, isRange: false }
+}
+
+function parseFilterSet(value: string | null) {
+  return new Set(value ? value.split(",").filter(Boolean) : [])
+}
+
 export function useUrlFilters() {
   const searchParams = useSearchParams()
   const router = useRouter()
+  const currentSearchParams = searchParams.toString()
+
+  const createParams = () => new URLSearchParams(currentSearchParams)
 
   // Parse page from URL (supports both single page and range syntax)
-  const pageRange: PageRange = useMemo(() => {
-    const pageParam = searchParams.get("page") || "1"
-
-    if (pageParam.includes("-")) {
-      const [start, end] = pageParam
-        .split("-")
-        .map((p) => Number.parseInt(p, 10))
-      if (!(Number.isNaN(start) || Number.isNaN(end)) && start <= end) {
-        return { start, end, isRange: true }
-      }
-    }
-
-    const singlePage = Number.parseInt(pageParam, 10)
-    return {
-      start: Number.isNaN(singlePage) ? 1 : singlePage,
-      end: Number.isNaN(singlePage) ? 1 : singlePage,
-      isRange: false,
-    }
-  }, [searchParams])
+  const pageParam = searchParams.get("page") || "1"
+  const pageRange = parsePageRange(pageParam)
 
   // Legacy single page for backward compatibility
   const page = pageRange.start
 
-  // Parse search query from URL
   const searchQuery = searchParams.get("q") || ""
 
-  // Parse filters from URL
-  const filters: FilterState = useMemo(() => {
-    const categories = searchParams.get("categories")
-    const sizes = searchParams.get("sizes")
+  const categories = searchParams.get("categories")
+  const sizes = searchParams.get("sizes")
+  const filters: FilterState = {
+    categories: parseFilterSet(categories),
+    sizes: parseFilterSet(sizes),
+  }
 
-    return {
-      categories: new Set(
-        categories ? categories.split(",").filter(Boolean) : []
-      ),
-      sizes: new Set(sizes ? sizes.split(",").filter(Boolean) : []),
+  const setFilters = (newFilters: FilterState) => {
+    const params = createParams()
+
+    const categoriesArray = Array.from(newFilters.categories)
+    if (categoriesArray.length > 0) {
+      params.set("categories", categoriesArray.join(","))
+    } else {
+      params.delete("categories")
     }
-  }, [searchParams])
 
-  // Update filters in URL
-  const setFilters = useCallback(
-    (newFilters: FilterState) => {
-      const params = new URLSearchParams(searchParams.toString())
+    const sizesArray = Array.from(newFilters.sizes)
+    if (sizesArray.length > 0) {
+      params.set("sizes", sizesArray.join(","))
+    } else {
+      params.delete("sizes")
+    }
 
-      // Update categories
-      const categoriesArray = Array.from(newFilters.categories)
-      if (categoriesArray.length > 0) {
-        params.set("categories", categoriesArray.join(","))
-      } else {
-        params.delete("categories")
-      }
+    // Reset to page 1 when filters change
+    params.delete("page")
 
-      // Update sizes
-      const sizesArray = Array.from(newFilters.sizes)
-      if (sizesArray.length > 0) {
-        params.set("sizes", sizesArray.join(","))
-      } else {
-        params.delete("sizes")
-      }
+    router.push(`?${params.toString()}`, { scroll: false })
+  }
 
-      // Reset to page 1 when filters change
-      params.delete("page")
-
-      router.push(`?${params.toString()}`, { scroll: false })
-    },
-    [searchParams, router]
-  )
-
-  // Sort state
   const sortBy = (searchParams.get("sort") || "newest") as ExtendedSortOption
 
-  const setSortBy = useCallback(
-    (sort: ExtendedSortOption) => {
-      const params = new URLSearchParams(searchParams.toString())
-      params.set("sort", sort)
-      // Reset to page 1 when sort changes
+  const setSortBy = (sort: ExtendedSortOption) => {
+    const params = createParams()
+    params.set("sort", sort)
+    // Reset to page 1 when sort changes
+    params.delete("page")
+    router.push(`?${params.toString()}`, { scroll: false })
+  }
+
+  const setPage = (newPage: number) => {
+    const params = createParams()
+    if (newPage > 1) {
+      params.set("page", newPage.toString())
+    } else {
       params.delete("page")
-      router.push(`?${params.toString()}`, { scroll: false })
-    },
-    [searchParams, router]
-  )
+    }
+    router.push(`?${params.toString()}`)
+  }
 
-  // Page state - supports both single page and range
-  const setPage = useCallback(
-    (newPage: number) => {
-      const params = new URLSearchParams(searchParams.toString())
-      if (newPage > 1) {
-        params.set("page", newPage.toString())
-      } else {
-        params.delete("page")
-      }
-      router.push(`?${params.toString()}`)
-    },
-    [searchParams, router]
-  )
+  const getPageUrl = createPaginationGetPageUrl({
+    pathname: "/products",
+    searchParams: currentSearchParams,
+  })
 
-  // Set infinite page range (e.g., 1-3 for pages 1,2,3)
-  const setPageRange = useCallback(
-    (startPage: number, endPage: number) => {
-      const params = new URLSearchParams(searchParams.toString())
-      if (startPage === 1 && endPage === 1) {
-        params.delete("page")
-      } else if (startPage === endPage) {
-        params.set("page", startPage.toString())
-      } else {
-        params.set("page", `${startPage}-${endPage}`)
-      }
-      router.push(`?${params.toString()}`, { scroll: false })
-    },
-    [searchParams, router]
-  )
+  const setPageRange = (startPage: number, endPage: number) => {
+    const params = createParams()
+    if (startPage === 1 && endPage === 1) {
+      params.delete("page")
+    } else if (startPage === endPage) {
+      params.set("page", startPage.toString())
+    } else {
+      params.set("page", `${startPage}-${endPage}`)
+    }
+    router.push(`?${params.toString()}`, { scroll: false })
+  }
 
-  // Extend current page range by one page (for "load more" functionality)
-  const extendPageRange = useCallback(() => {
+  const extendPageRange = () => {
     const newEndPage = pageRange.end + 1
-    const params = new URLSearchParams(searchParams.toString())
+    const params = createParams()
     params.set("page", `${pageRange.start}-${newEndPage}`)
 
     // Use replace instead of push to avoid adding to history
     // scroll: false prevents resetting scroll position
     router.replace(`?${params.toString()}`, { scroll: false })
-  }, [pageRange.start, pageRange.end, searchParams, router])
+  }
 
-  // Update search query in URL
-  const setSearchQuery = useCallback(
-    (query: string) => {
-      const params = new URLSearchParams(searchParams.toString())
-      if (query) {
-        params.set("q", query)
-      } else {
-        params.delete("q")
-      }
-      // Reset to first page when searching
-      params.set("page", "1")
-      router.push(`?${params.toString()}`, { scroll: false })
-    },
-    [searchParams, router]
-  )
+  const setSearchQuery = (query: string) => {
+    const params = createParams()
+    if (query) {
+      params.set("q", query)
+    } else {
+      params.delete("q")
+    }
+    // Reset to first page when searching
+    params.set("page", "1")
+    router.push(`?${params.toString()}`, { scroll: false })
+  }
 
   return {
     filters,
@@ -170,6 +146,7 @@ export function useUrlFilters() {
     setSortBy,
     page,
     setPage,
+    getPageUrl,
     pageRange,
     setPageRange,
     extendPageRange,

--- a/apps/n1/src/app/(dynamic)/kategorie/[handle]/page.tsx
+++ b/apps/n1/src/app/(dynamic)/kategorie/[handle]/page.tsx
@@ -2,14 +2,10 @@
 import type { IconType } from "@techsio/ui-kit/atoms/icon"
 import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
 import { Breadcrumb } from "@techsio/ui-kit/molecules/breadcrumb"
+import { createPaginationGetPageUrl } from "@techsio/ui-kit/molecules/pagination"
 import NextLink from "next/link"
-import {
-  notFound,
-  useParams,
-  useRouter,
-  useSearchParams,
-} from "next/navigation"
-import { useCallback, useEffect, useRef } from "react"
+import { notFound, useParams, useSearchParams } from "next/navigation"
+import { useEffect, useRef } from "react"
 import { Banner } from "@/components/atoms/banner"
 import { Heading } from "@/components/heading"
 import { ProductGrid } from "@/components/molecules/product-grid"
@@ -32,9 +28,22 @@ import {
 import { useAnalytics } from "@/providers/analytics-provider"
 import { transformProduct } from "@/utils/transform/transform-product"
 
+type Category = (typeof allCategories)[number]
+
+function getCategoryPath(category: Category) {
+  const path: string[] = []
+  let current: Category | undefined = category
+
+  while (current) {
+    path.unshift(current.name)
+    current = allCategories.find((c) => c.id === current?.parent_category_id)
+  }
+
+  return path.join(" > ")
+}
+
 export default function CategoryPage() {
   const params = useParams()
-  const router = useRouter()
   const searchParams = useSearchParams()
   const handle = params.handle as string
   const { regionId, countryCode } = useSuspenseRegion()
@@ -51,22 +60,6 @@ export default function CategoryPage() {
     allCategories.find((cat) => cat.id === currentCategory?.root_category_id) ??
     currentCategory
 
-  const buildCategoryPath = useCallback((): string | null => {
-    if (!currentCategory) {
-      return null
-    }
-
-    const path: string[] = []
-    let current: typeof currentCategory | undefined = currentCategory
-
-    while (current) {
-      path.unshift(current.name)
-      current = allCategories.find((c) => c.id === current?.parent_category_id)
-    }
-
-    return path.join(" > ")
-  }, [currentCategory])
-
   useEffect(() => {
     if (!currentCategory) {
       return
@@ -75,12 +68,9 @@ export default function CategoryPage() {
       return
     }
 
-    const categoryPath = buildCategoryPath()
-    if (categoryPath) {
-      trackedCategoryId.current = currentCategory.id
-      analytics.trackViewCategory({ category: categoryPath })
-    }
-  }, [currentCategory, analytics, buildCategoryPath])
+    trackedCategoryId.current = currentCategory.id
+    analytics.trackViewCategory({ category: getCategoryPath(currentCategory) })
+  }, [currentCategory, analytics])
 
   // Get current page from URL or default to 1
   const currentPage = Number(searchParams.get("page")) || 1
@@ -128,13 +118,10 @@ export default function CategoryPage() {
 
   const products = rawProducts.map(transformProduct)
 
-  const handlePageChange = (page: number) => {
-    const newSearchParams = new URLSearchParams(searchParams.toString())
-    newSearchParams.set("page", page.toString())
-    router.push(`/kategorie/${handle}?${newSearchParams.toString()}`, {
-      scroll: true,
-    })
-  }
+  const getPageUrl = createPaginationGetPageUrl({
+    pathname: `/kategorie/${handle}`,
+    searchParams: searchParams.toString(),
+  })
 
   if (!VALID_CATEGORY_ROUTES.includes(handle)) {
     notFound()
@@ -185,7 +172,7 @@ export default function CategoryPage() {
         <section>
           <ProductGrid
             currentPage={responsePage}
-            onPageChange={handlePageChange}
+            getPageUrl={getPageUrl}
             pageSize={PRODUCT_LIMIT}
             products={products}
             skeletonCount={24}

--- a/apps/n1/src/app/page.tsx
+++ b/apps/n1/src/app/page.tsx
@@ -46,7 +46,14 @@ export default function Home() {
           </span>
         </h2>
         <Suspense
-          fallback={<ProductGrid isLoading products={[]} skeletonCount={8} />}
+          fallback={
+            <ProductGrid
+              getPageUrl={null}
+              isLoading
+              products={[]}
+              skeletonCount={8}
+            />
+          }
         >
           <HomeProductGrid />
         </Suspense>
@@ -61,7 +68,7 @@ function HomeProductGrid() {
     : undefined
 
   if (!featuredCategoryIds) {
-    return <ProductGrid products={[]} skeletonCount={8} />
+    return <ProductGrid getPageUrl={null} products={[]} skeletonCount={8} />
   }
 
   return <FeaturedHomeProductGrid featuredCategoryIds={featuredCategoryIds} />
@@ -81,5 +88,5 @@ function FeaturedHomeProductGrid({
 
   const products = rawProducts.map(transformProduct)
 
-  return <ProductGrid products={products} skeletonCount={8} />
+  return <ProductGrid getPageUrl={null} products={products} skeletonCount={8} />
 }

--- a/apps/n1/src/app/ucet/profil/_components/order-list.tsx
+++ b/apps/n1/src/app/ucet/profil/_components/order-list.tsx
@@ -1,6 +1,11 @@
 "use client"
-import { Pagination } from "@techsio/ui-kit/molecules/pagination"
-import { Suspense, useState } from "react"
+import {
+  createPaginationGetPageUrl,
+  Pagination,
+} from "@techsio/ui-kit/molecules/pagination"
+import Link from "next/link"
+import { useSearchParams } from "next/navigation"
+import { Suspense } from "react"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useSuspenseOrders } from "@/hooks/use-orders"
 import { DesktopOrderCard } from "./orders/desktop-order-card"
@@ -24,10 +29,13 @@ export function OrderList() {
 }
 
 function OrderListContent() {
-  const [page, setPage] = useState(1)
+  const searchParams = useSearchParams()
   const { data: ordersData } = useSuspenseOrders()
 
   const orders = ordersData?.orders || []
+  const totalPages = Math.max(1, Math.ceil(orders.length / PAGE_SIZE))
+  const requestedPage = Number(searchParams.get("ordersPage")) || 1
+  const page = Math.min(Math.max(requestedPage, 1), totalPages)
 
   // Calculate summary stats (from all orders, not just current page)
   const totalAmount = orders.reduce(
@@ -45,6 +53,14 @@ function OrderListContent() {
   // Pagination
   const startIndex = (page - 1) * PAGE_SIZE
   const paginatedOrders = orders.slice(startIndex, startIndex + PAGE_SIZE)
+  const getPageUrl = createPaginationGetPageUrl({
+    pathname: "/ucet/profil",
+    searchParams: searchParams.toString(),
+    pageParam: "ordersPage",
+    searchParamOverrides: {
+      tab: "orders",
+    },
+  })
 
   return (
     <div className="space-y-400">
@@ -86,7 +102,8 @@ function OrderListContent() {
           {orders.length > PAGE_SIZE && (
             <Pagination
               count={orders.length}
-              onPageChange={setPage}
+              getPageUrl={getPageUrl}
+              linkAs={Link}
               page={page}
               pageSize={PAGE_SIZE}
               size="sm"

--- a/apps/n1/src/app/ucet/profil/_components/order-list.tsx
+++ b/apps/n1/src/app/ucet/profil/_components/order-list.tsx
@@ -18,6 +18,15 @@ import { OrdersSummary } from "./orders/orders-summary"
 const MIN_ORDERS_COUNT = 5
 const PAGE_SIZE = 5
 
+function parsePageParam(value: string | null) {
+  if (!value) {
+    return 1
+  }
+
+  const parsedPage = Number(value)
+  return Number.isFinite(parsedPage) ? Math.trunc(parsedPage) : 1
+}
+
 export function OrderList() {
   return (
     <ErrorBoundary fallback={<OrdersError />}>
@@ -34,7 +43,7 @@ function OrderListContent() {
 
   const orders = ordersData?.orders || []
   const totalPages = Math.max(1, Math.ceil(orders.length / PAGE_SIZE))
-  const requestedPage = Number(searchParams.get("ordersPage")) || 1
+  const requestedPage = parsePageParam(searchParams.get("ordersPage"))
   const page = Math.min(Math.max(requestedPage, 1), totalPages)
 
   // Calculate summary stats (from all orders, not just current page)

--- a/apps/n1/src/components/molecules/product-grid.tsx
+++ b/apps/n1/src/components/molecules/product-grid.tsx
@@ -17,7 +17,7 @@ type ProductGridProps = {
   totalCount?: number
   currentPage?: number
   pageSize?: number
-  getPageUrl?: NonNullable<UIPaginationProps["getPageUrl"]>
+  getPageUrl?: NonNullable<UIPaginationProps["getPageUrl"]> | null
   isLoading?: boolean
   skeletonCount?: number
 }

--- a/apps/n1/src/components/molecules/product-grid.tsx
+++ b/apps/n1/src/components/molecules/product-grid.tsx
@@ -1,5 +1,8 @@
 import { Badge } from "@techsio/ui-kit/atoms/badge"
-import { Pagination } from "@techsio/ui-kit/molecules/pagination"
+import {
+  Pagination,
+  type PaginationProps as UIPaginationProps,
+} from "@techsio/ui-kit/molecules/pagination"
 import { ProductCard } from "@techsio/ui-kit/molecules/product-card"
 import Image from "next/image"
 import Link from "next/link"
@@ -14,7 +17,7 @@ type ProductGridProps = {
   totalCount?: number
   currentPage?: number
   pageSize?: number
-  onPageChange?: (page: number) => void
+  getPageUrl?: NonNullable<UIPaginationProps["getPageUrl"]>
   isLoading?: boolean
   skeletonCount?: number
 }
@@ -24,7 +27,7 @@ export const ProductGrid = ({
   totalCount,
   currentPage = 1,
   pageSize = 24,
-  onPageChange,
+  getPageUrl,
   isLoading = false,
   skeletonCount = 12,
 }: ProductGridProps) => {
@@ -137,12 +140,13 @@ export const ProductGrid = ({
         ))}
       </div>
 
-      {totalPages > 1 && onPageChange && (
+      {totalPages > 1 && getPageUrl && (
         <div className="mt-700 flex justify-end">
           <Pagination
             className="sm:hidden"
             count={totalCount || products.length}
-            onPageChange={onPageChange}
+            getPageUrl={getPageUrl}
+            linkAs={Link}
             page={currentPage}
             pageSize={pageSize}
             siblingCount={0}
@@ -150,7 +154,8 @@ export const ProductGrid = ({
           <Pagination
             className="hidden sm:flex"
             count={totalCount || products.length}
-            onPageChange={onPageChange}
+            getPageUrl={getPageUrl}
+            linkAs={Link}
             page={currentPage}
             pageSize={pageSize}
             siblingCount={1}

--- a/apps/new-engine-ctl/project.json
+++ b/apps/new-engine-ctl/project.json
@@ -7,7 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "dependsOn": ["typecheck"],
+      "dependsOn": ["typecheck", "^build"],
       "outputs": ["{projectRoot}/dist"],
       "options": {
         "cwd": "apps/new-engine-ctl",

--- a/apps/zane-operator/project.json
+++ b/apps/zane-operator/project.json
@@ -7,7 +7,7 @@
   "targets": {
     "build": {
       "executor": "nx:run-commands",
-      "dependsOn": ["typecheck"],
+      "dependsOn": ["typecheck", "^build"],
       "outputs": ["{projectRoot}/dist"],
       "options": {
         "cwd": "apps/zane-operator",

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -129,7 +129,7 @@ type PaginationLinkProps<T extends ElementType> = Omit<
 
 export type PaginationProps<T extends ElementType = "a"> =
   PaginationBaseProps & {
-    getPageUrl?: PaginationGetPageUrl
+    getPageUrl: PaginationGetPageUrl
     linkAs?: T
     linkProps?: PaginationLinkProps<T>
   }
@@ -227,7 +227,6 @@ export function Pagination<T extends ElementType = "a">({
   ...props
 }: PaginationProps<T>) {
   const uniqueId = useId()
-  const isLinkMode = typeof getPageUrl === "function"
 
   const service = useMachine(paginationMachine, {
     id: uniqueId,
@@ -238,8 +237,8 @@ export function Pagination<T extends ElementType = "a">({
     page,
     dir,
     defaultPage,
-    type: isLinkMode ? "link" : "button",
-    ...(isLinkMode ? { getPageUrl } : {}),
+    type: "link",
+    getPageUrl,
     onPageChange: (details) => {
       onChange?.(details.page)
       onPageChange?.(details.page)
@@ -272,15 +271,13 @@ export function Pagination<T extends ElementType = "a">({
       ...overrides,
     })
 
-    if (isLinkMode && !hasHref(triggerProps)) {
-      return mergeProps(baseTriggerProps, {
-        disabled: true,
-      }) as LinkButtonProps<T>
-    }
-
     return mergeProps(sharedLinkProps, baseTriggerProps, {
       ...(linkAs ? { as: linkAs } : {}),
-      ...(isLinkMode || linkAs ? {} : { as: "button", type: "button" }),
+      ...(hasHref(triggerProps)
+        ? {}
+        : {
+            disabled: true,
+          }),
     }) as LinkButtonProps<T>
   }
 

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -187,10 +187,10 @@ export function createPaginationGetPageUrl({
       }
     }
 
-    if (page > defaultPage) {
-      nextSearchParams.set(pageParam, page.toString())
-    } else {
+    if (page === defaultPage) {
       nextSearchParams.delete(pageParam)
+    } else {
+      nextSearchParams.set(pageParam, page.toString())
     }
 
     const query = nextSearchParams.toString()
@@ -264,6 +264,7 @@ export function Pagination<T extends ElementType = "a">({
     triggerProps: PaginationTriggerProps,
     overrides: Record<string, unknown> = {}
   ) => {
+    const isNavigable = hasHref(triggerProps)
     const baseTriggerProps = mergeProps(triggerProps, {
       className: link(),
       size: "current" as const,
@@ -271,14 +272,18 @@ export function Pagination<T extends ElementType = "a">({
       ...overrides,
     })
 
-    return mergeProps(sharedLinkProps, baseTriggerProps, {
-      ...(linkAs ? { as: linkAs } : {}),
-      ...(hasHref(triggerProps)
-        ? {}
-        : {
-            disabled: true,
-          }),
-    }) as LinkButtonProps<T>
+    return mergeProps(
+      isNavigable ? sharedLinkProps : undefined,
+      baseTriggerProps,
+      {
+        ...(isNavigable && linkAs ? { as: linkAs } : {}),
+        ...(isNavigable
+          ? {}
+          : {
+              disabled: true,
+            }),
+      }
+    ) as LinkButtonProps<T>
   }
 
   const prevTriggerProps = api.getPrevTriggerProps() as PaginationTriggerProps

--- a/libs/ui/src/molecules/pagination.tsx
+++ b/libs/ui/src/molecules/pagination.tsx
@@ -1,12 +1,19 @@
-import * as pagination from "@zag-js/pagination"
-import { mergeProps, normalizeProps, useMachine } from "@zag-js/react"
-import { type ElementType, type HTMLAttributes, type ReactNode, useId } from "react"
-import { Icon } from "../atoms/icon"
 import {
-  LinkButton,
-  type LinkButtonProps,
-} from "../atoms/link-button"
+  connect as connectPagination,
+  type IntlTranslations as PaginationIntlTranslations,
+  type PageUrlDetails as PaginationPageUrlDetails,
+  machine as paginationMachine,
+} from "@zag-js/pagination"
+import { mergeProps, normalizeProps, useMachine } from "@zag-js/react"
+import {
+  type ElementType,
+  type HTMLAttributes,
+  type ReactNode,
+  useId,
+} from "react"
 import type { VariantProps } from "tailwind-variants"
+import { Icon } from "../atoms/icon"
+import { LinkButton, type LinkButtonProps } from "../atoms/link-button"
 import { tv } from "../utils"
 
 export const paginationVariants = tv({
@@ -98,11 +105,8 @@ export type PaginationBaseProps = HTMLAttributes<HTMLElement> &
     showPrevNext?: boolean
     dir?: "ltr" | "rtl"
     compact?: boolean
-    compactLabel?: (details: {
-      page: number
-      totalPages: number
-    }) => ReactNode
-    translations?: pagination.IntlTranslations
+    compactLabel?: (details: { page: number; totalPages: number }) => ReactNode
+    translations?: PaginationIntlTranslations
   }
 
 type PaginationLinkProps<T extends ElementType> = Omit<
@@ -120,12 +124,74 @@ type PaginationLinkProps<T extends ElementType> = Omit<
 
 export type PaginationProps<T extends ElementType = "a"> =
   PaginationBaseProps & {
-    getPageUrl: (details: pagination.PageUrlDetails) => string
+    getPageUrl: PaginationGetPageUrl
     linkAs?: T
     linkProps?: PaginationLinkProps<T>
   }
 
 type PaginationTriggerProps = Record<string, unknown>
+type PaginationSearchParamValue = string | number | boolean | null | undefined
+type PaginationSearchParamsRecord = Record<string, PaginationSearchParamValue>
+
+export type PaginationGetPageUrl = (details: PaginationPageUrlDetails) => string
+
+export type PaginationSearchParamsInput =
+  | string
+  | URLSearchParams
+  | { toString: () => string }
+
+export type CreatePaginationGetPageUrlOptions = {
+  pathname: string
+  searchParams?: PaginationSearchParamsInput
+  pageParam?: string
+  defaultPage?: number
+  searchParamOverrides?: PaginationSearchParamsRecord
+}
+
+function toURLSearchParams(searchParams?: PaginationSearchParamsInput) {
+  if (!searchParams) {
+    return new URLSearchParams()
+  }
+
+  if (typeof searchParams === "string") {
+    return new URLSearchParams(searchParams)
+  }
+
+  return new URLSearchParams(searchParams.toString())
+}
+
+export function createPaginationGetPageUrl({
+  pathname,
+  searchParams,
+  pageParam = "page",
+  defaultPage = 1,
+  searchParamOverrides,
+}: CreatePaginationGetPageUrlOptions): PaginationGetPageUrl {
+  const baseSearchParams = toURLSearchParams(searchParams)
+
+  return ({ page }) => {
+    const nextSearchParams = new URLSearchParams(baseSearchParams)
+
+    if (searchParamOverrides) {
+      for (const [key, value] of Object.entries(searchParamOverrides)) {
+        if (value == null) {
+          nextSearchParams.delete(key)
+        } else {
+          nextSearchParams.set(key, String(value))
+        }
+      }
+    }
+
+    if (page > defaultPage) {
+      nextSearchParams.set(pageParam, page.toString())
+    } else {
+      nextSearchParams.delete(pageParam)
+    }
+
+    const query = nextSearchParams.toString()
+    return query ? `${pathname}?${query}` : pathname
+  }
+}
 
 function hasHref(
   triggerProps: PaginationTriggerProps
@@ -155,7 +221,7 @@ export function Pagination<T extends ElementType = "a">({
 }: PaginationProps<T>) {
   const uniqueId = useId()
 
-  const service = useMachine(pagination.machine, {
+  const service = useMachine(paginationMachine, {
     id: uniqueId,
     count,
     pageSize,
@@ -169,7 +235,7 @@ export function Pagination<T extends ElementType = "a">({
     translations,
   })
 
-  const api = pagination.connect(service, normalizeProps)
+  const api = connectPagination(service, normalizeProps)
   const { base, list, link, item, ellipsis, compactText } = paginationVariants({
     variant,
     size,
@@ -230,23 +296,36 @@ export function Pagination<T extends ElementType = "a">({
             </span>
           </li>
         ) : (
-          api.pages.map((page, index) => {
-            if (page.type === "page") {
+          api.pages.map((paginationPage, index) => {
+            if (paginationPage.type === "page") {
               return (
-                <li className={item()} key={page.value}>
+                <li className={item()} key={paginationPage.value}>
                   <LinkButton
                     {...getTriggerButtonProps(
-                      api.getItemProps(page) as Record<string, unknown>
+                      api.getItemProps(paginationPage) as Record<
+                        string,
+                        unknown
+                      >
                     )}
                   >
-                    {page.value}
+                    {paginationPage.value}
                   </LinkButton>
                 </li>
               )
             }
 
+            const previousPage = api.pages[index - 1]
+            const nextPage = api.pages[index + 1]
+            const previousPageValue =
+              previousPage?.type === "page" ? previousPage.value : "start"
+            const nextPageValue =
+              nextPage?.type === "page" ? nextPage.value : "end"
+
             return (
-              <li className={item()} key={`ellipsis-${index}`}>
+              <li
+                className={item()}
+                key={`ellipsis-${previousPageValue}-${nextPageValue}`}
+              >
                 <span
                   aria-hidden="true"
                   className={ellipsis()}

--- a/nx.json
+++ b/nx.json
@@ -21,6 +21,9 @@
     }
   ],
   "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    },
     "@nx/esbuild:esbuild": {
       "cache": true,
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary
- add a global Nx build target dependency so app/library builds run upstream workspace builds first, and explicitly merge `^build` into projects that already define their own `dependsOn`
- keep shared UI Pagination link-only and migrate current app consumers away from button/onPageChange mode
- export `createPaginationGetPageUrl` from the Pagination module so apps share the common preserve-query/set-or-delete-page-param behavior without adding Next/nuqs dependencies to UI kit
- remove unnecessary manual `useMemo`/`useCallback` from the touched URL pagination flow, extract small pure URL/category helpers, and let React Compiler handle referential optimization
- stabilize current-master frontend-demo build without pulling the large #356 Storefront Data migration: use StatusText instead of removed text atoms, update old Steps/Carousel call sites, lazy-init Resend, and allow category generation to emit an empty fallback only for clean local non-CI builds
- address PR review recommendations: category generation no longer overwrites an existing static module on backend failure, checkout renders one Steps tree, and address-form error helpers show icons consistently
- align with #352's link-based category pagination direction while covering the remaining current-master call sites

## Impact
- directly validated in this PR: `n1`, `frontend-demo`, `ui-kit`, `new-engine-ctl`, and `zane-operator` builds
- N1 impact is intentional: Nx now builds workspace dependencies before `n1`, and N1 pagination consumers use the shared link-driven Pagination URL helper
- Herbatica/downstream storefront impact is expected through shared `@techsio/ui-kit` Pagination API and workspace build assumptions, but Herbatica is not present in this repo so this PR does not claim runtime validation there
- any downstream app still using the removed button/onPageChange Pagination mode should migrate to `getPageUrl`/link navigation, preferably using `createPaginationGetPageUrl` for consistent query handling

## Scope decision
- kept as one PR because the commits form a single reviewable build-stabilization chain: Nx build dependency ordering exposes current app build breakages, and the pagination/API updates are required for those app builds to pass on current master
- split would create a stacked PR chain with repeated CI/review churn and less useful intermediate states
- commits are separated by layer so reviewers can still inspect Nx wiring, frontend-demo compatibility, and link-driven pagination independently

## Branch/PR research
- #356 (`refactor/migrate-sd-into-frontend-demo`) already contains the broader long-term frontend-demo direction from KaiUweCZE: runtime category registry via Storefront Data and removed static category generation
- #242 (`schaltwerk/issue-222-nuqs-search-params`) adds nuqs for N1 category pagination, but it is based on the old `onPageChange` ProductGrid contract; it should be updated later to keep nuqs for state parsing while using link-only pagination/getPageUrl for href generation
- this PR intentionally takes only the narrow build fixes needed on current master, because #356 changes 100+ files and is too broad to fold into this onboarding/build fix

## Verification
- `node --check apps/frontend-demo/scripts/generate-categories.mjs`
- category generator failure matrix: clean local fallback writes module and exits 0; CI failure exits 1 and writes no module; existing module failure exits 1 and preserves file hash
- `NEXT_PUBLIC_MEDUSA_BACKEND_URL=http://127.0.0.1:9 NX_DAEMON=false bunx nx run frontend-demo:build --skip-nx-cache`
- `NX_DAEMON=false bunx nx run n1:build --skip-nx-cache`
- `NX_DAEMON=false bunx nx run zane-operator:build --skip-nx-cache`
- `NX_DAEMON=false bunx nx run new-engine-ctl:build --skip-nx-cache`
- `bunx biome check --write apps/frontend-demo/src/hooks/use-url-filters.ts apps/n1/src/app/'(dynamic)'/kategorie/'[handle]'/page.tsx`
- `bunx biome check --write apps/frontend-demo/src/app/checkout/page.tsx apps/zane-operator/project.json apps/new-engine-ctl/project.json`
- `bunx biome format --write apps/frontend-demo/src/app/checkout/page.tsx apps/frontend-demo/src/components/organisms/address-form.tsx apps/zane-operator/project.json apps/new-engine-ctl/project.json`
- earlier coverage on this branch: `pnpm --filter ui-kit exec tsc -p tsconfig.json --noEmit`, `pnpm --filter n1 exec tsc -p tsconfig.json --noEmit`, targeted Biome for pagination/app consumer files

## Notes
- frontend-demo clean local build still logs expected category/backend warnings when Medusa is unavailable; CI and existing generated modules now fail instead of silently shipping/replacing empty category data
- `pnpm --filter frontend-demo exec tsc -p tsconfig.json --noEmit` is still blocked by existing TS project-reference config: `libs/ui may not disable emit`; the Next/Nx frontend-demo build passes
- full Biome over `address-form.tsx` is still blocked by pre-existing complexity and exhaustive-deps lint debt; this PR only changes the reviewed `StatusText showIcon` rendering there




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Pagination now uses URL-based navigation, enabling better page bookmarking and sharing.

**Bug Fixes**
* Email service now returns a clear error message when not properly configured.
* Improved error messaging display consistency across authentication and checkout forms.
* Enhanced responsive handling for checkout flow on different screen sizes.

**Chores**
* Build system improvements for better dependency management.
* Workspace configuration optimisations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->