### PR TITLE
Refactor zane-operator reconciliation inputs to Zod

### DIFF
--- a/apps/zane-operator/package.json
+++ b/apps/zane-operator/package.json
@@ -8,6 +8,13 @@
     "start": "bun src/main.ts",
     "create:dev-user": "bun src/cli.ts create-dev-user",
     "build": "bun build src/main.ts --compile --outfile dist/zane-operator",
-    "typecheck": "bunx tsc --noEmit -p tsconfig.json"
+    "typecheck": "bunx tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "zod": "^4.1.13"
+  },
+  "devDependencies": {
+    "vitest": "^4.0.18"
   }
 }

--- a/apps/zane-operator/project.json
+++ b/apps/zane-operator/project.json
@@ -21,6 +21,13 @@
         "command": "bun run typecheck"
       }
     },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/zane-operator",
+        "command": "pnpm run test"
+      }
+    },
     "dev": {
       "executor": "nx:run-commands",
       "cache": false,

--- a/apps/zane-operator/src/__tests__/bun-stub.ts
+++ b/apps/zane-operator/src/__tests__/bun-stub.ts
@@ -1,0 +1,3 @@
+export class SQL {
+  readonly unavailable = true
+}

--- a/apps/zane-operator/src/zane-inputs.test.ts
+++ b/apps/zane-operator/src/zane-inputs.test.ts
@@ -26,7 +26,7 @@ test("normalizes service reconciliation specs", () => {
           branch_name: null,
         },
         builder: {
-          sync_from_source: "true",
+          sync_from_source: true,
           build_stage_target: null,
         },
         healthcheck: {
@@ -47,7 +47,7 @@ test("normalizes service reconciliation specs", () => {
         commit_sha: "HEAD",
       },
       builder: {
-        sync_from_source: false,
+        sync_from_source: true,
         build_stage_target: null,
       },
       healthcheck: {
@@ -55,6 +55,23 @@ test("normalizes service reconciliation specs", () => {
       },
     },
   ])
+})
+
+test("rejects malformed service reconciliation sync flags", () => {
+  expect(() =>
+    parseResolveEnvironmentInput({
+      ...resolveEnvironmentPayload,
+      service_specs: [
+        {
+          service_id: "medusa-be",
+          service_slug: "api",
+          builder: {
+            sync_from_source: "true",
+          },
+        },
+      ],
+    })
+  ).toThrow(BadRequestError)
 })
 
 test("defaults missing service reconciliation specs to an empty list", () => {

--- a/apps/zane-operator/src/zane-inputs.test.ts
+++ b/apps/zane-operator/src/zane-inputs.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "vitest"
+
+import { BadRequestError } from "./db"
+import { parseResolveEnvironmentInput } from "./zane-inputs"
+
+const resolveEnvironmentPayload = {
+  lane: "preview",
+  project_slug: "storefront",
+  environment_name: "pr-123",
+  source_environment_name: "production",
+  expected_preview_service_slugs: [],
+  excluded_preview_service_slugs: [],
+  targets: [],
+  env_overrides: [],
+}
+
+test("normalizes service reconciliation specs", () => {
+  const parsed = parseResolveEnvironmentInput({
+    ...resolveEnvironmentPayload,
+    service_specs: [
+      {
+        service_id: " medusa-be ",
+        service_slug: " api ",
+        git_source: {
+          sync_from_source: true,
+          branch_name: null,
+        },
+        builder: {
+          sync_from_source: "true",
+          build_stage_target: null,
+        },
+        healthcheck: {
+          sync_from_source: true,
+        },
+        resource_limits: null,
+        ignored: "value",
+      },
+    ],
+  })
+
+  expect(parsed.serviceSpecs).toEqual([
+    {
+      service_id: "medusa-be",
+      service_slug: "api",
+      git_source: {
+        sync_from_source: true,
+        commit_sha: "HEAD",
+      },
+      builder: {
+        sync_from_source: false,
+        build_stage_target: null,
+      },
+      healthcheck: {
+        sync_from_source: true,
+      },
+    },
+  ])
+})
+
+test("defaults missing service reconciliation specs to an empty list", () => {
+  expect(
+    parseResolveEnvironmentInput(resolveEnvironmentPayload).serviceSpecs
+  ).toEqual([])
+})
+
+test("rejects invalid service reconciliation specs", () => {
+  expect(() =>
+    parseResolveEnvironmentInput({
+      ...resolveEnvironmentPayload,
+      service_specs: [
+        {
+          service_id: "medusa-be",
+          service_slug: "",
+        },
+      ],
+    })
+  ).toThrow(BadRequestError)
+})

--- a/apps/zane-operator/src/zane-inputs.ts
+++ b/apps/zane-operator/src/zane-inputs.ts
@@ -27,10 +27,7 @@ type JsonRecord = Record<string, unknown>
 
 const nonEmptyTrimmedStringSchema = z.string().trim().min(1, "cannot be empty")
 
-const strictTrueBooleanSchema = z.preprocess(
-  (value) => value === true,
-  z.boolean()
-)
+const strictTrueBooleanSchema = z.literal(true)
 
 const optionalTrimmedStringSchema = z.preprocess(
   (value) => (value == null ? undefined : value),

--- a/apps/zane-operator/src/zane-inputs.ts
+++ b/apps/zane-operator/src/zane-inputs.ts
@@ -1,3 +1,5 @@
+import { z } from "zod"
+
 import { BadRequestError } from "./db"
 import type {
   ArchiveEnvironmentInput,
@@ -22,6 +24,97 @@ import type {
 } from "./zane-contract"
 
 type JsonRecord = Record<string, unknown>
+
+const nonEmptyTrimmedStringSchema = z.string().trim().min(1, "cannot be empty")
+
+const strictTrueBooleanSchema = z.preprocess(
+  (value) => value === true,
+  z.boolean()
+)
+
+const optionalTrimmedStringSchema = z.preprocess(
+  (value) => (value == null ? undefined : value),
+  nonEmptyTrimmedStringSchema.optional()
+)
+
+const optionalNullableTrimmedStringSchema = z.preprocess(
+  (value) => (value === undefined ? undefined : value),
+  nonEmptyTrimmedStringSchema.nullable().optional()
+)
+
+const serviceReconciliationGitSourceSchema = z.object({
+  sync_from_source: strictTrueBooleanSchema,
+  branch_name: optionalTrimmedStringSchema,
+  commit_sha: z.preprocess(
+    (value) => (value == null ? "HEAD" : value),
+    nonEmptyTrimmedStringSchema
+  ),
+})
+
+const serviceReconciliationBuilderSchema = z.object({
+  sync_from_source: strictTrueBooleanSchema,
+  build_stage_target: optionalNullableTrimmedStringSchema,
+})
+
+const serviceReconciliationSyncFlagSchema = z.object({
+  sync_from_source: strictTrueBooleanSchema,
+})
+
+const serviceReconciliationSpecSchema = z.object({
+  service_id: nonEmptyTrimmedStringSchema,
+  service_slug: nonEmptyTrimmedStringSchema,
+  git_source: z.preprocess(
+    (value) => (value == null ? undefined : value),
+    serviceReconciliationGitSourceSchema.optional()
+  ),
+  builder: z.preprocess(
+    (value) => (value == null ? undefined : value),
+    serviceReconciliationBuilderSchema.optional()
+  ),
+  healthcheck: z.preprocess(
+    (value) => (value == null ? undefined : value),
+    serviceReconciliationSyncFlagSchema.optional()
+  ),
+  resource_limits: z.preprocess(
+    (value) => (value == null ? undefined : value),
+    serviceReconciliationSyncFlagSchema.optional()
+  ),
+})
+
+const serviceReconciliationSpecsSchema = z.array(
+  serviceReconciliationSpecSchema
+)
+
+function formatZodPath(label: string, path: PropertyKey[]): string {
+  let current = label
+
+  for (const part of path) {
+    if (typeof part === "number") {
+      current = `${current}[${String(part)}]`
+      continue
+    }
+
+    current = `${current}.${String(part)}`
+  }
+
+  return current
+}
+
+function parseZodInput<T>(
+  schema: z.ZodType<T>,
+  value: unknown,
+  label: string
+): T {
+  const result = schema.safeParse(value)
+  if (result.success) {
+    return result.data
+  }
+
+  const issue = result.error.issues[0]
+  const path = issue ? formatZodPath(label, issue.path) : label
+  const message = issue?.message ?? "is invalid"
+  throw new BadRequestError(`${path} ${message}`)
+}
 
 function assertObject(value: unknown, label: string): JsonRecord {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -395,107 +488,7 @@ function parseServiceReconciliationSpecs(
     return []
   }
 
-  if (!Array.isArray(value)) {
-    throw new BadRequestError(`${label} must be an array`)
-  }
-
-  return value.map((item, index) => {
-    const object = assertObject(item, `${label}[${index}]`)
-    const gitSource = parseServiceReconciliationGitSource(
-      object.git_source,
-      `${label}[${index}].git_source`
-    )
-    const builder =
-      object.builder == null
-        ? undefined
-        : (() => {
-            const builderObject = assertObject(
-              object.builder,
-              `${label}[${index}].builder`
-            )
-            return {
-              sync_from_source: builderObject.sync_from_source === true,
-              build_stage_target: parseOptionalNullableString(
-                builderObject.build_stage_target,
-                `${label}[${index}].builder.build_stage_target`
-              ),
-            }
-          })()
-    const healthcheck =
-      object.healthcheck == null
-        ? undefined
-        : (() => {
-            const healthcheckObject = assertObject(
-              object.healthcheck,
-              `${label}[${index}].healthcheck`
-            )
-            return {
-              sync_from_source: healthcheckObject.sync_from_source === true,
-            }
-          })()
-    const resourceLimits =
-      object.resource_limits == null
-        ? undefined
-        : (() => {
-            const resourceLimitsObject = assertObject(
-              object.resource_limits,
-              `${label}[${index}].resource_limits`
-            )
-            return {
-              sync_from_source: resourceLimitsObject.sync_from_source === true,
-            }
-          })()
-
-    return {
-      service_id: assertString(
-        object.service_id,
-        `${label}[${index}].service_id`
-      ),
-      service_slug: assertString(
-        object.service_slug,
-        `${label}[${index}].service_slug`
-      ),
-      ...(gitSource ? { git_source: gitSource } : {}),
-      ...(builder ? { builder } : {}),
-      ...(healthcheck ? { healthcheck } : {}),
-      ...(resourceLimits ? { resource_limits: resourceLimits } : {}),
-    }
-  })
-}
-
-function parseOptionalNullableString(
-  value: unknown,
-  label: string
-): string | null | undefined {
-  if (typeof value === "undefined") {
-    return
-  }
-
-  if (value === null) {
-    return null
-  }
-
-  return assertString(value, label)
-}
-
-function parseServiceReconciliationGitSource(
-  value: unknown,
-  label: string
-): ZaneServiceReconciliationSpec["git_source"] {
-  if (value == null) {
-    return
-  }
-
-  const object = assertObject(value, label)
-  return {
-    sync_from_source: object.sync_from_source === true,
-    branch_name: assertOptionalString(
-      object.branch_name,
-      `${label}.branch_name`
-    ),
-    commit_sha:
-      assertOptionalString(object.commit_sha, `${label}.commit_sha`) ?? "HEAD",
-  }
+  return parseZodInput(serviceReconciliationSpecsSchema, value, label)
 }
 
 export function parseResolveEnvironmentInput(

--- a/apps/zane-operator/vitest.config.ts
+++ b/apps/zane-operator/vitest.config.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath, URL } from "node:url"
+
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      bun: fileURLToPath(
+        new URL("./src/__tests__/bun-stub.ts", import.meta.url)
+      ),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,7 +402,15 @@ importers:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.4.0)(less@4.1.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@24.10.1)(typescript@5.9.3))(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
 
-  apps/zane-operator: {}
+  apps/zane-operator:
+    dependencies:
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
+    devDependencies:
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(less@4.1.3)(lightningcss@1.30.2)(msw@2.12.10(@types/node@25.0.3)(typescript@5.9.3))(sass@1.84.0)(stylus@0.64.0)(terser@5.44.1)(tsx@4.19.4)(yaml@2.7.1)
 
   libs/analytics:
     dependencies:


### PR DESCRIPTION
## Summary
- replace manual service_specs reconciliation parsing with Zod schemas while preserving existing null/default behavior
- add a Vitest target for zane-operator with a Bun SQL stub for parser unit tests
- cover service_specs normalization, defaulting, and validation errors

## Verification
- bunx biome check --write apps/zane-operator/package.json apps/zane-operator/project.json apps/zane-operator/src/zane-inputs.ts apps/zane-operator/src/zane-inputs.test.ts apps/zane-operator/src/__tests__/bun-stub.ts apps/zane-operator/vitest.config.ts pnpm-lock.yaml
- bunx nx run zane-operator:typecheck
- bunx nx run zane-operator:test
- bunx nx run zane-operator:build
- pnpm install --frozen-lockfile --offline
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Established a comprehensive test suite for input validation and service configuration processing.
  * Configured testing infrastructure with Vitest.

* **Refactor**
  * Enhanced input validation mechanisms for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->