### PR TITLE
[codex] chore(medusa): colocate module test runner

### DIFF
--- a/apps/medusa-be/package.json
+++ b/apps/medusa-be/package.json
@@ -21,7 +21,7 @@
     "develop": "medusa develop",
     "dev": "medusa develop",
     "test:integration:http": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --forceExit",
-    "test:integration:modules": "node ../../scripts/ci/run-medusa-module-tests.mjs",
+    "test:integration:modules": "node ./scripts/run-module-tests.mjs",
     "test:e2e:http": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand integration-tests/http/*.spec.ts",
     "test:e2e:http:debug": "cross-env TEST_TYPE=integration:http NODE_OPTIONS=--experimental-vm-modules jest --silent=false --runInBand --detectOpenHandles integration-tests/http/*.spec.ts",
     "test:unit": "cross-env TEST_TYPE=unit NODE_OPTIONS=--experimental-vm-modules jest --silent --runInBand --forceExit",

--- a/apps/medusa-be/scripts/run-module-tests.mjs
+++ b/apps/medusa-be/scripts/run-module-tests.mjs
@@ -6,11 +6,9 @@ import path from "node:path"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
-const repoRoot = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "../.."
-)
-const medusaBeDir = path.join(repoRoot, "apps/medusa-be")
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const medusaBeDir = path.resolve(scriptDir, "..")
+const repoRoot = path.resolve(medusaBeDir, "../..")
 
 const dbEnv = {
   DB_HOST: process.env.DB_HOST || "127.0.0.1",


### PR DESCRIPTION
## Summary

Move the Medusa module integration test runner out of the repository-level `scripts/ci` folder and into `apps/medusa-be/scripts`.

The runner is app-specific: it hardcodes Medusa backend paths, prepares Medusa module-test environment variables, starts a fallback Postgres container only for GitHub Actions, and runs the Medusa backend Jest module tests. Keeping it next to `apps/medusa-be/package.json` makes the ownership clearer and avoids presenting it as a shared workspace CI utility.

## Changes

- Renamed `scripts/ci/run-medusa-module-tests.mjs` to `apps/medusa-be/scripts/run-module-tests.mjs`.
- Updated `apps/medusa-be/package.json` so `test:integration:modules` calls the colocated script.
- Adjusted path derivation in the runner to resolve `medusaBeDir` from its own script directory and derive `repoRoot` from there.

## Validation

- `bunx biome check --write apps/medusa-be/package.json apps/medusa-be/scripts/run-module-tests.mjs`
- `node --check apps/medusa-be/scripts/run-module-tests.mjs`

I did not run the full module integration test locally because it requires a Postgres-backed Medusa test environment; CI should exercise the unchanged `pnpm --filter medusa-be test:integration:modules` entrypoint.
