### PR TITLE
fix(ci): harden Medusa module test pipeline

### DIFF
--- a/.github/workflows/medusa-be-tests-after-ci.yml
+++ b/.github/workflows/medusa-be-tests-after-ci.yml
@@ -54,7 +54,7 @@ jobs:
           while IFS= read -r file; do
             [[ -n "$file" ]] || continue
             case "$file" in
-              apps/medusa-be/*|apps/medusa-be/**|docker-compose.e2e.yaml|docker/development/medusa-be/*|docker/development/medusa-be/**|docker/development/postgres/*|docker/development/postgres/**|docker/development/medusa-valkey/*|docker/development/medusa-valkey/**|docker/development/medusa-minio/*|docker/development/medusa-minio/**|docker/development/medusa-meilisearch/*|docker/development/medusa-meilisearch/**|scripts/e2e/*|scripts/e2e/**|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|tsconfig.base.json)
+              apps/medusa-be/**|docker-compose.e2e.yaml|docker/development/medusa-be/**|docker/development/postgres/**|docker/development/medusa-valkey/**|docker/development/medusa-minio/**|docker/development/medusa-meilisearch/**|scripts/ci/**|scripts/e2e/**|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.npmrc|tsconfig.base.json)
                 should_run=true
                 break
                 ;;
@@ -106,6 +106,26 @@ jobs:
     if: needs.preflight.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:18.1-alpine
+        env:
+          POSTGRES_USER: root
+          POSTGRES_PASSWORD: root
+          POSTGRES_DB: medusa_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U root -d medusa_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_HOST: 127.0.0.1
+      DB_USERNAME: root
+      DB_PASSWORD: root
+      DB_PORT: "5432"
+      DB_TEMP_NAME: medusa_test
     steps:
       - name: Checkout workflow head SHA
         uses: actions/checkout@v4

--- a/apps/medusa-be/package.json
+++ b/apps/medusa-be/package.json
@@ -21,7 +21,7 @@
     "develop": "medusa develop",
     "dev": "medusa develop",
     "test:integration:http": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
-    "test:integration:modules": "cross-env TEST_TYPE=integration:modules NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit",
+    "test:integration:modules": "node ../../scripts/ci/run-medusa-module-tests.mjs",
     "test:e2e:http": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand integration-tests/http/*.spec.ts",
     "test:e2e:http:debug": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --detectOpenHandles integration-tests/http/*.spec.ts",
     "test:unit": "cross-env TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit",

--- a/scripts/build-medusa.sh
+++ b/scripts/build-medusa.sh
@@ -156,6 +156,17 @@ log_info "Step 5/5: Creating production node_modules deployment..."
 
 pnpm --filter=medusa-be --prod deploy medusa-be-prod
 rm -rf node_modules apps/medusa-be/node_modules
+if [[ "${PNPM_CLEAN_STORE_AFTER_DEPLOY:-false}" == "true" && -n "${npm_config_store_dir:-}" ]]; then
+  store_dir="$(node -e 'console.log(require("node:path").resolve(process.argv[1]))' "$npm_config_store_dir")"
+  case "$store_dir" in
+    "$PROJECT_ROOT"/.pnpm-store|"$PROJECT_ROOT"/.pnpm-store/*|/tmp/pnpm-store|/tmp/pnpm-store/*)
+      rm -rf "$store_dir"
+      ;;
+    *)
+      log_warn "Skipping pnpm store cleanup for unexpected path: $store_dir"
+      ;;
+  esac
+fi
 
 step_end "Prod deploy"
 

--- a/scripts/ci/run-medusa-module-tests.mjs
+++ b/scripts/ci/run-medusa-module-tests.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process"
+import net from "node:net"
+import path from "node:path"
+import process from "node:process"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../.."
+)
+const medusaBeDir = path.join(repoRoot, "apps/medusa-be")
+
+const dbEnv = {
+  DB_HOST: process.env.DB_HOST || "127.0.0.1",
+  DB_USERNAME: process.env.DB_USERNAME || "root",
+  DB_PASSWORD: process.env.DB_PASSWORD || "root",
+  DB_PORT: process.env.DB_PORT || "5432",
+  DB_TEMP_NAME: process.env.DB_TEMP_NAME || "medusa_test",
+}
+
+const dbUser = encodeURIComponent(dbEnv.DB_USERNAME)
+const dbPassword = encodeURIComponent(dbEnv.DB_PASSWORD)
+const dbName = encodeURIComponent(dbEnv.DB_TEMP_NAME)
+dbEnv.DATABASE_URL =
+  process.env.DATABASE_URL ||
+  `postgres://${dbUser}:${dbPassword}@${dbEnv.DB_HOST}:${dbEnv.DB_PORT}/${dbName}`
+
+const nodeOptions = [process.env.NODE_OPTIONS, "--experimental-vm-modules"]
+  .filter(Boolean)
+  .join(" ")
+
+const testEnv = {
+  ...process.env,
+  ...dbEnv,
+  TEST_TYPE: "integration:modules",
+  NODE_OPTIONS: nodeOptions,
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd || repoRoot,
+      env: options.env || process.env,
+      stdio: options.stdio || "inherit",
+    })
+
+    child.on("error", reject)
+    child.on("exit", (code) => {
+      if (options.allowFailure) {
+        resolve(code ?? 1)
+        return
+      }
+
+      if (code === 0) {
+        resolve(0)
+        return
+      }
+
+      reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`))
+    })
+  })
+}
+
+function canConnect(host, port, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host, port }, () => {
+      socket.end()
+      resolve(true)
+    })
+
+    socket.on("error", () => resolve(false))
+    socket.setTimeout(timeoutMs, () => {
+      socket.destroy()
+      resolve(false)
+    })
+  })
+}
+
+async function waitForTcp(host, port, attempts = 30) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (await canConnect(host, port)) {
+      return true
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+
+  return false
+}
+
+async function waitForDockerPostgres(containerName, attempts = 60) {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const code = await run(
+      "docker",
+      [
+        "exec",
+        "-e",
+        `PGPASSWORD=${dbEnv.DB_PASSWORD}`,
+        containerName,
+        "pg_isready",
+        "-U",
+        dbEnv.DB_USERNAME,
+        "-d",
+        dbEnv.DB_TEMP_NAME,
+      ],
+      { allowFailure: true, stdio: "ignore" }
+    )
+
+    if (code === 0) {
+      return true
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  }
+
+  return false
+}
+
+function dockerContainerName() {
+  const raw = [
+    "new-engine-medusa-module-test-pg",
+    process.env.GITHUB_RUN_ID || "local",
+    process.env.GITHUB_RUN_ATTEMPT || process.pid,
+  ].join("-")
+
+  return raw.replace(/[^a-zA-Z0-9_.-]/g, "-")
+}
+
+async function ensureGithubPostgres() {
+  if (process.env.GITHUB_ACTIONS !== "true") {
+    return null
+  }
+
+  const port = Number(dbEnv.DB_PORT)
+  if (await waitForTcp(dbEnv.DB_HOST, port, 30)) {
+    return null
+  }
+
+  const name = dockerContainerName()
+  await run("docker", ["rm", "-f", name], {
+    allowFailure: true,
+    stdio: "ignore",
+  })
+  await run("docker", [
+    "run",
+    "--rm",
+    "-d",
+    "--name",
+    name,
+    "-e",
+    `POSTGRES_USER=${dbEnv.DB_USERNAME}`,
+    "-e",
+    `POSTGRES_PASSWORD=${dbEnv.DB_PASSWORD}`,
+    "-e",
+    `POSTGRES_DB=${dbEnv.DB_TEMP_NAME}`,
+    "-p",
+    `${dbEnv.DB_HOST}:${dbEnv.DB_PORT}:5432`,
+    "postgres:18.1-alpine",
+  ])
+
+  if (
+    !(
+      (await waitForTcp(dbEnv.DB_HOST, port, 30)) &&
+      (await waitForDockerPostgres(name, 60))
+    )
+  ) {
+    await run("docker", ["logs", name], { allowFailure: true })
+    throw new Error(
+      `Postgres did not become ready on ${dbEnv.DB_HOST}:${dbEnv.DB_PORT}`
+    )
+  }
+
+  return name
+}
+
+let postgresContainer = null
+
+try {
+  postgresContainer = await ensureGithubPostgres()
+  const exitCode = await run(
+    "pnpm",
+    ["exec", "jest", "--silent", "--runInBand", "--forceExit"],
+    {
+      cwd: medusaBeDir,
+      env: testEnv,
+      allowFailure: true,
+    }
+  )
+
+  process.exitCode = exitCode
+} finally {
+  if (postgresContainer) {
+    await run("docker", ["rm", "-f", postgresContainer], {
+      allowFailure: true,
+      stdio: "ignore",
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated Medusa module integration test runner that composes DATABASE_URL safely and preserves existing NODE_OPTIONS
- run module tests with an explicit Postgres service in the after-CI workflow and include scripts/ci changes in the preflight scope
- add guarded pnpm store cleanup for Medusa builds so disk cleanup cannot remove unexpected paths

## Validation
- actionlint .github/workflows/medusa-be-tests-after-ci.yml
- node --check scripts/ci/run-medusa-module-tests.mjs
- bash -n scripts/build-medusa.sh
- bunx biome check --write scripts/ci/run-medusa-module-tests.mjs apps/medusa-be/package.json
- GITHUB_ACTIONS=true pnpm --filter medusa-be test:integration:modules