### PR TITLE
fix(ci): pass Storybook baseline CLI args directly

### DIFF
--- a/.github/workflows/storybook-a11y-baseline.yml
+++ b/.github/workflows/storybook-a11y-baseline.yml
@@ -111,7 +111,7 @@ jobs:
             echo "Storybook server failed to start within timeout." >&2
             exit 1
           fi
-          pnpm -C libs/ui run test-storybook -- --url "http://127.0.0.1:6006/?globals=theme:${{ matrix.theme }}" --config-dir .storybook --maxWorkers 2 --testTimeout 60000
+          pnpm -C libs/ui exec test-storybook --url "http://127.0.0.1:6006/?globals=theme:${{ matrix.theme }}" --config-dir .storybook --maxWorkers 2 --testTimeout 60000
 
       - name: Upload baseline report (${{ matrix.theme }})
         if: always() && hashFiles(format('libs/ui/a11y-report/{0}/report.json', matrix.theme)) != ''


### PR DESCRIPTION
## Summary
- call Storybook test-runner through pnpm exec in the baseline workflow
- avoid passing --url/--config-dir through the Jest separator path

## Why
Master Storybook A11y Baseline failed after #383 with: Unrecognized CLI Parameters ["url", "config-dir"]. The previous command produced test-storybook -- --url ..., so those flags were parsed by Jest instead of the Storybook runner.

## Validation
- /Users/satan/side/experiments/skills/actionlint/scripts/run_actionlint.sh /Users/satan/work/new-engine-pipeline-stability --files .github/workflows/storybook-a11y-baseline.yml
- pnpm -C libs/ui exec test-storybook --help