### PR TITLE
fix(zane): always run preview teardown cleanup

### DIFF
--- a/.github/workflows/zaneops-preview-teardown.yml
+++ b/.github/workflows/zaneops-preview-teardown.yml
@@ -46,6 +46,8 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:
@@ -56,7 +58,26 @@ jobs:
         with:
           node-version: 24
 
+      - name: Fetch PR revisions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
+
+      - name: Resolve teardown scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          node apps/new-engine-ctl/dist/cli.js scope \
+            --lane preview \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
+            --preview-baseline-complete true
+
       - name: Validate teardown inputs
+        if: steps.scope.outputs.services_csv != ''
         env:
           ZANE_OPERATOR_BASE_URL: ${{ secrets.ZANEOPS_ZANE_OPERATOR_BASE_URL }}
           ZANE_OPERATOR_API_TOKEN: ${{ secrets.ZANEOPS_ZANE_OPERATOR_API_TOKEN }}
@@ -65,6 +86,7 @@ jobs:
         run: node apps/new-engine-ctl/dist/cli.js check-workflow-inputs --mode preview-teardown
 
       - name: Run preview teardown
+        if: steps.scope.outputs.services_csv != ''
         id: run_teardown
         continue-on-error: true
         env:
@@ -83,6 +105,9 @@ jobs:
           {
             echo "## Preview Teardown"
             echo "- PR: #${{ github.event.pull_request.number }}"
+            echo "- Scope services: ${{ steps.scope.outputs.services_csv || 'none' }}"
+            echo "- Scope projects: ${{ steps.scope.outputs.projects_csv || 'none' }}"
+            echo "- Skipped: ${{ steps.run_teardown.outcome == 'skipped' && 'true' || 'false' }}"
             echo "- Environment outcome: ${{ steps.run_teardown.outputs.environment_outcome || 'n/a' }}"
             echo "- Environment HTTP: ${{ steps.run_teardown.outputs.environment_http_code || 'n/a' }}"
             echo "- Environment name: ${{ steps.run_teardown.outputs.environment_name || 'n/a' }}"
@@ -95,7 +120,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail when teardown failed
-        if: steps.run_teardown.outcome != 'success'
+        if: steps.run_teardown.outcome == 'failure'
         run: |
           echo "Preview teardown failed and requires manual retry." >&2
           exit 1

--- a/.github/workflows/zaneops-preview-teardown.yml
+++ b/.github/workflows/zaneops-preview-teardown.yml
@@ -77,7 +77,6 @@ jobs:
             --preview-baseline-complete true
 
       - name: Validate teardown inputs
-        if: steps.scope.outputs.services_csv != ''
         env:
           ZANE_OPERATOR_BASE_URL: ${{ secrets.ZANEOPS_ZANE_OPERATOR_BASE_URL }}
           ZANE_OPERATOR_API_TOKEN: ${{ secrets.ZANEOPS_ZANE_OPERATOR_API_TOKEN }}
@@ -86,7 +85,6 @@ jobs:
         run: node apps/new-engine-ctl/dist/cli.js check-workflow-inputs --mode preview-teardown
 
       - name: Run preview teardown
-        if: steps.scope.outputs.services_csv != ''
         id: run_teardown
         continue-on-error: true
         env:

--- a/.github/workflows/zaneops-preview-teardown.yml
+++ b/.github/workflows/zaneops-preview-teardown.yml
@@ -58,24 +58,6 @@ jobs:
         with:
           node-version: 24
 
-      - name: Fetch PR revisions
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: git fetch --no-tags --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
-
-      - name: Resolve teardown scope
-        id: scope
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          node apps/new-engine-ctl/dist/cli.js scope \
-            --lane preview \
-            --base-sha "$BASE_SHA" \
-            --head-sha "$HEAD_SHA" \
-            --preview-baseline-complete true
-
       - name: Validate teardown inputs
         env:
           ZANE_OPERATOR_BASE_URL: ${{ secrets.ZANEOPS_ZANE_OPERATOR_BASE_URL }}
@@ -103,8 +85,6 @@ jobs:
           {
             echo "## Preview Teardown"
             echo "- PR: #${{ github.event.pull_request.number }}"
-            echo "- Scope services: ${{ steps.scope.outputs.services_csv || 'none' }}"
-            echo "- Scope projects: ${{ steps.scope.outputs.projects_csv || 'none' }}"
             echo "- Skipped: ${{ steps.run_teardown.outcome == 'skipped' && 'true' || 'false' }}"
             echo "- Environment outcome: ${{ steps.run_teardown.outputs.environment_outcome || 'n/a' }}"
             echo "- Environment HTTP: ${{ steps.run_teardown.outputs.environment_http_code || 'n/a' }}"

--- a/.github/workflows/zaneops-preview-teardown.yml
+++ b/.github/workflows/zaneops-preview-teardown.yml
@@ -46,8 +46,6 @@ jobs:
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- resolve preview scope before PR-close teardown calls Zane
- skip operator/DB teardown when the PR did not affect any preview services
- only fail the workflow when the teardown step actually ran and failed

## Validation
- /Users/satan/side/experiments/skills/actionlint/scripts/run_actionlint.sh /Users/satan/work/new-engine-pipeline-stability --files .github/workflows/zaneops-preview-teardown.yml
- pnpm exec nx run new-engine-ctl:build
- node apps/new-engine-ctl/dist/cli.js scope --lane preview --base-sha 86b803cf45f69615939a82d1d5afa8a463fcbc51 --head-sha 7e08aadf3c01e2ace457fd5460d39f9796ce0b32 --preview-baseline-complete true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved preview teardown process to ensure complete repository context during cleanup.
  * Enhanced job summaries now report whether teardown ran or was skipped.
  * Refined failure gating so the pipeline flags a failure only when the teardown actually fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->