### PR TITLE
Fix Docker builds with pnpm patches

### DIFF
--- a/docker/development/medusa-be/Dockerfile
+++ b/docker/development/medusa-be/Dockerfile
@@ -32,6 +32,7 @@ ENV NODE_ENV=development
 ENV DATABASE_TYPE=postgres
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 RUN --mount=type=cache,id=pnpm-store-medusa-ci-dev,target=/pnpm/store \
     corepack install && \
     pnpm fetch --store-dir=/pnpm/store --frozen-lockfile
@@ -54,6 +55,7 @@ FROM base AS build
 
 # Prime pnpm store from lockfile so dependency downloads are cached across source-only changes.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 RUN --mount=type=cache,id=pnpm-store-medusa,target=/pnpm/store \
     corepack install && \
     pnpm fetch --store-dir=/pnpm/store --frozen-lockfile

--- a/docker/development/n1/Dockerfile
+++ b/docker/development/n1/Dockerfile
@@ -38,6 +38,7 @@ ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 RUN --mount=type=cache,id=pnpm-store-n1-ci-dev,target=/pnpm/store \
     corepack install && \
     pnpm fetch --store-dir=/pnpm/store --frozen-lockfile
@@ -66,6 +67,7 @@ FROM base AS build
 
 # Prime pnpm store from lockfile so dependency downloads are cached across source-only changes.
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 RUN --mount=type=cache,id=pnpm-store-n1,target=/pnpm/store \
     corepack install && \
     pnpm fetch --store-dir=/pnpm/store --frozen-lockfile

--- a/docker/development/payload/Dockerfile
+++ b/docker/development/payload/Dockerfile
@@ -27,6 +27,7 @@ FROM base AS ci-dev
 ENV NODE_ENV=development
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 COPY apps/payload/package.json apps/payload/package.json
 RUN --mount=type=cache,id=pnpm-store-payload-ci-dev,target=/pnpm/store \
     corepack install && \
@@ -67,6 +68,7 @@ ENV S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
 ENV S3_SECRET_ACCESS_KEY=${S3_SECRET_ACCESS_KEY}
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 COPY apps/payload/package.json apps/payload/package.json
 RUN --mount=type=cache,id=pnpm-store-payload,target=/pnpm/store \
     corepack install && \

--- a/docker/development/zane-operator/Dockerfile
+++ b/docker/development/zane-operator/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /var/www
 ENV NODE_ENV=production
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
+COPY patches ./patches
 COPY apps/zane-operator/package.json apps/zane-operator/package.json
 RUN --mount=type=cache,id=pnpm-store-zane-operator,target=/pnpm/store \
   corepack install \


### PR DESCRIPTION
## Summary
- copy root `patches/` into Docker build stages before `pnpm fetch` or root-lockfile installs
- cover Medusa, N1, Payload, and zane-operator Dockerfiles so root `patchedDependencies` are available consistently

## Validation
- `docker build --progress=plain --target build -f docker/development/medusa-be/Dockerfile .`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configurations across all services (Medusa backend, N1 frontend, Payload CMS, and Zane Operator) to include the patches directory in build stages. This ensures patch files are available during dependency installation and build processes, enabling consistent builds across containerised environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->