### PR TITLE
fix(storefront-data): align medusa build-time dependencies

### DIFF
--- a/libs/storefront-data/package.json
+++ b/libs/storefront-data/package.json
@@ -281,7 +281,9 @@
     "jsdom": "^27.4.0",
     "msw": "^2.8.0",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.0.17",
+    "@medusajs/js-sdk": "2.14.1",
+    "@medusajs/types": "2.14.1"
   },
   "peerDependencies": {
     "@medusajs/js-sdk": ">=2.12.0",

--- a/libs/storefront-data/package.json
+++ b/libs/storefront-data/package.json
@@ -282,8 +282,8 @@
     "msw": "^2.8.0",
     "typescript": "^5.9.3",
     "vitest": "^4.0.17",
-    "@medusajs/js-sdk": "2.14.1",
-    "@medusajs/types": "2.14.1"
+    "@medusajs/js-sdk": "^2.14.1",
+    "@medusajs/types": "^2.14.1"
   },
   "peerDependencies": {
     "@medusajs/js-sdk": ">=2.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,10 +442,10 @@ importers:
         version: 19.2.3(react@19.2.3)
     devDependencies:
       '@medusajs/js-sdk':
-        specifier: 2.14.1
+        specifier: ^2.14.1
         version: 2.14.1
       '@medusajs/types':
-        specifier: 2.14.1
+        specifier: ^2.14.1
         version: 2.14.1(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))
       '@rsbuild/plugin-react':
         specifier: ^1.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,12 +431,6 @@ importers:
 
   libs/storefront-data:
     dependencies:
-      '@medusajs/js-sdk':
-        specifier: '>=2.12.0'
-        version: 2.13.1
-      '@medusajs/types':
-        specifier: '>=2.12.0'
-        version: 2.12.2(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))
       '@tanstack/react-query':
         specifier: '>=5.0.0'
         version: 5.90.10(react@19.2.3)
@@ -447,6 +441,12 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
     devDependencies:
+      '@medusajs/js-sdk':
+        specifier: 2.14.1
+        version: 2.14.1
+      '@medusajs/types':
+        specifier: 2.14.1
+        version: 2.14.1(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))
       '@rsbuild/plugin-react':
         specifier: ^1.4.1
         version: 1.4.2(@rsbuild/core@1.6.7)
@@ -3232,10 +3232,6 @@ packages:
 
   '@medusajs/js-sdk@2.12.4':
     resolution: {integrity: sha512-RSZJd7vLXPnvtLUV8WI/aaVRG/3WcrRrCBJg3fUBsVeGupvG3Ac7S77V9bXs1I24mIY6arlfSQ4a7oLe3E6sEA==}
-    engines: {node: '>=20'}
-
-  '@medusajs/js-sdk@2.13.1':
-    resolution: {integrity: sha512-FbUJF3nHX/yvR9YiC/DP4eIh5bPoksphkHsoe4hzqNc/qs9MVslDJt2FYivW86kbiEwsvEHToXikDKISEkArvw==}
     engines: {node: '>=20'}
 
   '@medusajs/js-sdk@2.14.1':
@@ -17766,11 +17762,6 @@ snapshots:
       fetch-event-stream: 0.1.6
       qs: 6.14.1
 
-  '@medusajs/js-sdk@2.13.1':
-    dependencies:
-      fetch-event-stream: 0.1.6
-      qs: 6.14.1
-
   '@medusajs/js-sdk@2.14.1':
     dependencies:
       fetch-event-stream: 0.1.6
@@ -18052,19 +18043,19 @@ snapshots:
       ioredis: 5.9.0
       vite: 5.4.21(@types/node@20.17.47)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)
 
-  '@medusajs/types@2.12.2(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))':
-    dependencies:
-      bignumber.js: 9.3.1
-    optionalDependencies:
-      ioredis: 5.9.0
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
-
   '@medusajs/types@2.14.1(ioredis@5.9.0)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       ioredis: 5.9.0
       vite: 5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)
+
+  '@medusajs/types@2.14.1(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      bignumber.js: 9.3.1
+    optionalDependencies:
+      ioredis: 5.9.0
+      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
 
   '@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two pinned development dependencies (@medusajs/js-sdk and @medusajs/types at ^2.14.1) to improve build consistency.
  * Kept the existing test tooling dependency version unchanged to preserve current test behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->