### PR TITLE
fix(zane): pin preview git reconciliation to PR branch

### DIFF
--- a/apps/new-engine-ctl/package.json
+++ b/apps/new-engine-ctl/package.json
@@ -11,7 +11,7 @@
     "dev": "tsx src/cli.ts",
     "lint": "biome check src scripts",
     "format": "biome format --write src scripts",
-    "test": "node --import tsx --test \"src/**/*.test.ts\"",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
@@ -23,6 +23,7 @@
     "@biomejs/biome": "^2.3.7",
     "@types/node": "^24.10.1",
     "esbuild": "^0.27.3",
-    "tsx": "^4.19.4"
+    "tsx": "^4.19.4",
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/new-engine-ctl/src/__tests__/ci-workflows.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/ci-workflows.test.ts
@@ -1,9 +1,8 @@
-import assert from "node:assert/strict"
 import { readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
-import { test } from "node:test"
 import { fileURLToPath } from "node:url"
 
+import { expect, test } from "vitest"
 import { parse as parseYaml } from "yaml"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../../..")
@@ -60,25 +59,13 @@ test("ZaneOps workflows alias the prefixed project slug secret for ctl", async (
     const parsed = parseYaml(raw)
     const envMaps = collectEnvMaps(parsed)
 
-    assert.equal(
-      raw.includes("ZANE_CANONICAL_PROJECT_SLUG"),
-      false,
-      `${workflowPath} must not use the old canonical project slug env`
-    )
+    expect(raw.includes("ZANE_CANONICAL_PROJECT_SLUG")).toBe(false)
 
     for (const envMap of envMaps) {
-      assert.equal(
-        Object.hasOwn(envMap, "ZANE_CANONICAL_PROJECT_SLUG"),
-        false,
-        `${workflowPath} contains the old canonical project slug env`
-      )
+      expect(Object.hasOwn(envMap, "ZANE_CANONICAL_PROJECT_SLUG")).toBe(false)
 
       if (Object.hasOwn(envMap, "ZANEOPS_ZANE_PROJECT_SLUG")) {
-        assert.equal(
-          envMap.ZANE_PROJECT_SLUG,
-          envMap.ZANEOPS_ZANE_PROJECT_SLUG,
-          `${workflowPath} must expose ZANE_PROJECT_SLUG as the ctl alias`
-        )
+        expect(envMap.ZANE_PROJECT_SLUG).toBe(envMap.ZANEOPS_ZANE_PROJECT_SLUG)
       }
     }
   }
@@ -90,9 +77,9 @@ test("main deploy passes downtime approval only after the approval gate", async 
     "utf8"
   )
 
-  assert.match(raw, downtimeEnvironmentPattern)
-  assert.match(raw, downtimeApprovalEnvPattern)
-  assert.match(raw, approveDowntimeRiskFlagPattern)
+  expect(raw).toMatch(downtimeEnvironmentPattern)
+  expect(raw).toMatch(downtimeApprovalEnvPattern)
+  expect(raw).toMatch(approveDowntimeRiskFlagPattern)
 })
 
 test("preview scope feeds baseline state into prepare decisions", async () => {
@@ -101,14 +88,14 @@ test("preview scope feeds baseline state into prepare decisions", async () => {
     "utf8"
   )
 
-  assert.match(raw, baselineCompleteOutputPattern)
-  assert.match(raw, previewBaselineCompleteEnvPattern)
-  assert.match(raw, previewBaselineCompleteFlagPattern)
+  expect(raw).toMatch(baselineCompleteOutputPattern)
+  expect(raw).toMatch(previewBaselineCompleteEnvPattern)
+  expect(raw).toMatch(previewBaselineCompleteFlagPattern)
 })
 
 test("main CI runs new-engine-ctl tests on the supported Node version", async () => {
   const raw = await readFile(join(repoRoot, ".github/workflows/ci.yml"), "utf8")
 
-  assert.match(raw, node24Pattern)
-  assert.match(raw, ciCtlTestPattern)
+  expect(raw).toMatch(node24Pattern)
+  expect(raw).toMatch(ciCtlTestPattern)
 })

--- a/apps/new-engine-ctl/src/__tests__/github-event.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/github-event.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { test } from "node:test"
+
+import { resolveGitHubPreviewHeadBranch } from "../github-event.js"
+
+async function withoutBranchEnv(callback: () => Promise<void>): Promise<void> {
+  const originalPreviewBranch = process.env.ZANE_PREVIEW_GIT_BRANCH
+  const originalHeadRef = process.env.GITHUB_HEAD_REF
+  Reflect.deleteProperty(process.env, "ZANE_PREVIEW_GIT_BRANCH")
+  Reflect.deleteProperty(process.env, "GITHUB_HEAD_REF")
+
+  try {
+    await callback()
+  } finally {
+    if (typeof originalPreviewBranch === "undefined") {
+      Reflect.deleteProperty(process.env, "ZANE_PREVIEW_GIT_BRANCH")
+    } else {
+      process.env.ZANE_PREVIEW_GIT_BRANCH = originalPreviewBranch
+    }
+    if (typeof originalHeadRef === "undefined") {
+      Reflect.deleteProperty(process.env, "GITHUB_HEAD_REF")
+    } else {
+      process.env.GITHUB_HEAD_REF = originalHeadRef
+    }
+  }
+}
+
+async function withEventFile(
+  event: unknown,
+  callback: (path: string) => Promise<void>
+): Promise<void> {
+  const directory = await mkdtemp(join(tmpdir(), "new-engine-ctl-event-"))
+  const path = join(directory, "event.json")
+  await writeFile(path, JSON.stringify(event), "utf8")
+
+  try {
+    await callback(path)
+  } finally {
+    await rm(directory, { force: true, recursive: true })
+  }
+}
+
+test("resolves PR head branch from workflow_run pull request payload", async () => {
+  await withoutBranchEnv(async () => {
+    await withEventFile(
+      {
+        workflow_run: {
+          head_branch: "master",
+          pull_requests: [
+            {
+              head: {
+                ref: "ci/pipeline-smoke-20260428",
+              },
+            },
+          ],
+        },
+      },
+      async (path) => {
+        const branch = await resolveGitHubPreviewHeadBranch(path)
+
+        assert.equal(branch, "ci/pipeline-smoke-20260428")
+      }
+    )
+  })
+})
+
+test("falls back to workflow_run head_branch when PR head ref is unavailable", async () => {
+  await withoutBranchEnv(async () => {
+    await withEventFile(
+      {
+        workflow_run: {
+          head_branch: "ci/pipeline-smoke-20260428",
+          pull_requests: [],
+        },
+      },
+      async (path) => {
+        const branch = await resolveGitHubPreviewHeadBranch(path)
+
+        assert.equal(branch, "ci/pipeline-smoke-20260428")
+      }
+    )
+  })
+})
+
+test("explicit preview branch env overrides event payload", async () => {
+  await withoutBranchEnv(async () => {
+    process.env.ZANE_PREVIEW_GIT_BRANCH = "manual-preview-branch"
+
+    await withEventFile(
+      {
+        workflow_run: {
+          head_branch: "master",
+        },
+      },
+      async (path) => {
+        const branch = await resolveGitHubPreviewHeadBranch(path)
+
+        assert.equal(branch, "manual-preview-branch")
+      }
+    )
+  })
+})

--- a/apps/new-engine-ctl/src/__tests__/github-event.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/github-event.test.ts
@@ -1,8 +1,7 @@
-import assert from "node:assert/strict"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { test } from "node:test"
+import { expect, test } from "vitest"
 
 import { resolveGitHubPreviewHeadBranch } from "../github-event.js"
 
@@ -61,7 +60,7 @@ test("resolves PR head branch from workflow_run pull request payload", async () 
       async (path) => {
         const branch = await resolveGitHubPreviewHeadBranch(path)
 
-        assert.equal(branch, "ci/pipeline-smoke-20260428")
+        expect(branch).toBe("ci/pipeline-smoke-20260428")
       }
     )
   })
@@ -79,7 +78,7 @@ test("falls back to workflow_run head_branch when PR head ref is unavailable", a
       async (path) => {
         const branch = await resolveGitHubPreviewHeadBranch(path)
 
-        assert.equal(branch, "ci/pipeline-smoke-20260428")
+        expect(branch).toBe("ci/pipeline-smoke-20260428")
       }
     )
   })
@@ -98,7 +97,7 @@ test("explicit preview branch env overrides event payload", async () => {
       async (path) => {
         const branch = await resolveGitHubPreviewHeadBranch(path)
 
-        assert.equal(branch, "manual-preview-branch")
+        expect(branch).toBe("manual-preview-branch")
       }
     )
   })

--- a/apps/new-engine-ctl/src/__tests__/preview-runtime-reconciliation.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/preview-runtime-reconciliation.test.ts
@@ -1,5 +1,4 @@
-import assert from "node:assert/strict"
-import { test } from "node:test"
+import { expect, test } from "vitest"
 
 import { stackInputsSchema } from "../contracts/stack-inputs.js"
 import { stackManifestSchema } from "../contracts/stack-manifest.js"
@@ -35,7 +34,7 @@ test("preview service reconciliation pins git source to the PR branch", () => {
     previewGitBranch: "ci/pipeline-smoke-20260428",
   })
 
-  assert.equal(specs[0]?.git_source?.branch_name, "ci/pipeline-smoke-20260428")
+  expect(specs[0]?.git_source?.branch_name).toBe("ci/pipeline-smoke-20260428")
 })
 
 test("main service reconciliation does not override source branch", () => {
@@ -47,5 +46,5 @@ test("main service reconciliation does not override source branch", () => {
     previewGitBranch: "ci/pipeline-smoke-20260428",
   })
 
-  assert.equal(specs[0]?.git_source?.branch_name, undefined)
+  expect(specs[0]?.git_source?.branch_name).toBeUndefined()
 })

--- a/apps/new-engine-ctl/src/__tests__/preview-runtime-reconciliation.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/preview-runtime-reconciliation.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { stackInputsSchema } from "../contracts/stack-inputs.js"
+import { stackManifestSchema } from "../contracts/stack-manifest.js"
+import { buildServiceReconciliationSpecs } from "../orchestration/preview-runtime-reconciliation.js"
+
+const manifest = stackManifestSchema.parse({
+  ci: {
+    ignore_path_globs: [],
+    global_runtime_rules: [],
+  },
+  services: [
+    {
+      id: "medusa-be",
+      ci: {
+        deployable: true,
+        zane: {
+          service_slug: "medusa-be",
+          deploy_lanes: ["preview", "main"],
+        },
+      },
+    },
+  ],
+})
+
+const stackInputs = stackInputsSchema.parse({})
+
+test("preview service reconciliation pins git source to the PR branch", () => {
+  const specs = buildServiceReconciliationSpecs({
+    stackInputs,
+    manifest,
+    lane: "preview",
+    serviceIds: ["medusa-be"],
+    previewGitBranch: "ci/pipeline-smoke-20260428",
+  })
+
+  assert.equal(specs[0]?.git_source?.branch_name, "ci/pipeline-smoke-20260428")
+})
+
+test("main service reconciliation does not override source branch", () => {
+  const specs = buildServiceReconciliationSpecs({
+    stackInputs,
+    manifest,
+    lane: "main",
+    serviceIds: ["medusa-be"],
+    previewGitBranch: "ci/pipeline-smoke-20260428",
+  })
+
+  assert.equal(specs[0]?.git_source?.branch_name, undefined)
+})

--- a/apps/new-engine-ctl/src/__tests__/scope-preview.test.ts
+++ b/apps/new-engine-ctl/src/__tests__/scope-preview.test.ts
@@ -1,8 +1,7 @@
-import assert from "node:assert/strict"
 import { dirname, join, resolve } from "node:path"
-import { test } from "node:test"
 import { fileURLToPath } from "node:url"
 
+import { expect, test } from "vitest"
 import { executePlan } from "../orchestration/plan.js"
 import { executeScope } from "../orchestration/scope.js"
 
@@ -30,10 +29,10 @@ test("preview scope prepares DB credentials for first baseline replay", async ()
     nxIsolatePlugins: true,
   })
 
-  assert.equal(result.services_csv, "n1")
-  assert.equal(result.should_prepare, true)
-  assert.equal(result.requires_preview_db, true)
-  assert.equal(result.preview_db_service_ids, "medusa-be")
+  expect(result.services_csv).toBe("n1")
+  expect(result.should_prepare).toBe(true)
+  expect(result.requires_preview_db).toBe(true)
+  expect(result.preview_db_service_ids).toBe("medusa-be")
 })
 
 test("preview scope skips prepare for non-DB services after baseline is complete", async () => {
@@ -47,14 +46,14 @@ test("preview scope skips prepare for non-DB services after baseline is complete
     nxIsolatePlugins: true,
   })
 
-  assert.equal(result.services_csv, "n1")
-  assert.equal(result.should_prepare, false)
-  assert.equal(result.requires_preview_db, false)
-  assert.equal(result.preview_db_service_ids, "")
+  expect(result.services_csv).toBe("n1")
+  expect(result.should_prepare).toBe(false)
+  expect(result.requires_preview_db).toBe(false)
+  expect(result.preview_db_service_ids).toBe("")
 })
 
 test("preview scope rejects explicit services excluded from preview cloning", async () => {
-  await assert.rejects(
+  await expect(
     executeScope({
       lane: "preview",
       servicesCsv: "medusa-db",
@@ -63,13 +62,12 @@ test("preview scope rejects explicit services excluded from preview cloning", as
       stackManifestPath,
       stackInputsPath,
       nxIsolatePlugins: true,
-    }),
-    explicitPreviewRejectPattern
-  )
+    })
+  ).rejects.toThrow(explicitPreviewRejectPattern)
 })
 
 test("preview plan rejects services marked clone_to_preview false", async () => {
-  await assert.rejects(
+  await expect(
     executePlan({
       lane: "preview",
       servicesCsv: "medusa-db",
@@ -77,7 +75,6 @@ test("preview plan rejects services marked clone_to_preview false", async () => 
       outputJson: undefined,
       stackManifestPath,
       previewEnvPrefix: "pr-",
-    }),
-    cloneToPreviewRejectPattern
-  )
+    })
+  ).rejects.toThrow(cloneToPreviewRejectPattern)
 })

--- a/apps/new-engine-ctl/src/commands/resolve-environment.ts
+++ b/apps/new-engine-ctl/src/commands/resolve-environment.ts
@@ -17,6 +17,7 @@ export function createResolveEnvironmentCommand(): Command {
     .option("--reconcile-service-ids-csv <csv>", "", "")
     .option("--preview-cloned-service-ids-csv <csv>", "", "")
     .option("--preview-excluded-service-ids-csv <csv>", "", "")
+    .option("--preview-git-branch <branch>")
     .option("--output-json <path>")
     .option("--base-url <url>")
     .option("--api-token <token>")
@@ -49,6 +50,11 @@ export function createResolveEnvironmentCommand(): Command {
         reconcileServiceIdsCsv: options.reconcileServiceIdsCsv,
         previewClonedServiceIdsCsv: options.previewClonedServiceIdsCsv,
         previewExcludedServiceIdsCsv: options.previewExcludedServiceIdsCsv,
+        previewGitBranch:
+          typeof options.previewGitBranch === "string" &&
+          options.previewGitBranch.trim()
+            ? options.previewGitBranch.trim()
+            : (process.env.ZANE_PREVIEW_GIT_BRANCH?.trim() ?? ""),
         outputJson: options.outputJson,
         baseUrl: options.baseUrl ?? process.env.ZANE_OPERATOR_BASE_URL ?? "",
         apiToken: options.apiToken ?? process.env.ZANE_OPERATOR_API_TOKEN ?? "",

--- a/apps/new-engine-ctl/src/contracts/resolve-environment.ts
+++ b/apps/new-engine-ctl/src/contracts/resolve-environment.ts
@@ -12,6 +12,7 @@ export const resolveEnvironmentCommandInputSchema = z
     reconcileServiceIdsCsv: z.string().default(""),
     previewClonedServiceIdsCsv: z.string().default(""),
     previewExcludedServiceIdsCsv: z.string().default(""),
+    previewGitBranch: z.string().default(""),
     outputJson: z.string().min(1).optional(),
     baseUrl: z.string().default(""),
     apiToken: z.string().default(""),

--- a/apps/new-engine-ctl/src/contracts/resolve-environment.ts
+++ b/apps/new-engine-ctl/src/contracts/resolve-environment.ts
@@ -92,7 +92,10 @@ export const resolveEnvironmentResponseSchema = z.object({
   warnings: z.array(warningSchema).default([]),
 })
 
-export type ResolveEnvironmentCommandInput = z.infer<
+export type ResolveEnvironmentCommandInput = z.input<
+  typeof resolveEnvironmentCommandInputSchema
+>
+export type ResolvedEnvironmentCommandInput = z.infer<
   typeof resolveEnvironmentCommandInputSchema
 >
 export type ResolveEnvironmentResponse = z.infer<

--- a/apps/new-engine-ctl/src/github-event.ts
+++ b/apps/new-engine-ctl/src/github-event.ts
@@ -1,0 +1,61 @@
+import { readFile } from "node:fs/promises"
+
+function readNestedString(value: unknown, path: string[]): string {
+  let current = value
+
+  for (const segment of path) {
+    if (Array.isArray(current)) {
+      const index = Number(segment)
+      if (!Number.isInteger(index)) {
+        return ""
+      }
+
+      current = current[index]
+      continue
+    }
+
+    if (!current || typeof current !== "object") {
+      return ""
+    }
+
+    current = (current as Record<string, unknown>)[segment]
+  }
+
+  return typeof current === "string" ? current.trim() : ""
+}
+
+export async function resolveGitHubPreviewHeadBranch(
+  eventPath = process.env.GITHUB_EVENT_PATH
+): Promise<string> {
+  if (process.env.ZANE_PREVIEW_GIT_BRANCH?.trim()) {
+    return process.env.ZANE_PREVIEW_GIT_BRANCH.trim()
+  }
+
+  if (process.env.GITHUB_HEAD_REF?.trim()) {
+    return process.env.GITHUB_HEAD_REF.trim()
+  }
+
+  if (!eventPath) {
+    return ""
+  }
+
+  let event: unknown
+
+  try {
+    event = JSON.parse(await readFile(eventPath, "utf8"))
+  } catch {
+    return ""
+  }
+
+  return (
+    readNestedString(event, [
+      "workflow_run",
+      "pull_requests",
+      "0",
+      "head",
+      "ref",
+    ]) ||
+    readNestedString(event, ["workflow_run", "head_branch"]) ||
+    readNestedString(event, ["pull_request", "head", "ref"])
+  )
+}

--- a/apps/new-engine-ctl/src/orchestration/deploy-main.ts
+++ b/apps/new-engine-ctl/src/orchestration/deploy-main.ts
@@ -110,7 +110,6 @@ export async function executeDeployMain(
     stackManifestPath: input.stackManifestPath,
     stackInputsPath: input.stackInputsPath,
     previewEnvPrefix: "pr-",
-    previewGitBranch: "",
   })
   const prerequisitePlan = await expandPlanForRuntimeProviderPrerequisites({
     lane: "main",

--- a/apps/new-engine-ctl/src/orchestration/deploy-main.ts
+++ b/apps/new-engine-ctl/src/orchestration/deploy-main.ts
@@ -110,6 +110,7 @@ export async function executeDeployMain(
     stackManifestPath: input.stackManifestPath,
     stackInputsPath: input.stackInputsPath,
     previewEnvPrefix: "pr-",
+    previewGitBranch: "",
   })
   const prerequisitePlan = await expandPlanForRuntimeProviderPrerequisites({
     lane: "main",

--- a/apps/new-engine-ctl/src/orchestration/deploy-preview.ts
+++ b/apps/new-engine-ctl/src/orchestration/deploy-preview.ts
@@ -10,6 +10,7 @@ import type { ResolveTargetsPayload } from "../contracts/resolve-targets.js"
 import type { RuntimeProviderOutputs } from "../contracts/runtime-provider-outputs.js"
 import { getPreviewRandomOnceSecretDefinitions } from "../contracts/stack-inputs.js"
 import type { PreviewRandomOnceSecretInput } from "../contracts/verify.js"
+import { resolveGitHubPreviewHeadBranch } from "../github-event.js"
 import { ZaneOperatorClient } from "../zane-operator-client/client.js"
 import { executeApplyEnvOverridesPayload } from "./apply-env-overrides.js"
 import { loadDeployContracts } from "./deploy-inputs.js"
@@ -309,6 +310,7 @@ export async function executeDeployPreview(
     stackManifestPath: input.stackManifestPath,
     previewEnvPrefix: input.previewEnvPrefix,
   })
+  const previewGitBranch = await resolveGitHubPreviewHeadBranch()
   const environment = await executeResolveEnvironment({
     lane: "preview",
     projectSlug: input.projectSlug,
@@ -326,6 +328,7 @@ export async function executeDeployPreview(
     stackManifestPath: input.stackManifestPath,
     stackInputsPath: input.stackInputsPath,
     previewEnvPrefix: input.previewEnvPrefix,
+    previewGitBranch,
   })
   const baselineDeploy = environment.created || !environment.baseline_complete
   logDeployProgress(

--- a/apps/new-engine-ctl/src/orchestration/preview-runtime-reconciliation.ts
+++ b/apps/new-engine-ctl/src/orchestration/preview-runtime-reconciliation.ts
@@ -35,6 +35,8 @@ export type PreviewServiceSpecSyncService = {
   service_slug: string
   git_source?: {
     sync_from_source: boolean
+    branch_name?: string
+    commit_sha?: string
   }
   builder?: {
     sync_from_source: boolean
@@ -45,6 +47,18 @@ export type PreviewServiceSpecSyncService = {
   }
   resource_limits?: {
     sync_from_source: boolean
+  }
+}
+
+function buildPreviewGitSourceSpec(input: {
+  lane: ServiceReconciliationLane
+  previewGitBranch?: string
+}): PreviewServiceSpecSyncService["git_source"] {
+  return {
+    sync_from_source: true,
+    ...(input.lane === "preview" && input.previewGitBranch
+      ? { branch_name: input.previewGitBranch }
+      : {}),
   }
 }
 
@@ -275,6 +289,7 @@ export function buildServiceReconciliationSpecs(input: {
   manifest: StackManifest
   lane: ServiceReconciliationLane
   serviceIds: string[]
+  previewGitBranch?: string
 }): PreviewServiceSpecSyncService[] {
   const definitionByServiceId = new Map(
     getServiceReconciliationDefinitions(input.stackInputs).map((definition) => [
@@ -310,9 +325,7 @@ export function buildServiceReconciliationSpecs(input: {
     }
 
     if (definition.git_source.sync_from_source) {
-      serviceSpec.git_source = {
-        sync_from_source: true,
-      }
+      serviceSpec.git_source = buildPreviewGitSourceSpec(input)
     }
 
     if (definition.builder.sync_from_source) {

--- a/apps/new-engine-ctl/src/orchestration/resolve-environment.ts
+++ b/apps/new-engine-ctl/src/orchestration/resolve-environment.ts
@@ -82,6 +82,7 @@ export async function executeResolveEnvironment(
             input.lane === "preview"
               ? normalizeCsvToArray(input.previewClonedServiceIdsCsv)
               : normalizeCsvToArray(input.reconcileServiceIdsCsv),
+          previewGitBranch: input.previewGitBranch,
         })
       : []
 

--- a/apps/new-engine-ctl/src/orchestration/resolve-environment.ts
+++ b/apps/new-engine-ctl/src/orchestration/resolve-environment.ts
@@ -1,8 +1,10 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname } from "node:path"
 import {
+  type ResolvedEnvironmentCommandInput,
   type ResolveEnvironmentCommandInput,
   type ResolveEnvironmentResponse,
+  resolveEnvironmentCommandInputSchema,
   resolveEnvironmentResponseSchema,
 } from "../contracts/resolve-environment.js"
 import {
@@ -14,7 +16,7 @@ import { loadDeployContracts, normalizeCsvToArray } from "./deploy-inputs.js"
 import { buildServiceReconciliationSpecs } from "./preview-runtime-reconciliation.js"
 
 function buildPreviewEnvironmentName(
-  input: ResolveEnvironmentCommandInput
+  input: ResolvedEnvironmentCommandInput
 ): string {
   if (input.environmentName) {
     return input.environmentName
@@ -24,7 +26,7 @@ function buildPreviewEnvironmentName(
 }
 
 function buildPreviewServiceSlugSets(
-  input: ResolveEnvironmentCommandInput,
+  input: ResolvedEnvironmentCommandInput,
   manifest: StackManifest
 ): {
   expectedPreviewServiceSlugs: string[]
@@ -59,41 +61,42 @@ async function writeJsonFile(path: string, value: unknown): Promise<void> {
 export async function executeResolveEnvironment(
   input: ResolveEnvironmentCommandInput
 ): Promise<ResolveEnvironmentResponse> {
+  const resolvedInput = resolveEnvironmentCommandInputSchema.parse(input)
   const contracts = await loadDeployContracts(
-    input.stackManifestPath,
-    input.stackInputsPath
+    resolvedInput.stackManifestPath,
+    resolvedInput.stackInputsPath
   )
   const manifest = contracts.manifest
-  const environmentName = buildPreviewEnvironmentName(input)
+  const environmentName = buildPreviewEnvironmentName(resolvedInput)
   const previewServiceSlugSets =
-    input.lane === "preview"
-      ? buildPreviewServiceSlugSets(input, manifest)
+    resolvedInput.lane === "preview"
+      ? buildPreviewServiceSlugSets(resolvedInput, manifest)
       : {
           expectedPreviewServiceSlugs: [],
           excludedPreviewServiceSlugs: [],
         }
   const serviceSpecs =
-    input.lane === "preview" || input.reconcileServiceIdsCsv
+    resolvedInput.lane === "preview" || resolvedInput.reconcileServiceIdsCsv
       ? buildServiceReconciliationSpecs({
           stackInputs: contracts.stackInputs,
           manifest,
-          lane: input.lane,
+          lane: resolvedInput.lane,
           serviceIds:
-            input.lane === "preview"
-              ? normalizeCsvToArray(input.previewClonedServiceIdsCsv)
-              : normalizeCsvToArray(input.reconcileServiceIdsCsv),
-          previewGitBranch: input.previewGitBranch,
+            resolvedInput.lane === "preview"
+              ? normalizeCsvToArray(resolvedInput.previewClonedServiceIdsCsv)
+              : normalizeCsvToArray(resolvedInput.reconcileServiceIdsCsv),
+          previewGitBranch: resolvedInput.previewGitBranch,
         })
       : []
 
-  const response = input.dryRun
+  const response = resolvedInput.dryRun
     ? resolveEnvironmentResponseSchema.parse({
-        lane: input.lane,
-        project_slug: input.projectSlug,
+        lane: resolvedInput.lane,
+        project_slug: resolvedInput.projectSlug,
         environment_name: environmentName,
         environment_id: `dry-run:${environmentName}`,
-        created: input.dryRunCreated,
-        baseline_complete: !input.dryRunCreated,
+        created: resolvedInput.dryRunCreated,
+        baseline_complete: !resolvedInput.dryRunCreated,
         ready: true,
         expected_preview_service_slugs:
           previewServiceSlugSets.expectedPreviewServiceSlugs,
@@ -105,13 +108,14 @@ export async function executeResolveEnvironment(
         warnings: [],
       })
     : await new ZaneOperatorClient(
-        input.baseUrl,
-        input.apiToken
+        resolvedInput.baseUrl,
+        resolvedInput.apiToken
       ).resolveEnvironment({
-        lane: input.lane,
-        project_slug: input.projectSlug,
+        lane: resolvedInput.lane,
+        project_slug: resolvedInput.projectSlug,
         environment_name: environmentName,
-        source_environment_name: input.sourceEnvironmentName || environmentName,
+        source_environment_name:
+          resolvedInput.sourceEnvironmentName || environmentName,
         expected_preview_service_slugs:
           previewServiceSlugSets.expectedPreviewServiceSlugs,
         excluded_preview_service_slugs:
@@ -119,14 +123,14 @@ export async function executeResolveEnvironment(
         service_specs: serviceSpecs,
       })
 
-  if (input.lane === "preview" && !response.ready) {
+  if (resolvedInput.lane === "preview" && !response.ready) {
     throw new Error(
       `Preview environment ${response.environment_name} is missing required cloned services: ${response.missing_preview_service_slugs.join(",")}`
     )
   }
 
-  if (input.outputJson) {
-    await writeJsonFile(input.outputJson, response)
+  if (resolvedInput.outputJson) {
+    await writeJsonFile(resolvedInput.outputJson, response)
   }
 
   return response

--- a/apps/new-engine-ctl/src/zane-operator-client/client.ts
+++ b/apps/new-engine-ctl/src/zane-operator-client/client.ts
@@ -163,6 +163,8 @@ export class ZaneOperatorClient {
       service_slug: string
       git_source?: {
         sync_from_source: boolean
+        branch_name?: string
+        commit_sha?: string
       }
       builder?: {
         sync_from_source: boolean

--- a/apps/zane-operator/src/zane-contract.ts
+++ b/apps/zane-operator/src/zane-contract.ts
@@ -16,6 +16,8 @@ export interface ZaneServiceReconciliationSpec {
   service_slug: string
   git_source?: {
     sync_from_source: boolean
+    branch_name?: string
+    commit_sha?: string
   }
   builder?: {
     sync_from_source: boolean

--- a/apps/zane-operator/src/zane-environments.ts
+++ b/apps/zane-operator/src/zane-environments.ts
@@ -181,7 +181,10 @@ function buildDesiredGitSource(
   }
 
   const repositoryUrl = sourceDetails.repository_url?.trim() ?? ""
-  const branchName = sourceDetails.branch_name?.trim() ?? ""
+  const branchName =
+    spec.git_source?.branch_name?.trim() ||
+    sourceDetails.branch_name?.trim() ||
+    ""
   if (!repositoryUrl || !branchName) {
     throw new UpstreamHttpError(
       409,

--- a/apps/zane-operator/src/zane-inputs.ts
+++ b/apps/zane-operator/src/zane-inputs.ts
@@ -90,7 +90,7 @@ function assertStringArray(value: unknown, label: string): string[] {
 function normalizeRuntimeProviderOutput(
   value: unknown,
   label: string
- ): RuntimeProviderOutputInput {
+): RuntimeProviderOutputInput {
   const object = assertObject(value, label)
   const policy = assertObject(object.policy, `${label}.policy`)
   const kind = assertString(policy.kind, `${label}.policy.kind`)
@@ -401,23 +401,10 @@ function parseServiceReconciliationSpecs(
 
   return value.map((item, index) => {
     const object = assertObject(item, `${label}[${index}]`)
-    const gitSource =
-      object.git_source == null
-        ? undefined
-        : (() => {
-            const gitSourceObject = assertObject(
-              object.git_source,
-              `${label}[${index}].git_source`
-            )
-            return {
-              sync_from_source: gitSourceObject.sync_from_source === true,
-              commit_sha:
-                assertOptionalString(
-                  gitSourceObject.commit_sha,
-                  `${label}[${index}].git_source.commit_sha`
-                ) ?? "HEAD",
-            }
-          })()
+    const gitSource = parseServiceReconciliationGitSource(
+      object.git_source,
+      `${label}[${index}].git_source`
+    )
     const builder =
       object.builder == null
         ? undefined
@@ -428,15 +415,10 @@ function parseServiceReconciliationSpecs(
             )
             return {
               sync_from_source: builderObject.sync_from_source === true,
-              build_stage_target:
-                typeof builderObject.build_stage_target === "string"
-                  ? assertString(
-                      builderObject.build_stage_target,
-                      `${label}[${index}].builder.build_stage_target`
-                    )
-                  : builderObject.build_stage_target === null
-                    ? null
-                    : undefined,
+              build_stage_target: parseOptionalNullableString(
+                builderObject.build_stage_target,
+                `${label}[${index}].builder.build_stage_target`
+              ),
             }
           })()
     const healthcheck =
@@ -479,6 +461,41 @@ function parseServiceReconciliationSpecs(
       ...(resourceLimits ? { resource_limits: resourceLimits } : {}),
     }
   })
+}
+
+function parseOptionalNullableString(
+  value: unknown,
+  label: string
+): string | null | undefined {
+  if (typeof value === "undefined") {
+    return
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  return assertString(value, label)
+}
+
+function parseServiceReconciliationGitSource(
+  value: unknown,
+  label: string
+): ZaneServiceReconciliationSpec["git_source"] {
+  if (value == null) {
+    return
+  }
+
+  const object = assertObject(value, label)
+  return {
+    sync_from_source: object.sync_from_source === true,
+    branch_name: assertOptionalString(
+      object.branch_name,
+      `${label}.branch_name`
+    ),
+    commit_sha:
+      assertOptionalString(object.commit_sha, `${label}.commit_sha`) ?? "HEAD",
+  }
 }
 
 export function parseResolveEnvironmentInput(
@@ -697,7 +714,7 @@ export function parseSyncPreviewServiceEnvInput(
 
 export function parseRuntimeProviderRunInput(
   rawPayload: unknown
- ): RuntimeProviderRunInput {
+): RuntimeProviderRunInput {
   const payload = assertObject(rawPayload, "request body")
   const rawOutputs = payload.outputs
   if (!Array.isArray(rawOutputs) || rawOutputs.length === 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,7 +202,7 @@ importers:
         version: 2.14.1
       '@medusajs/medusa':
         specifier: ^2.13.6
-        version: 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
+        version: 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
       '@medusajs/ui':
         specifier: ^4.1.6
         version: 4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -398,6 +398,9 @@ importers:
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(less@4.1.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3))(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
 
   apps/zane-operator: {}
 
@@ -436,7 +439,7 @@ importers:
         version: 2.13.1
       '@medusajs/types':
         specifier: '>=2.12.0'
-        version: 2.12.2(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))
+        version: 2.12.2(ioredis@5.9.0)(vite@5.4.21(@types/node@25.0.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))
       '@tanstack/react-query':
         specifier: '>=5.0.0'
         version: 5.90.10(react@19.2.3)
@@ -16924,12 +16927,34 @@ snapshots:
       '@inquirer/type': 1.5.5
       chalk: 4.1.2
 
+  '@inquirer/confirm@5.1.21(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.10.1)
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+    optionalDependencies:
+      '@types/node': 24.10.1
+    optional: true
+
   '@inquirer/confirm@5.1.21(@types/node@25.0.3)':
     dependencies:
       '@inquirer/core': 10.3.2(@types/node@25.0.3)
       '@inquirer/type': 3.0.10(@types/node@25.0.3)
     optionalDependencies:
       '@types/node': 25.0.3
+
+  '@inquirer/core@10.3.2(@types/node@24.10.1)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.10.1)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.10.1
+    optional: true
 
   '@inquirer/core@10.3.2(@types/node@25.0.3)':
     dependencies:
@@ -16997,6 +17022,11 @@ snapshots:
   '@inquirer/type@2.0.0':
     dependencies:
       mute-stream: 1.0.0
+
+  '@inquirer/type@3.0.10(@types/node@24.10.1)':
+    optionalDependencies:
+      '@types/node': 24.10.1
+    optional: true
 
   '@inquirer/type@3.0.10(@types/node@25.0.3)':
     optionalDependencies:
@@ -17374,10 +17404,10 @@ snapshots:
       '@jsonjoy.com/codegen': 1.0.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  '@medusajs/admin-bundler@2.14.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yaml@2.7.1)':
+  '@medusajs/admin-bundler@2.14.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yaml@2.7.1)':
     dependencies:
       '@medusajs/admin-shared': 2.14.1
-      '@medusajs/admin-vite-plugin': 2.14.1(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))
+      '@medusajs/admin-vite-plugin': 2.14.1(picomatch@4.0.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))
       '@medusajs/dashboard': 2.14.1(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(typescript@5.9.3)
       '@vitejs/plugin-react': 4.7.0(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))
       autoprefixer: 10.4.23(postcss@8.5.6)
@@ -17416,14 +17446,14 @@ snapshots:
 
   '@medusajs/admin-shared@2.14.1': {}
 
-  '@medusajs/admin-vite-plugin@2.14.1(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))':
+  '@medusajs/admin-vite-plugin@2.14.1(picomatch@4.0.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))':
     dependencies:
       '@babel/parser': 7.25.6
       '@babel/traverse': 7.25.6
       '@babel/types': 7.25.6
       '@medusajs/admin-shared': 2.14.1
       chokidar: 3.6.0
-      fdir: 6.1.1
+      fdir: 6.1.1(picomatch@4.0.3)
       magic-string: 0.30.5
       outdent: 0.8.0
       picocolors: 1.1.1
@@ -17795,12 +17825,12 @@ snapshots:
     dependencies:
       '@medusajs/framework': 2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0)
 
-  '@medusajs/medusa@2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)':
+  '@medusajs/medusa@2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)':
     dependencies:
       '@inquirer/checkbox': 2.5.0
       '@inquirer/confirm': 2.0.17
       '@inquirer/input': 2.3.0
-      '@medusajs/admin-bundler': 2.14.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yaml@2.7.1)
+      '@medusajs/admin-bundler': 2.14.1(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yaml@2.7.1)
       '@medusajs/analytics': 2.14.1(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))
       '@medusajs/analytics-local': 2.14.1(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))
       '@medusajs/analytics-posthog': 2.14.1(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(posthog-node@4.18.0)
@@ -18036,7 +18066,7 @@ snapshots:
       ulid: 2.4.0
     optionalDependencies:
       '@medusajs/core-flows': 2.14.1(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))
-      '@medusajs/medusa': 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
+      '@medusajs/medusa': 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
     transitivePeerDependencies:
       - debug
       - supports-color
@@ -18052,12 +18082,12 @@ snapshots:
       ioredis: 5.9.0
       vite: 5.4.21(@types/node@20.17.47)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)
 
-  '@medusajs/types@2.12.2(ioredis@5.9.0)(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))':
+  '@medusajs/types@2.12.2(ioredis@5.9.0)(vite@5.4.21(@types/node@25.0.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))':
     dependencies:
       bignumber.js: 9.3.1
     optionalDependencies:
       ioredis: 5.9.0
-      vite: 7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
+      vite: 5.4.21(@types/node@25.0.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)
 
   '@medusajs/types@2.14.1(ioredis@5.9.0)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))':
     dependencies:
@@ -21559,7 +21589,7 @@ snapshots:
       '@medusajs/cli': 2.14.1(@types/node@24.10.1)(mysql2@3.15.3)
       '@medusajs/framework': 2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0)
       '@medusajs/icons': 2.14.1(react@19.2.3)
-      '@medusajs/medusa': 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
+      '@medusajs/medusa': 2.14.1(@medusajs/admin-sdk@2.14.1)(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/icons@2.14.1(react@19.2.3))(@medusajs/test-utils@2.14.1)(@medusajs/ui@4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(@swc/core@1.15.3(@swc/helpers@0.5.18))(@types/node@24.10.1)(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(awilix@12.0.5)(less@4.1.3)(lightningcss@1.30.2)(picomatch@4.0.3)(posthog-node@4.18.0)(react-dom@19.2.3(react@19.2.3))(react-router-dom@6.30.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(typescript@5.9.3)(yalc@1.0.0-pre.53)(yaml@2.7.1)
       '@medusajs/test-utils': 2.14.1(@medusajs/core-flows@2.14.1(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0)))(@medusajs/framework@2.14.1(@medusajs/cli@2.14.1(@types/node@24.10.1)(mysql2@3.15.3))(@types/node@24.10.1)(ioredis@5.9.0)(mysql2@3.15.3)(vite@5.4.21(@types/node@24.10.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1))(zod@4.2.0))(@medusajs/medusa@2.14.1)
       '@medusajs/ui': 4.1.8(@types/react-dom@19.2.3(@types/react@19.2.3))(@types/react@19.2.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
       '@mikro-orm/cli': 6.6.12(mysql2@3.15.3)(pg@8.20.0)
@@ -23460,6 +23490,15 @@ snapshots:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.12.10(@types/node@24.10.1)(typescript@5.9.3)
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
 
   '@vitest/mocker@4.0.18(msw@2.12.10(@types/node@25.0.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))':
     dependencies:
@@ -25673,7 +25712,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.1.1: {}
+  fdir@6.1.1(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -27777,6 +27818,32 @@ snapshots:
   msgpackr@1.11.8:
     optionalDependencies:
       msgpackr-extract: 3.0.3
+
+  msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@24.10.1)
+      '@mswjs/interceptors': 0.41.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.2.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
 
   msw@2.12.10(@types/node@25.0.3)(typescript@5.9.3):
     dependencies:
@@ -30611,6 +30678,41 @@ snapshots:
       stylus: 0.64.0
       terser: 5.44.1
 
+  vite@5.4.21(@types/node@25.0.3)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.55.1
+    optionalDependencies:
+      '@types/node': 25.0.3
+      fsevents: 2.3.3
+      less: 4.1.3
+      lightningcss: 1.30.2
+      sass: 1.84.0
+      stylus: 0.64.0
+      terser: 5.44.1
+    optional: true
+
+  vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.10.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      less: 4.1.3
+      lightningcss: 1.30.2
+      sass: 1.84.0
+      stylus: 0.64.0
+      terser: 5.44.1
+      tsx: 4.19.4
+      yaml: 2.7.1
+
   vite@7.3.1(@types/node@25.0.3)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:
       esbuild: 0.27.3
@@ -30630,6 +30732,45 @@ snapshots:
       terser: 5.44.1
       tsx: 4.19.4
       yaml: 2.7.1
+
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(less@4.1.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3))(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3))(vite@7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@24.10.1)(jiti@2.6.1)(less@4.1.3)(lightningcss@1.30.2)(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 24.10.1
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(less@4.1.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.0.3)(typescript@5.9.3))(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1):
     dependencies:


### PR DESCRIPTION
## Summary
- resolve the PR head branch from workflow_run payloads instead of falling back to the source environment branch
- pass that branch through new-engine-ctl reconciliation specs and zane-operator service reconciliation
- reject malformed build_stage_target payloads instead of silently dropping invalid values

## Validation
- bunx biome check --write on changed new-engine-ctl files and zane-inputs
- pnpm exec nx run new-engine-ctl:typecheck
- pnpm exec nx run new-engine-ctl:test
- bunx tsc --noEmit -p apps/zane-operator/tsconfig.json
- docker compose -f docker-compose.yaml config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--preview-git-branch` CLI parameter to configure the git branch for preview environment deployments
  * Preview deployments now support branch-specific git source synchronisation with improved GitHub integration

* **Tests**
  * Added comprehensive unit tests for GitHub event parsing and branch resolution
  * Added tests for preview runtime reconciliation with branch-specific configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->