### PR TITLE
[codex] Add order expedition bulk actions

### DIFF
--- a/apps/medusa-be/src/admin/routes/order-expedition/page.tsx
+++ b/apps/medusa-be/src/admin/routes/order-expedition/page.tsx
@@ -1,0 +1,603 @@
+import { defineRouteConfig } from "@medusajs/admin-sdk"
+import { DocumentSeries } from "@medusajs/icons"
+import {
+  Badge,
+  Button,
+  Checkbox,
+  Container,
+  Heading,
+  Select,
+  Table,
+  Text,
+  toast,
+} from "@medusajs/ui"
+import { useQuery } from "@tanstack/react-query"
+import { useMemo, useState } from "react"
+import { sdk } from "../../lib/sdk"
+
+type CarrierKey = "ppl" | "packeta" | "other"
+type TargetStatus = "completed" | "archived" | "canceled"
+
+type CarrierOption = {
+  label: string
+  value: CarrierKey
+}
+
+type ResolvedCarrier = CarrierOption & {
+  shipping_method_name?: string
+  shipping_option_id?: string
+}
+
+type ExpeditionItem = {
+  id?: string | null
+  title: string
+  quantity: number
+  sku?: string | null
+  variant?: string | null
+}
+
+type ExpeditionOrder = {
+  id: string
+  order_display_id: string
+  customer: string
+  email?: string | null
+  delivery_address: string[]
+  carrier: ResolvedCarrier
+  payment_method: string
+  payment_status?: string | null
+  status?: string | null
+  items: ExpeditionItem[]
+}
+
+type OrdersResponse = {
+  orders: ExpeditionOrder[]
+  count: number
+  limit: number
+  offset: number
+  carrier: CarrierKey | null
+}
+
+type CarriersResponse = {
+  carriers: CarrierOption[]
+}
+
+type BlockingOrder = {
+  id: string
+  order_display_id: string
+  reason: string
+}
+
+type StatusBlockedPayload = {
+  message?: string
+  blocked_orders?: BlockingOrder[]
+}
+
+const PAGE_SIZE = 50
+const ALL_CARRIERS = "all"
+
+const TARGET_STATUSES: Array<{ value: TargetStatus; label: string }> = [
+  { value: "completed", label: "Completed" },
+  { value: "archived", label: "Archived" },
+  { value: "canceled", label: "Canceled" },
+]
+
+function getOrderItemsSummary(order: ExpeditionOrder) {
+  if (!order.items.length) {
+    return "-"
+  }
+
+  return order.items
+    .slice(0, 3)
+    .map((item) => `${item.quantity}x ${item.sku || item.title}`)
+    .join(", ")
+}
+
+function getCarrierLabel(order: ExpeditionOrder) {
+  return order.carrier.shipping_method_name || order.carrier.label
+}
+
+function getErrorMessage(payload: unknown, fallback: string) {
+  if (typeof payload === "object" && payload !== null && "message" in payload) {
+    const message = (payload as { message?: unknown }).message
+    if (typeof message === "string") {
+      return message
+    }
+  }
+
+  return fallback
+}
+
+function getBlockingOrders(payload: unknown): BlockingOrder[] {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "blocked_orders" in payload &&
+    Array.isArray((payload as StatusBlockedPayload).blocked_orders)
+  ) {
+    return (payload as { blocked_orders: BlockingOrder[] }).blocked_orders
+  }
+
+  return []
+}
+
+async function downloadPdf(orderIds: string[]) {
+  const response = await fetch("/admin/order-expedition/pdf", {
+    body: JSON.stringify({
+      order_ids: orderIds,
+    }),
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  })
+
+  if (!response.ok) {
+    const payload: unknown = await response.json().catch(() => null)
+    throw new Error(
+      getErrorMessage(payload, "Failed to generate expedition PDF")
+    )
+  }
+
+  const blob = await response.blob()
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = `order-expedition-${new Date()
+    .toISOString()
+    .slice(0, 10)}.pdf`
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}
+
+async function updateStatus(orderIds: string[], targetStatus: TargetStatus) {
+  const response = await fetch("/admin/order-expedition/status", {
+    body: JSON.stringify({
+      order_ids: orderIds,
+      target_status: targetStatus,
+    }),
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  })
+
+  const payload: unknown = await response.json().catch(() => null)
+
+  if (!response.ok) {
+    return {
+      blockedOrders: getBlockingOrders(payload),
+      ok: false as const,
+      message: getErrorMessage(payload, "Failed to update order status"),
+    }
+  }
+
+  return {
+    blockedOrders: [],
+    ok: true as const,
+  }
+}
+
+type OrdersTableProps = {
+  allPageOrdersSelected: boolean
+  isLoading: boolean
+  onToggleOrder: (orderId: string) => void
+  onTogglePage: () => void
+  orders: ExpeditionOrder[]
+  selectedOrderIds: Set<string>
+  somePageOrdersSelected: boolean
+}
+
+function OrdersTable({
+  allPageOrdersSelected,
+  isLoading,
+  onToggleOrder,
+  onTogglePage,
+  orders,
+  selectedOrderIds,
+  somePageOrdersSelected,
+}: OrdersTableProps) {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell className="w-12">
+            <Checkbox
+              checked={
+                somePageOrdersSelected ? "indeterminate" : allPageOrdersSelected
+              }
+              disabled={orders.length === 0}
+              onCheckedChange={onTogglePage}
+            />
+          </Table.HeaderCell>
+          <Table.HeaderCell>Order</Table.HeaderCell>
+          <Table.HeaderCell>Customer</Table.HeaderCell>
+          <Table.HeaderCell>Carrier</Table.HeaderCell>
+          <Table.HeaderCell>Payment</Table.HeaderCell>
+          <Table.HeaderCell>Status</Table.HeaderCell>
+          <Table.HeaderCell>Items</Table.HeaderCell>
+          <Table.HeaderCell>Address</Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {isLoading ? (
+          <Table.Row>
+            <Table.Cell>Loading...</Table.Cell>
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+          </Table.Row>
+        ) : null}
+
+        {isLoading || orders.length ? null : (
+          <Table.Row>
+            <Table.Cell>No orders found.</Table.Cell>
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+            <Table.Cell />
+          </Table.Row>
+        )}
+
+        {orders.map((order) => (
+          <Table.Row key={order.id}>
+            <Table.Cell>
+              <Checkbox
+                checked={selectedOrderIds.has(order.id)}
+                onCheckedChange={() => onToggleOrder(order.id)}
+              />
+            </Table.Cell>
+            <Table.Cell className="whitespace-nowrap text-ui-fg-base">
+              {order.order_display_id}
+            </Table.Cell>
+            <Table.Cell className="max-w-[220px]">
+              <div className="flex flex-col">
+                <Text className="truncate" size="small">
+                  {order.customer}
+                </Text>
+                <Text className="truncate text-ui-fg-subtle" size="small">
+                  {order.email ?? "-"}
+                </Text>
+              </div>
+            </Table.Cell>
+            <Table.Cell className="whitespace-nowrap">
+              <Badge size="2xsmall">{getCarrierLabel(order)}</Badge>
+            </Table.Cell>
+            <Table.Cell className="whitespace-nowrap">
+              <div className="flex flex-col">
+                <Text size="small">{order.payment_method}</Text>
+                <Text className="text-ui-fg-subtle" size="small">
+                  {order.payment_status ?? "-"}
+                </Text>
+              </div>
+            </Table.Cell>
+            <Table.Cell className="whitespace-nowrap">
+              {order.status ?? "-"}
+            </Table.Cell>
+            <Table.Cell className="max-w-[260px] truncate">
+              {getOrderItemsSummary(order)}
+            </Table.Cell>
+            <Table.Cell className="max-w-[280px] truncate">
+              {order.delivery_address.join(", ") || "-"}
+            </Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  )
+}
+
+const OrderExpeditionPage = () => {
+  const [carrier, setCarrier] = useState<typeof ALL_CARRIERS | CarrierKey>(
+    ALL_CARRIERS
+  )
+  const [offset, setOffset] = useState(0)
+  const [selectedOrderIds, setSelectedOrderIds] = useState<Set<string>>(
+    new Set()
+  )
+  const [targetStatus, setTargetStatus] = useState<TargetStatus | "">("")
+  const [isPrinting, setIsPrinting] = useState(false)
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false)
+  const [isConfirmingStatus, setIsConfirmingStatus] = useState(false)
+  const [blockingOrders, setBlockingOrders] = useState<BlockingOrder[]>([])
+
+  const carriersQuery = useQuery({
+    queryFn: () =>
+      sdk.client.fetch<CarriersResponse>("/admin/order-expedition/carriers"),
+    queryKey: ["order-expedition-carriers"],
+  })
+
+  const ordersQuery = useQuery({
+    queryFn: () => {
+      const search = new URLSearchParams({
+        limit: String(PAGE_SIZE),
+        offset: String(offset),
+      })
+
+      if (carrier !== ALL_CARRIERS) {
+        search.set("carrier", carrier)
+      }
+
+      return sdk.client.fetch<OrdersResponse>(
+        `/admin/order-expedition/orders?${search}`
+      )
+    },
+    queryKey: ["order-expedition-orders", carrier, offset],
+  })
+
+  const orders = ordersQuery.data?.orders ?? []
+  const selectedOrderIdsList = useMemo(
+    () => [...selectedOrderIds],
+    [selectedOrderIds]
+  )
+  const allPageOrdersSelected =
+    orders.length > 0 && orders.every((order) => selectedOrderIds.has(order.id))
+  const somePageOrdersSelected =
+    orders.some((order) => selectedOrderIds.has(order.id)) &&
+    !allPageOrdersSelected
+  const selectedCount = selectedOrderIds.size
+  const count = ordersQuery.data?.count ?? 0
+  const pageIndex = Math.floor(offset / PAGE_SIZE)
+  const pageCount = Math.max(Math.ceil(count / PAGE_SIZE), 1)
+  const targetStatusLabel =
+    TARGET_STATUSES.find((status) => status.value === targetStatus)?.label ??
+    targetStatus
+
+  const handleCarrierChange = (value: string) => {
+    setCarrier(value as typeof ALL_CARRIERS | CarrierKey)
+    setOffset(0)
+    setSelectedOrderIds(new Set())
+    setIsConfirmingStatus(false)
+    setBlockingOrders([])
+  }
+
+  const handleTargetStatusChange = (value: string) => {
+    setTargetStatus(value as TargetStatus)
+    setIsConfirmingStatus(false)
+  }
+
+  const toggleOrder = (orderId: string) => {
+    setIsConfirmingStatus(false)
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(orderId)) {
+        next.delete(orderId)
+      } else {
+        next.add(orderId)
+      }
+      return next
+    })
+  }
+
+  const togglePage = () => {
+    setIsConfirmingStatus(false)
+    setSelectedOrderIds((prev) => {
+      const next = new Set(prev)
+      if (allPageOrdersSelected) {
+        for (const order of orders) {
+          next.delete(order.id)
+        }
+      } else {
+        for (const order of orders) {
+          next.add(order.id)
+        }
+      }
+      return next
+    })
+  }
+
+  const handlePrint = async () => {
+    if (!selectedOrderIdsList.length) {
+      return
+    }
+
+    setIsPrinting(true)
+    setBlockingOrders([])
+    try {
+      await downloadPdf(selectedOrderIdsList)
+      toast.success("Order expedition PDF generated")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to print PDF")
+    } finally {
+      setIsPrinting(false)
+    }
+  }
+
+  const requestStatusUpdate = () => {
+    if (!selectedOrderIdsList.length) {
+      return
+    }
+
+    if (!targetStatus) {
+      toast.error("Select a target status")
+      return
+    }
+
+    setIsConfirmingStatus(true)
+  }
+
+  const handleStatusUpdate = async () => {
+    if (!selectedOrderIdsList.length) {
+      return
+    }
+
+    if (!targetStatus) {
+      toast.error("Select a target status")
+      return
+    }
+
+    const nextStatus = targetStatus
+    setIsConfirmingStatus(false)
+    setIsUpdatingStatus(true)
+    setBlockingOrders([])
+    try {
+      const result = await updateStatus(selectedOrderIdsList, nextStatus)
+
+      if (!result.ok) {
+        setBlockingOrders(result.blockedOrders)
+        toast.error(result.message)
+        return
+      }
+
+      toast.success(`${selectedCount} order(s) updated`)
+      setSelectedOrderIds(new Set())
+      await ordersQuery.refetch()
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to update order status"
+      )
+    } finally {
+      setIsUpdatingStatus(false)
+    }
+  }
+
+  if (carriersQuery.error) {
+    throw carriersQuery.error
+  }
+
+  if (ordersQuery.error) {
+    throw ordersQuery.error
+  }
+
+  return (
+    <Container className="divide-y p-0">
+      <div className="flex flex-col gap-4 px-6 py-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <Heading level="h1">Order Expedition</Heading>
+          <Text className="text-ui-fg-subtle" size="small">
+            {selectedCount} selected
+          </Text>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Select onValueChange={handleCarrierChange} value={carrier}>
+            <Select.Trigger className="w-[160px]">
+              <Select.Value placeholder="Carrier" />
+            </Select.Trigger>
+            <Select.Content>
+              <Select.Item value={ALL_CARRIERS}>All carriers</Select.Item>
+              {(carriersQuery.data?.carriers ?? []).map((option) => (
+                <Select.Item key={option.value} value={option.value}>
+                  {option.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+
+          <Button
+            disabled={selectedCount === 0}
+            isLoading={isPrinting}
+            onClick={handlePrint}
+            size="small"
+            variant="secondary"
+          >
+            <DocumentSeries />
+            PDF
+          </Button>
+
+          <Select onValueChange={handleTargetStatusChange} value={targetStatus}>
+            <Select.Trigger className="w-[144px]">
+              <Select.Value placeholder="Status" />
+            </Select.Trigger>
+            <Select.Content>
+              {TARGET_STATUSES.map((status) => (
+                <Select.Item key={status.value} value={status.value}>
+                  {status.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select>
+
+          <Button
+            disabled={
+              selectedCount === 0 || !targetStatus || isConfirmingStatus
+            }
+            isLoading={isUpdatingStatus}
+            onClick={requestStatusUpdate}
+            size="small"
+          >
+            Apply status
+          </Button>
+        </div>
+      </div>
+
+      {isConfirmingStatus && targetStatus ? (
+        <div className="flex flex-col gap-3 bg-ui-bg-subtle px-6 py-4 md:flex-row md:items-center md:justify-between">
+          <Text size="small">
+            Change {selectedCount} selected order(s) to {targetStatusLabel}?
+          </Text>
+          <div className="flex items-center gap-2">
+            <Button
+              disabled={isUpdatingStatus}
+              onClick={() => setIsConfirmingStatus(false)}
+              size="small"
+              variant="secondary"
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={selectedCount === 0 || !targetStatus}
+              isLoading={isUpdatingStatus}
+              onClick={handleStatusUpdate}
+              size="small"
+            >
+              Confirm
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {blockingOrders.length ? (
+        <div className="flex flex-col gap-2 bg-ui-bg-subtle px-6 py-4">
+          <Text className="font-medium text-ui-fg-error">
+            Some orders could not be updated.
+          </Text>
+          <div className="flex flex-col gap-1">
+            {blockingOrders.map((order) => (
+              <Text key={`${order.id}-${order.reason}`} size="small">
+                {order.order_display_id}: {order.reason}
+              </Text>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <OrdersTable
+        allPageOrdersSelected={allPageOrdersSelected}
+        isLoading={ordersQuery.isLoading}
+        onToggleOrder={toggleOrder}
+        onTogglePage={togglePage}
+        orders={orders}
+        selectedOrderIds={selectedOrderIds}
+        somePageOrdersSelected={somePageOrdersSelected}
+      />
+
+      <Table.Pagination
+        canNextPage={offset + PAGE_SIZE < count}
+        canPreviousPage={offset > 0}
+        count={count}
+        nextPage={() => setOffset((prev) => prev + PAGE_SIZE)}
+        pageCount={pageCount}
+        pageIndex={pageIndex}
+        pageSize={PAGE_SIZE}
+        previousPage={() => setOffset((prev) => Math.max(0, prev - PAGE_SIZE))}
+      />
+    </Container>
+  )
+}
+
+export const config = defineRouteConfig({
+  icon: DocumentSeries,
+  label: "Order Expedition",
+})
+
+export default OrderExpeditionPage

--- a/apps/medusa-be/src/api/admin/order-expedition/carriers/__tests__/route.unit.spec.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/carriers/__tests__/route.unit.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest"
+
+const createMockResponse = () => ({
+  json: vi.fn().mockReturnThis(),
+})
+
+describe("GET /admin/order-expedition/carriers", () => {
+  it("returns supported carrier options", async () => {
+    const { GET } = await import("../route")
+    const res = createMockResponse()
+
+    await GET({} as never, res as never)
+
+    expect(res.json).toHaveBeenCalledWith({
+      carriers: [
+        { label: "PPL", value: "ppl" },
+        { label: "Packeta", value: "packeta" },
+        { label: "Other", value: "other" },
+      ],
+    })
+  })
+})

--- a/apps/medusa-be/src/api/admin/order-expedition/carriers/route.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/carriers/route.ts
@@ -1,0 +1,8 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import { ORDER_EXPEDITION_CARRIER_OPTIONS } from "../../../../utils/order-expedition"
+
+export async function GET(_req: MedusaRequest, res: MedusaResponse) {
+  res.json({
+    carriers: ORDER_EXPEDITION_CARRIER_OPTIONS,
+  })
+}

--- a/apps/medusa-be/src/api/admin/order-expedition/middlewares.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/middlewares.ts
@@ -1,0 +1,32 @@
+import { validateAndTransformQuery } from "@medusajs/framework"
+import type { MiddlewareRoute } from "@medusajs/framework/http"
+import { validateAndTransformBody } from "@medusajs/framework/http"
+import {
+  GetAdminOrderExpeditionOrdersSchema,
+  PostAdminOrderExpeditionPdfSchema,
+  PostAdminOrderExpeditionStatusSchema,
+} from "./validators"
+
+export const adminOrderExpeditionRoutesMiddlewares: MiddlewareRoute[] = [
+  {
+    methods: ["GET"],
+    matcher: "/admin/order-expedition/orders",
+    middlewares: [
+      validateAndTransformQuery(GetAdminOrderExpeditionOrdersSchema, {
+        isList: true,
+      }),
+    ],
+  },
+  {
+    methods: ["POST"],
+    matcher: "/admin/order-expedition/pdf",
+    middlewares: [validateAndTransformBody(PostAdminOrderExpeditionPdfSchema)],
+  },
+  {
+    methods: ["POST"],
+    matcher: "/admin/order-expedition/status",
+    middlewares: [
+      validateAndTransformBody(PostAdminOrderExpeditionStatusSchema),
+    ],
+  },
+]

--- a/apps/medusa-be/src/api/admin/order-expedition/orders/__tests__/route.unit.spec.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/orders/__tests__/route.unit.spec.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@medusajs/framework/utils", () => ({
+  ContainerRegistrationKeys: {
+    QUERY: "query",
+  },
+}))
+
+const createMockResponse = () => ({
+  json: vi.fn().mockReturnThis(),
+})
+
+const createMockRequest = (
+  validatedQuery: Record<string, unknown>,
+  graph: ReturnType<typeof vi.fn>
+) => ({
+  scope: {
+    resolve: vi.fn(() => ({ graph })),
+  },
+  validatedQuery,
+})
+
+describe("GET /admin/order-expedition/orders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns an unfiltered page of orders", async () => {
+    const { GET } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "order_1",
+          display_id: 1001,
+          status: "pending",
+          shipping_methods: [{ name: "PPL ParcelShop" }],
+        },
+      ],
+      metadata: {
+        count: 1,
+      },
+    })
+    const req = createMockRequest({ limit: 50, offset: 0 }, graph)
+    const res = createMockResponse()
+
+    await GET(req, res)
+
+    expect(graph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "order",
+        pagination: {
+          skip: 0,
+          take: 50,
+        },
+      })
+    )
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        carrier: null,
+        count: 1,
+        limit: 50,
+        offset: 0,
+        orders: [
+          expect.objectContaining({
+            carrier: expect.objectContaining({ value: "ppl" }),
+            id: "order_1",
+            order_display_id: "#1001",
+          }),
+        ],
+      })
+    )
+  })
+
+  it("carrier filtering only narrows visible rows", async () => {
+    const { GET } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "order_1",
+          display_id: 1001,
+          shipping_methods: [{ name: "PPL" }],
+          status: "pending",
+        },
+        {
+          id: "order_2",
+          display_id: 1002,
+          shipping_methods: [{ name: "Packeta" }],
+          status: "pending",
+        },
+      ],
+      metadata: {
+        count: 2,
+      },
+    })
+    const req = createMockRequest(
+      { carrier: "packeta", limit: 50, offset: 0 },
+      graph
+    )
+    const res = createMockResponse()
+
+    await GET(req, res)
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        carrier: "packeta",
+        count: 1,
+        orders: [
+          expect.objectContaining({
+            id: "order_2",
+            order_display_id: "#1002",
+          }),
+        ],
+      })
+    )
+  })
+})

--- a/apps/medusa-be/src/api/admin/order-expedition/orders/route.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/orders/route.ts
@@ -1,0 +1,119 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { Query } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  ORDER_EXPEDITION_DEFAULT_LIMIT,
+  ORDER_EXPEDITION_ORDER_FIELDS,
+  type OrderExpeditionCarrierKey,
+  type OrderExpeditionRawOrder,
+  orderMatchesExpeditionCarrier,
+  toOrderExpeditionDto,
+} from "../../../../utils/order-expedition"
+import type { GetAdminOrderExpeditionOrdersSchemaType } from "../validators"
+
+type OrderGraphResult = Awaited<ReturnType<Query["graph"]>>
+
+const ORDER_EXPEDITION_SCAN_BATCH_SIZE = 100
+
+export async function GET(req: MedusaRequest, res: MedusaResponse) {
+  const query = req.scope.resolve<Query>(ContainerRegistrationKeys.QUERY)
+  const { carrier, limit, offset } =
+    req.validatedQuery as GetAdminOrderExpeditionOrdersSchemaType
+  const normalizedLimit = limit ?? ORDER_EXPEDITION_DEFAULT_LIMIT
+  const normalizedOffset = offset ?? 0
+
+  const result = carrier
+    ? await fetchCarrierFilteredOrders(
+        query,
+        carrier,
+        normalizedLimit,
+        normalizedOffset
+      )
+    : await fetchOrders(query, normalizedLimit, normalizedOffset)
+
+  res.json({
+    orders: result.orders.map(toOrderExpeditionDto),
+    count: result.count,
+    offset: normalizedOffset,
+    limit: normalizedLimit,
+    carrier: carrier ?? null,
+  })
+}
+
+async function fetchOrders(
+  query: Query,
+  limit: number,
+  offset: number
+): Promise<{ orders: OrderExpeditionRawOrder[]; count: number }> {
+  const { data: orders, metadata } = await query.graph({
+    entity: "order",
+    fields: ORDER_EXPEDITION_ORDER_FIELDS,
+    pagination: {
+      skip: offset,
+      take: limit,
+    },
+  })
+
+  return {
+    orders: orders as OrderExpeditionRawOrder[],
+    count: metadata?.count ?? orders.length,
+  }
+}
+
+async function fetchCarrierFilteredOrders(
+  query: Query,
+  carrier: OrderExpeditionCarrierKey,
+  limit: number,
+  offset: number
+): Promise<{ orders: OrderExpeditionRawOrder[]; count: number }> {
+  const orders: OrderExpeditionRawOrder[] = []
+  let count = 0
+  let scanOffset = 0
+
+  while (true) {
+    const batch = await fetchOrderBatch(query, scanOffset)
+
+    if (!batch.orders.length) {
+      break
+    }
+
+    for (const order of batch.orders) {
+      if (!orderMatchesExpeditionCarrier(order, carrier)) {
+        continue
+      }
+
+      if (count >= offset && orders.length < limit) {
+        orders.push(order)
+      }
+
+      count += 1
+    }
+
+    scanOffset += ORDER_EXPEDITION_SCAN_BATCH_SIZE
+
+    if (batch.totalCount <= scanOffset) {
+      break
+    }
+  }
+
+  return { orders, count }
+}
+
+async function fetchOrderBatch(
+  query: Query,
+  offset: number
+): Promise<{ orders: OrderExpeditionRawOrder[]; totalCount: number }> {
+  const { data: orders, metadata } = (await query.graph({
+    entity: "order",
+    fields: ORDER_EXPEDITION_ORDER_FIELDS,
+    pagination: {
+      skip: offset,
+      take: ORDER_EXPEDITION_SCAN_BATCH_SIZE,
+    },
+  })) as OrderGraphResult
+
+  return {
+    orders: orders as OrderExpeditionRawOrder[],
+    totalCount: metadata?.count ?? offset + orders.length,
+  }
+}

--- a/apps/medusa-be/src/api/admin/order-expedition/pdf/__tests__/route.unit.spec.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/pdf/__tests__/route.unit.spec.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@medusajs/framework/utils", () => ({
+  ContainerRegistrationKeys: {
+    QUERY: "query",
+  },
+  MedusaError: class MedusaError extends Error {
+    static Types = {
+      INVALID_DATA: "invalid_data",
+    }
+
+    constructor(_type: string, message: string) {
+      super(message)
+    }
+  },
+}))
+
+const { mockAddPage, mockDrawText, mockEmbedFont, mockSave } = vi.hoisted(
+  () => {
+    const drawText = vi.fn()
+
+    return {
+      mockAddPage: vi.fn(() => ({
+        drawText,
+      })),
+      mockDrawText: drawText,
+      mockEmbedFont: vi.fn().mockResolvedValue({
+        widthOfTextAtSize: (text: string) => text.length,
+      }),
+      mockSave: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+    }
+  }
+)
+
+vi.mock("pdf-lib", () => ({
+  PageSizes: {
+    A4: [595.28, 841.89],
+  },
+  PDFDocument: {
+    create: vi.fn().mockResolvedValue({
+      addPage: mockAddPage,
+      embedFont: mockEmbedFont,
+      save: mockSave,
+    }),
+  },
+  rgb: vi.fn(() => ({})),
+  StandardFonts: {
+    Helvetica: "Helvetica",
+    HelveticaBold: "HelveticaBold",
+  },
+}))
+
+const createMockResponse = () => ({
+  send: vi.fn().mockReturnThis(),
+  set: vi.fn().mockReturnThis(),
+})
+
+const createMockRequest = (
+  validatedBody: Record<string, unknown>,
+  graph: ReturnType<typeof vi.fn>
+) => ({
+  scope: {
+    resolve: vi.fn(() => ({ graph })),
+  },
+  validatedBody,
+})
+
+describe("POST /admin/order-expedition/pdf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockSave.mockResolvedValue(new Uint8Array([1, 2, 3]))
+  })
+
+  it("fails before generating a PDF when any selected order is missing", async () => {
+    const { POST } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [{ id: "order_1", display_id: 1001 }],
+    })
+    const req = createMockRequest(
+      {
+        order_ids: ["order_1", "order_missing"],
+      },
+      graph
+    )
+    const res = createMockResponse()
+
+    await expect(POST(req, res)).rejects.toThrow(
+      "Orders not found: order_missing"
+    )
+    expect(mockSave).not.toHaveBeenCalled()
+    expect(res.send).not.toHaveBeenCalled()
+  })
+
+  it("generates one PDF for exactly the selected orders", async () => {
+    const { POST } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          id: "order_1",
+          display_id: 1001,
+          customer: { first_name: "Jana", last_name: "Novakova" },
+          items: [{ quantity: 1, title: "Tea" }],
+          shipping_methods: [{ name: "PPL" }],
+          status: "pending",
+        },
+      ],
+    })
+    const req = createMockRequest({ order_ids: ["order_1"] }, graph)
+    const res = createMockResponse()
+
+    await POST(req, res)
+
+    expect(res.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        "Content-Disposition": 'attachment; filename="expedition-1001.pdf"',
+        "Content-Type": "application/pdf",
+      })
+    )
+    expect(res.send).toHaveBeenCalledWith(Buffer.from([1, 2, 3]))
+    expect(mockDrawText).toHaveBeenCalled()
+  })
+})

--- a/apps/medusa-be/src/api/admin/order-expedition/pdf/route.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/pdf/route.ts
@@ -1,0 +1,274 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { Query } from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  MedusaError,
+} from "@medusajs/framework/utils"
+import type { PDFFont, PDFPage } from "pdf-lib"
+import { PageSizes, PDFDocument, rgb, StandardFonts } from "pdf-lib"
+import {
+  findMissingOrderIds,
+  ORDER_EXPEDITION_ORDER_FIELDS,
+  type OrderExpeditionOrderDto,
+  type OrderExpeditionRawOrder,
+  orderOrdersByRequestedIds,
+  toOrderExpeditionDto,
+} from "../../../../utils/order-expedition"
+import type { PostAdminOrderExpeditionPdfSchemaType } from "../validators"
+
+const PAGE_MARGIN = 40
+const PAGE_BOTTOM = 40
+const BODY_SIZE = 10
+const BODY_LINE_HEIGHT = 14
+const HEADING_SIZE = 16
+const SECTION_GAP = 12
+const FILENAME_SAFE_CHARS_REGEX = /[^a-z0-9-]+/gi
+const WHITESPACE_REGEX = /\s+/
+
+type DrawState = {
+  document: PDFDocument
+  page: PDFPage
+  y: number
+}
+
+type DrawContext = DrawState & {
+  boldFont: PDFFont
+  regularFont: PDFFont
+}
+
+export async function POST(
+  req: MedusaRequest<PostAdminOrderExpeditionPdfSchemaType>,
+  res: MedusaResponse
+): Promise<void> {
+  const { order_ids: orderIds } = req.validatedBody
+  const query = req.scope.resolve<Query>(ContainerRegistrationKeys.QUERY)
+
+  const { data } = await query.graph({
+    entity: "order",
+    fields: ORDER_EXPEDITION_ORDER_FIELDS,
+    filters: {
+      id: orderIds,
+    },
+  })
+
+  const orders = data as OrderExpeditionRawOrder[]
+  const missingOrderIds = findMissingOrderIds(orderIds, orders)
+
+  if (missingOrderIds.length > 0) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Orders not found: ${missingOrderIds.join(", ")}`
+    )
+  }
+
+  const orderedDtos = orderOrdersByRequestedIds(orderIds, orders).map(
+    toOrderExpeditionDto
+  )
+  const pdfBytes = await generateExpeditionPdf(orderedDtos)
+  const buffer = Buffer.from(pdfBytes)
+
+  res.set({
+    "Content-Type": "application/pdf",
+    "Content-Disposition": `attachment; filename="${buildFilename(orderedDtos)}"`,
+    "Content-Length": buffer.length,
+  })
+  res.send(buffer)
+}
+
+async function generateExpeditionPdf(orders: OrderExpeditionOrderDto[]) {
+  const document = await PDFDocument.create()
+  const regularFont = await document.embedFont(StandardFonts.Helvetica)
+  const boldFont = await document.embedFont(StandardFonts.HelveticaBold)
+  const state: DrawContext = {
+    boldFont,
+    document,
+    page: document.addPage(PageSizes.A4),
+    regularFont,
+    y: PageSizes.A4[1] - PAGE_MARGIN,
+  }
+
+  for (const [index, order] of orders.entries()) {
+    if (index > 0) {
+      state.page = document.addPage(PageSizes.A4)
+      state.y = PageSizes.A4[1] - PAGE_MARGIN
+    }
+
+    drawOrderSection(state, order)
+  }
+
+  return document.save()
+}
+
+function drawOrderSection(state: DrawContext, order: OrderExpeditionOrderDto) {
+  drawLine(state, `Expedicni prehled - ${order.order_display_id}`, {
+    font: state.boldFont,
+    size: HEADING_SIZE,
+  })
+  state.y -= SECTION_GAP
+
+  drawKeyValue(state, "Zakaznik", order.customer)
+  drawKeyValue(state, "E-mail", order.email ?? "-")
+  drawKeyValue(
+    state,
+    "Dopravce",
+    order.carrier.shipping_method_name ?? order.carrier.label
+  )
+  drawKeyValue(state, "Zpusob platby", order.payment_method)
+  drawKeyValue(state, "Stav", order.status ?? "-")
+
+  state.y -= SECTION_GAP
+  drawLine(state, "Dorucovaci adresa", { font: state.boldFont })
+  const addressLines =
+    order.delivery_address.length > 0 ? order.delivery_address : ["-"]
+  for (const line of addressLines) {
+    drawLine(state, line, { font: state.regularFont })
+  }
+
+  state.y -= SECTION_GAP
+  drawLine(state, "Polozky", { font: state.boldFont })
+  drawLine(state, "Mnozstvi  Nazev", { font: state.boldFont })
+
+  for (const item of order.items) {
+    const sku = item.sku ? ` (${item.sku})` : ""
+    drawWrappedText(state, `${item.quantity}x  ${item.title}${sku}`, {
+      font: state.regularFont,
+      size: BODY_SIZE,
+      maxWidth: PageSizes.A4[0] - PAGE_MARGIN * 2,
+    })
+  }
+}
+
+function drawKeyValue(state: DrawContext, label: string, value: string) {
+  ensureSpace(state, BODY_LINE_HEIGHT)
+  const labelX = PAGE_MARGIN
+  const valueX = PAGE_MARGIN + 120
+
+  state.page.drawText(toPdfSafeText(`${label}:`), {
+    x: labelX,
+    y: state.y,
+    size: BODY_SIZE,
+    font: state.boldFont,
+    color: rgb(0, 0, 0),
+  })
+  state.page.drawText(toPdfSafeText(value), {
+    x: valueX,
+    y: state.y,
+    size: BODY_SIZE,
+    font: state.regularFont,
+    color: rgb(0, 0, 0),
+  })
+  state.y -= BODY_LINE_HEIGHT
+}
+
+function drawLine(
+  state: DrawState,
+  text: string,
+  options: {
+    font: PDFFont
+    size?: number
+  }
+) {
+  drawWrappedText(state, text, {
+    font: options.font,
+    size: options.size ?? BODY_SIZE,
+    maxWidth: PageSizes.A4[0] - PAGE_MARGIN * 2,
+  })
+}
+
+function drawWrappedText(
+  state: DrawState,
+  text: string,
+  options: {
+    font: PDFFont
+    size: number
+    maxWidth: number
+  }
+) {
+  const lines = wrapText(
+    toPdfSafeText(text),
+    options.font,
+    options.size,
+    options.maxWidth
+  )
+
+  for (const line of lines) {
+    ensureSpace(state, BODY_LINE_HEIGHT)
+    state.page.drawText(line, {
+      x: PAGE_MARGIN,
+      y: state.y,
+      size: options.size,
+      font: options.font,
+      color: rgb(0, 0, 0),
+    })
+    state.y -= BODY_LINE_HEIGHT
+  }
+}
+
+function ensureSpace(state: DrawState, requiredHeight: number) {
+  if (state.y - requiredHeight >= PAGE_BOTTOM) {
+    return
+  }
+
+  state.page = state.document.addPage(PageSizes.A4)
+  state.y = PageSizes.A4[1] - PAGE_MARGIN
+}
+
+function wrapText(text: string, font: PDFFont, size: number, maxWidth: number) {
+  const words = text.split(WHITESPACE_REGEX)
+  const lines: string[] = []
+  let currentLine = ""
+
+  for (const word of words) {
+    const candidate = currentLine ? `${currentLine} ${word}` : word
+    if (font.widthOfTextAtSize(candidate, size) <= maxWidth) {
+      currentLine = candidate
+      continue
+    }
+
+    if (currentLine) {
+      lines.push(currentLine)
+    }
+    currentLine = word
+  }
+
+  if (currentLine) {
+    lines.push(currentLine)
+  }
+
+  return lines.length > 0 ? lines : [""]
+}
+
+function buildFilename(orders: OrderExpeditionOrderDto[]) {
+  const firstOrder = orders[0]
+
+  if (orders.length === 1 && firstOrder) {
+    return `expedition-${firstOrder.order_display_id.replace(FILENAME_SAFE_CHARS_REGEX, "")}.pdf`
+  }
+
+  return `expedition-orders-${new Date().toISOString().slice(0, 10)}.pdf`
+}
+
+function toPdfSafeText(value: string) {
+  return value
+    .replace(/[áàâä]/gi, (match) => preserveCase(match, "a"))
+    .replace(/[č]/gi, (match) => preserveCase(match, "c"))
+    .replace(/[ď]/gi, (match) => preserveCase(match, "d"))
+    .replace(/[éèêëě]/gi, (match) => preserveCase(match, "e"))
+    .replace(/[íìîï]/gi, (match) => preserveCase(match, "i"))
+    .replace(/[ň]/gi, (match) => preserveCase(match, "n"))
+    .replace(/[óòôö]/gi, (match) => preserveCase(match, "o"))
+    .replace(/[ř]/gi, (match) => preserveCase(match, "r"))
+    .replace(/[š]/gi, (match) => preserveCase(match, "s"))
+    .replace(/[ť]/gi, (match) => preserveCase(match, "t"))
+    .replace(/[úùûüů]/gi, (match) => preserveCase(match, "u"))
+    .replace(/[ýÿ]/gi, (match) => preserveCase(match, "y"))
+    .replace(/[ž]/gi, (match) => preserveCase(match, "z"))
+    .replace(/€/g, "EUR")
+    .replace(/₽|£|¥|¢/g, "")
+}
+
+function preserveCase(source: string, replacement: string) {
+  return source === source.toUpperCase()
+    ? replacement.toUpperCase()
+    : replacement
+}

--- a/apps/medusa-be/src/api/admin/order-expedition/status/__tests__/route.unit.spec.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/status/__tests__/route.unit.spec.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@medusajs/framework/utils", () => ({
+  ContainerRegistrationKeys: {
+    QUERY: "query",
+  },
+}))
+
+const { mockArchiveRun, mockBulkCancelRun, mockCompleteRun } = vi.hoisted(
+  () => ({
+    mockArchiveRun: vi.fn(),
+    mockBulkCancelRun: vi.fn(),
+    mockCompleteRun: vi.fn(),
+  })
+)
+
+vi.mock("@medusajs/medusa/core-flows", () => ({
+  archiveOrderWorkflow: vi.fn(() => ({ run: mockArchiveRun })),
+  completeOrderWorkflow: vi.fn(() => ({ run: mockCompleteRun })),
+}))
+
+vi.mock("../../../../../workflows/order-expedition/bulk-cancel-orders", () => ({
+  bulkCancelOrdersWorkflow: vi.fn(() => ({ run: mockBulkCancelRun })),
+}))
+
+const createMockResponse = () => ({
+  json: vi.fn().mockReturnThis(),
+  status: vi.fn().mockReturnThis(),
+})
+
+const createMockRequest = (
+  validatedBody: Record<string, unknown>,
+  graph: ReturnType<typeof vi.fn>
+) => ({
+  scope: {
+    resolve: vi.fn(() => ({ graph })),
+  },
+  validatedBody,
+})
+
+describe("POST /admin/order-expedition/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("prevalidates every selected order and blocks the whole batch when one is missing", async () => {
+    const { POST } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [{ id: "order_1", display_id: 1001, status: "pending" }],
+    })
+    const req = createMockRequest(
+      {
+        order_ids: ["order_1", "order_missing"],
+        target_status: "completed",
+      },
+      graph
+    )
+    const res = createMockResponse()
+
+    await POST(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blocked_orders: [
+          {
+            id: "order_missing",
+            order_display_id: "order_missing",
+            reason: "Order was not found",
+          },
+        ],
+        code: "order_expedition_status_blocked",
+      })
+    )
+    expect(mockCompleteRun).not.toHaveBeenCalled()
+    expect(mockArchiveRun).not.toHaveBeenCalled()
+    expect(mockBulkCancelRun).not.toHaveBeenCalled()
+  })
+
+  it("runs completed as one bulk workflow after prevalidation", async () => {
+    const { POST } = await import("../route")
+    const graph = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          { id: "order_1", display_id: 1001, status: "pending" },
+          { id: "order_2", display_id: 1002, status: "pending" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          { id: "order_1", display_id: 1001, status: "completed" },
+          { id: "order_2", display_id: 1002, status: "completed" },
+        ],
+      })
+    const req = createMockRequest(
+      {
+        order_ids: ["order_1", "order_2"],
+        target_status: "completed",
+      },
+      graph
+    )
+    const res = createMockResponse()
+
+    await POST(req, res)
+
+    expect(mockCompleteRun).toHaveBeenCalledWith({
+      input: { orderIds: ["order_1", "order_2"] },
+    })
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        count: 2,
+        target_status: "completed",
+      })
+    )
+  })
+
+  it("blocks cancellation before mutation when a selected order has active fulfillments", async () => {
+    const { POST } = await import("../route")
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          fulfillments: [{ canceled_at: null, id: "ful_1" }],
+          id: "order_1",
+          display_id: 1001,
+          status: "pending",
+        },
+      ],
+    })
+    const req = createMockRequest(
+      {
+        order_ids: ["order_1"],
+        target_status: "canceled",
+      },
+      graph
+    )
+    const res = createMockResponse()
+
+    await POST(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        blocked_orders: [
+          {
+            id: "order_1",
+            order_display_id: "#1001",
+            reason: "Orders with active fulfillments cannot be canceled",
+          },
+        ],
+      })
+    )
+    expect(mockBulkCancelRun).not.toHaveBeenCalled()
+  })
+
+  it("runs cancel through the custom bulk cancel workflow after prevalidation", async () => {
+    const { POST } = await import("../route")
+    const graph = vi
+      .fn()
+      .mockResolvedValueOnce({
+        data: [
+          {
+            fulfillments: [],
+            id: "order_1",
+            display_id: 1001,
+            status: "pending",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            id: "order_1",
+            display_id: 1001,
+            status: "canceled",
+          },
+        ],
+      })
+    const req = createMockRequest(
+      {
+        order_ids: ["order_1"],
+        target_status: "canceled",
+      },
+      graph
+    )
+    const res = createMockResponse()
+
+    await POST(req, res)
+
+    expect(mockBulkCancelRun).toHaveBeenCalledWith({
+      input: { order_ids: ["order_1"] },
+    })
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        count: 1,
+        target_status: "canceled",
+      })
+    )
+  })
+})

--- a/apps/medusa-be/src/api/admin/order-expedition/status/route.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/status/route.ts
@@ -1,0 +1,171 @@
+import type { MedusaRequest, MedusaResponse } from "@medusajs/framework/http"
+import type { Query } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
+import {
+  archiveOrderWorkflow,
+  completeOrderWorkflow,
+} from "@medusajs/medusa/core-flows"
+import {
+  findMissingOrderIds,
+  getOrderExpeditionDisplayId,
+  ORDER_EXPEDITION_ORDER_FIELDS,
+  type OrderExpeditionBlockingOrder,
+  type OrderExpeditionRawOrder,
+  type OrderExpeditionTargetStatus,
+  orderOrdersByRequestedIds,
+  toOrderExpeditionBlockingOrder,
+} from "../../../../utils/order-expedition"
+import { bulkCancelOrdersWorkflow } from "../../../../workflows/order-expedition/bulk-cancel-orders"
+import type { PostAdminOrderExpeditionStatusSchemaType } from "../validators"
+
+type StatusChangedOrder = {
+  id: string
+  order_display_id: string
+  status: string | null
+}
+
+export async function POST(
+  req: MedusaRequest<PostAdminOrderExpeditionStatusSchemaType>,
+  res: MedusaResponse
+): Promise<void> {
+  const { order_ids: requestedOrderIds, target_status: targetStatus } =
+    req.validatedBody
+  const orderIds = uniqueOrderIds(requestedOrderIds)
+  const query = req.scope.resolve<Query>(ContainerRegistrationKeys.QUERY)
+
+  const orders = await fetchSelectedOrders(query, orderIds)
+  const orderedOrders = orderOrdersByRequestedIds(orderIds, orders)
+  const blockingOrders = collectBlockingOrders(
+    orderIds,
+    orderedOrders,
+    targetStatus
+  )
+
+  if (blockingOrders.length) {
+    res.status(400).json({
+      code: "order_expedition_status_blocked",
+      message: "One or more selected orders cannot transition to target status",
+      target_status: targetStatus,
+      blocked_orders: blockingOrders,
+    })
+    return
+  }
+
+  await runStatusWorkflow(
+    req.scope,
+    orderedOrders.map((order) => order.id),
+    targetStatus
+  )
+
+  const changedOrders = orderOrdersByRequestedIds(
+    orderIds,
+    await fetchSelectedOrders(query, orderIds)
+  )
+
+  res.json({
+    count: changedOrders.length,
+    target_status: targetStatus,
+    orders: changedOrders.map(toChangedOrder),
+  })
+}
+
+async function fetchSelectedOrders(query: Query, orderIds: string[]) {
+  const { data } = await query.graph({
+    entity: "order",
+    fields: ORDER_EXPEDITION_ORDER_FIELDS,
+    filters: {
+      id: orderIds,
+    },
+  })
+
+  return data as OrderExpeditionRawOrder[]
+}
+
+function collectBlockingOrders(
+  requestedOrderIds: string[],
+  orders: OrderExpeditionRawOrder[],
+  targetStatus: OrderExpeditionTargetStatus
+) {
+  const blockers: OrderExpeditionBlockingOrder[] = findMissingOrderIds(
+    requestedOrderIds,
+    orders
+  ).map((orderId) => ({
+    id: orderId,
+    order_display_id: orderId,
+    reason: "Order was not found",
+  }))
+
+  for (const order of orders) {
+    const reason = getTransitionBlockReason(order, targetStatus)
+
+    if (reason) {
+      blockers.push(toOrderExpeditionBlockingOrder(order, reason))
+    }
+  }
+
+  return blockers
+}
+
+function getTransitionBlockReason(
+  order: OrderExpeditionRawOrder,
+  targetStatus: OrderExpeditionTargetStatus
+) {
+  if (order.status === targetStatus) {
+    return `Order is already ${targetStatus}`
+  }
+
+  if (order.status === "archived") {
+    return "Archived orders cannot be changed"
+  }
+
+  if (order.status === "canceled") {
+    return "Canceled orders cannot be changed"
+  }
+
+  if (targetStatus === "canceled" && order.status === "completed") {
+    return "Completed orders cannot be canceled"
+  }
+
+  if (
+    targetStatus === "canceled" &&
+    order.fulfillments?.some((fulfillment) => !fulfillment.canceled_at)
+  ) {
+    return "Orders with active fulfillments cannot be canceled"
+  }
+
+  return
+}
+
+async function runStatusWorkflow(
+  scope: MedusaRequest["scope"],
+  orderIds: string[],
+  targetStatus: OrderExpeditionTargetStatus
+) {
+  if (targetStatus === "completed") {
+    await completeOrderWorkflow(scope).run({ input: { orderIds } })
+    return
+  }
+
+  if (targetStatus === "archived") {
+    await archiveOrderWorkflow(scope).run({ input: { orderIds } })
+    return
+  }
+
+  await bulkCancelOrdersWorkflow(scope).run({
+    input: {
+      order_ids: orderIds,
+    },
+  })
+}
+
+function toChangedOrder(order: OrderExpeditionRawOrder): StatusChangedOrder {
+  return {
+    id: order.id,
+    order_display_id: getOrderExpeditionDisplayId(order),
+    status: order.status ?? null,
+  }
+}
+
+function uniqueOrderIds(orderIds: string[]) {
+  return [...new Set(orderIds)]
+}

--- a/apps/medusa-be/src/api/admin/order-expedition/validators.ts
+++ b/apps/medusa-be/src/api/admin/order-expedition/validators.ts
@@ -1,0 +1,50 @@
+import { z } from "@medusajs/framework/zod"
+import {
+  ORDER_EXPEDITION_CARRIER_KEYS,
+  ORDER_EXPEDITION_MAX_LIMIT,
+  ORDER_EXPEDITION_MAX_ORDER_IDS,
+  ORDER_EXPEDITION_TARGET_STATUSES,
+} from "../../../utils/order-expedition"
+
+const OptionalPositiveIntQuerySchema = z.preprocess(
+  (value) => (Array.isArray(value) ? value[0] : value),
+  z.coerce.number().int().min(0).optional()
+)
+
+const OptionalLimitQuerySchema = z.preprocess(
+  (value) => (Array.isArray(value) ? value[0] : value),
+  z.coerce.number().int().min(1).max(ORDER_EXPEDITION_MAX_LIMIT).optional()
+)
+
+export const GetAdminOrderExpeditionOrdersSchema = z.object({
+  carrier: z.enum(ORDER_EXPEDITION_CARRIER_KEYS).optional(),
+  limit: OptionalLimitQuerySchema,
+  offset: OptionalPositiveIntQuerySchema,
+})
+
+export const PostAdminOrderExpeditionPdfSchema = z.object({
+  order_ids: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(ORDER_EXPEDITION_MAX_ORDER_IDS),
+})
+
+export const PostAdminOrderExpeditionStatusSchema = z.object({
+  order_ids: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(ORDER_EXPEDITION_MAX_ORDER_IDS),
+  target_status: z.enum(ORDER_EXPEDITION_TARGET_STATUSES),
+})
+
+export type GetAdminOrderExpeditionOrdersSchemaType = z.infer<
+  typeof GetAdminOrderExpeditionOrdersSchema
+>
+
+export type PostAdminOrderExpeditionPdfSchemaType = z.infer<
+  typeof PostAdminOrderExpeditionPdfSchema
+>
+
+export type PostAdminOrderExpeditionStatusSchemaType = z.infer<
+  typeof PostAdminOrderExpeditionStatusSchema
+>

--- a/apps/medusa-be/src/api/middlewares.ts
+++ b/apps/medusa-be/src/api/middlewares.ts
@@ -7,10 +7,11 @@ import { errorHandler } from "@medusajs/framework/http"
 import { defineMiddlewares } from "@medusajs/medusa"
 import { captureException } from "@sentry/node"
 import { normalizeError, shouldCaptureException } from "../utils/errors"
+import { adminOrderExpeditionRoutesMiddlewares } from "./admin/order-expedition/middlewares"
 import { adminOrderEmailRoutesMiddlewares } from "./admin/orders/[id]/email/middlewares"
-import { adminPayloadSsoRoutesMiddlewares } from "./admin/payload/sso/middlewares"
 import { adminPacketaConfigRoutesMiddlewares } from "./admin/packeta-config/middlewares"
 import { adminPacketaLabelsRoutesMiddlewares } from "./admin/packeta-labels/middlewares"
+import { adminPayloadSsoRoutesMiddlewares } from "./admin/payload/sso/middlewares"
 import { adminPplConfigRoutesMiddlewares } from "./admin/ppl-config/middlewares"
 import { adminPublishableKeyRoutesMiddlewares } from "./admin/provisioning/publishable-key/middlewares"
 import { storeCatalogProductsRoutesMiddlewares } from "./store/catalog/products/middlewares"
@@ -38,6 +39,7 @@ export default defineMiddlewares({
       matcher: "/webhooks/*",
       bodyParser: { preserveRawBody: true },
     },
+    ...adminOrderExpeditionRoutesMiddlewares,
     ...adminOrderEmailRoutesMiddlewares,
     ...adminPayloadSsoRoutesMiddlewares,
     ...adminPacketaConfigRoutesMiddlewares,

--- a/apps/medusa-be/src/utils/__tests__/order-expedition.unit.spec.ts
+++ b/apps/medusa-be/src/utils/__tests__/order-expedition.unit.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import {
+  findMissingOrderIds,
+  getOrderExpeditionDisplayId,
+  orderMatchesExpeditionCarrier,
+  orderOrdersByRequestedIds,
+  resolveOrderExpeditionCarrier,
+  toOrderExpeditionDto,
+} from "../order-expedition"
+
+describe("order expedition helpers", () => {
+  it("resolves carriers from shipping method names and data before fulfillment exists", () => {
+    expect(
+      resolveOrderExpeditionCarrier({
+        shipping_methods: [{ name: "PPL ParcelShop" }],
+      })
+    ).toMatchObject({ label: "PPL", value: "ppl" })
+
+    expect(
+      resolveOrderExpeditionCarrier({
+        shipping_methods: [
+          {
+            data: {
+              provider: "Zasilkovna",
+              pickupPoint: "123",
+            },
+          },
+        ],
+      })
+    ).toMatchObject({ label: "Packeta", value: "packeta" })
+  })
+
+  it("matches only the resolved carrier when a carrier filter is active", () => {
+    const order = {
+      shipping_methods: [{ shipping_option_id: "shipping-option-ppl-home" }],
+    }
+
+    expect(orderMatchesExpeditionCarrier(order, "ppl")).toBe(true)
+    expect(orderMatchesExpeditionCarrier(order, "packeta")).toBe(false)
+    expect(orderMatchesExpeditionCarrier(order)).toBe(true)
+  })
+
+  it("normalizes an order into the admin expedition DTO", () => {
+    const dto = toOrderExpeditionDto({
+      id: "order_1",
+      display_id: 1001,
+      custom_display_id: "#HERB-1001",
+      email: "customer@example.com",
+      status: "pending",
+      payment_status: "captured",
+      customer: {
+        first_name: "Jana",
+        last_name: "Novakova",
+      },
+      shipping_address: {
+        address_1: "Ulice 1",
+        city: "Praha",
+        country_code: "cz",
+        postal_code: "11000",
+      },
+      shipping_methods: [{ name: "Packeta Z-Point" }],
+      payment_collections: [{ payments: [{ provider_id: "stripe" }] }],
+      items: [{ id: "item_1", quantity: "2", title: "Tea" }],
+    })
+
+    expect(dto).toMatchObject({
+      carrier: { value: "packeta" },
+      customer: "Jana Novakova",
+      order_display_id: "#HERB-1001",
+      payment_method: "stripe",
+      status: "pending",
+    })
+    expect(dto.delivery_address).toEqual(["Ulice 1", "11000 Praha", "CZ"])
+    expect(dto.items).toEqual([
+      {
+        id: "item_1",
+        quantity: 2,
+        sku: undefined,
+        title: "Tea",
+        variant: undefined,
+      },
+    ])
+  })
+
+  it("preserves selected order order and reports missing IDs", () => {
+    const orders = [{ id: "order_2" }, { id: "order_1" }]
+
+    expect(orderOrdersByRequestedIds(["order_1", "order_2"], orders)).toEqual([
+      { id: "order_1" },
+      { id: "order_2" },
+    ])
+    expect(findMissingOrderIds(["order_1", "order_3"], orders)).toEqual([
+      "order_3",
+    ])
+  })
+
+  it("falls back to stable display IDs", () => {
+    expect(
+      getOrderExpeditionDisplayId({ id: "order_1", display_id: 1001 })
+    ).toBe("#1001")
+    expect(
+      getOrderExpeditionDisplayId({
+        custom_display_id: "CZ-1001",
+        display_id: 1001,
+        id: "order_1",
+      })
+    ).toBe("CZ-1001")
+  })
+})

--- a/apps/medusa-be/src/utils/order-expedition.ts
+++ b/apps/medusa-be/src/utils/order-expedition.ts
@@ -1,0 +1,391 @@
+export const ORDER_EXPEDITION_MAX_ORDER_IDS = 100
+export const ORDER_EXPEDITION_DEFAULT_LIMIT = 50
+export const ORDER_EXPEDITION_MAX_LIMIT = 100
+
+export const ORDER_EXPEDITION_CARRIER_KEYS = [
+  "ppl",
+  "packeta",
+  "other",
+] as const
+export const ORDER_EXPEDITION_TARGET_STATUSES = [
+  "completed",
+  "archived",
+  "canceled",
+] as const
+
+export type OrderExpeditionCarrierKey =
+  (typeof ORDER_EXPEDITION_CARRIER_KEYS)[number]
+
+export type OrderExpeditionTargetStatus =
+  (typeof ORDER_EXPEDITION_TARGET_STATUSES)[number]
+
+export type OrderExpeditionCarrierOption = {
+  label: string
+  value: OrderExpeditionCarrierKey
+}
+
+export type OrderExpeditionAddress = {
+  first_name?: string | null
+  last_name?: string | null
+  company?: string | null
+  address_1?: string | null
+  address_2?: string | null
+  postal_code?: string | null
+  city?: string | null
+  province?: string | null
+  country_code?: string | null
+}
+
+export type OrderExpeditionShippingMethod = {
+  id?: string | null
+  name?: string | null
+  shipping_option_id?: string | null
+  data?: Record<string, unknown> | null
+}
+
+export type OrderExpeditionLineItem = {
+  id?: string | null
+  title?: string | null
+  subtitle?: string | null
+  quantity?: number | string | null
+  variant_sku?: string | null
+  variant_title?: string | null
+}
+
+export type OrderExpeditionPayment = {
+  provider_id?: string | null
+}
+
+export type OrderExpeditionPaymentCollection = {
+  status?: string | null
+  payments?: OrderExpeditionPayment[] | null
+}
+
+export type OrderExpeditionFulfillment = {
+  id?: string | null
+  canceled_at?: string | null
+}
+
+export type OrderExpeditionCustomer = {
+  id?: string | null
+  first_name?: string | null
+  last_name?: string | null
+  email?: string | null
+  company_name?: string | null
+}
+
+export type OrderExpeditionRawOrder = {
+  id: string
+  display_id?: number | null
+  custom_display_id?: string | null
+  email?: string | null
+  status?: string | null
+  payment_status?: string | null
+  customer_id?: string | null
+  customer?: OrderExpeditionCustomer | null
+  shipping_address?: OrderExpeditionAddress | null
+  shipping_methods?: OrderExpeditionShippingMethod[] | null
+  fulfillments?: OrderExpeditionFulfillment[] | null
+  items?: OrderExpeditionLineItem[] | null
+  payment_collections?: OrderExpeditionPaymentCollection[] | null
+}
+
+export type ResolvedOrderExpeditionCarrier = OrderExpeditionCarrierOption & {
+  shipping_method_id?: string
+  shipping_method_name?: string
+  shipping_option_id?: string
+}
+
+export type OrderExpeditionItemDto = {
+  id?: string | null
+  title: string
+  quantity: number
+  sku?: string | null
+  variant?: string | null
+}
+
+export type OrderExpeditionOrderDto = {
+  id: string
+  display_id?: number | null
+  order_display_id: string
+  customer: string
+  email?: string | null
+  delivery_address: string[]
+  carrier: ResolvedOrderExpeditionCarrier
+  payment_method: string
+  payment_status?: string | null
+  status?: string | null
+  items: OrderExpeditionItemDto[]
+}
+
+export type OrderExpeditionBlockingOrder = {
+  id: string
+  order_display_id: string
+  reason: string
+}
+
+export const ORDER_EXPEDITION_CARRIER_OPTIONS: OrderExpeditionCarrierOption[] =
+  [
+    { label: "PPL", value: "ppl" },
+    { label: "Packeta", value: "packeta" },
+    { label: "Other", value: "other" },
+  ]
+
+export const ORDER_EXPEDITION_ORDER_FIELDS = [
+  "id",
+  "display_id",
+  "custom_display_id",
+  "email",
+  "status",
+  "payment_status",
+  "customer_id",
+  "customer.id",
+  "customer.first_name",
+  "customer.last_name",
+  "customer.email",
+  "customer.company_name",
+  "shipping_address.first_name",
+  "shipping_address.last_name",
+  "shipping_address.company",
+  "shipping_address.address_1",
+  "shipping_address.address_2",
+  "shipping_address.postal_code",
+  "shipping_address.city",
+  "shipping_address.province",
+  "shipping_address.country_code",
+  "shipping_methods.id",
+  "shipping_methods.name",
+  "shipping_methods.shipping_option_id",
+  "shipping_methods.data",
+  "fulfillments.id",
+  "fulfillments.canceled_at",
+  "items.id",
+  "items.title",
+  "items.subtitle",
+  "items.quantity",
+  "items.variant_sku",
+  "items.variant_title",
+  "payment_collections.status",
+  "payment_collections.payments.provider_id",
+]
+
+const CARRIER_MATCHERS: Record<
+  Exclude<OrderExpeditionCarrierKey, "other">,
+  { label: string; tokens: string[] }
+> = {
+  packeta: {
+    label: "Packeta",
+    tokens: ["packeta", "zasilkovna", "zasielkovna"],
+  },
+  ppl: {
+    label: "PPL",
+    tokens: ["ppl"],
+  },
+}
+
+export function getOrderExpeditionDisplayId(
+  order: Pick<
+    OrderExpeditionRawOrder,
+    "custom_display_id" | "display_id" | "id"
+  >
+) {
+  return order.custom_display_id || `#${order.display_id ?? order.id}`
+}
+
+export function isOrderExpeditionCarrierKey(
+  value: string
+): value is OrderExpeditionCarrierKey {
+  return ORDER_EXPEDITION_CARRIER_KEYS.includes(
+    value as OrderExpeditionCarrierKey
+  )
+}
+
+export function isOrderExpeditionTargetStatus(
+  value: string
+): value is OrderExpeditionTargetStatus {
+  return ORDER_EXPEDITION_TARGET_STATUSES.includes(
+    value as OrderExpeditionTargetStatus
+  )
+}
+
+export function resolveOrderExpeditionCarrier(
+  order: Pick<OrderExpeditionRawOrder, "shipping_methods">
+): ResolvedOrderExpeditionCarrier {
+  for (const shippingMethod of order.shipping_methods ?? []) {
+    const searchable = normalizeSearchValue([
+      shippingMethod.name,
+      shippingMethod.shipping_option_id,
+      shippingMethod.data,
+    ])
+
+    for (const key of ["ppl", "packeta"] as const) {
+      const matcher = CARRIER_MATCHERS[key]
+      if (matcher.tokens.some((token) => searchable.includes(token))) {
+        return {
+          label: matcher.label,
+          value: key,
+          shipping_method_id: shippingMethod.id ?? undefined,
+          shipping_method_name: shippingMethod.name ?? undefined,
+          shipping_option_id: shippingMethod.shipping_option_id ?? undefined,
+        }
+      }
+    }
+  }
+
+  return { label: "Other", value: "other" }
+}
+
+export function orderMatchesExpeditionCarrier(
+  order: Pick<OrderExpeditionRawOrder, "shipping_methods">,
+  carrier?: OrderExpeditionCarrierKey
+) {
+  if (!carrier) {
+    return true
+  }
+
+  return resolveOrderExpeditionCarrier(order).value === carrier
+}
+
+export function toOrderExpeditionDto(
+  order: OrderExpeditionRawOrder
+): OrderExpeditionOrderDto {
+  return {
+    id: order.id,
+    display_id: order.display_id,
+    order_display_id: getOrderExpeditionDisplayId(order),
+    customer: getOrderExpeditionCustomerName(order),
+    email: order.email ?? order.customer?.email ?? null,
+    delivery_address: formatOrderExpeditionAddress(order.shipping_address),
+    carrier: resolveOrderExpeditionCarrier(order),
+    payment_method: getOrderExpeditionPaymentMethod(order),
+    payment_status: order.payment_status,
+    status: order.status,
+    items: (order.items ?? []).map(toOrderExpeditionItemDto),
+  }
+}
+
+export function toOrderExpeditionBlockingOrder(
+  order: Pick<
+    OrderExpeditionRawOrder,
+    "id" | "custom_display_id" | "display_id"
+  >,
+  reason: string
+): OrderExpeditionBlockingOrder {
+  return {
+    id: order.id,
+    order_display_id: getOrderExpeditionDisplayId(order),
+    reason,
+  }
+}
+
+export function findMissingOrderIds(
+  requestedOrderIds: string[],
+  orders: Pick<OrderExpeditionRawOrder, "id">[]
+) {
+  const orderIds = new Set(orders.map((order) => order.id))
+  return requestedOrderIds.filter((orderId) => !orderIds.has(orderId))
+}
+
+export function orderOrdersByRequestedIds<T extends { id: string }>(
+  requestedOrderIds: string[],
+  orders: T[]
+) {
+  const ordersById = new Map(orders.map((order) => [order.id, order]))
+  return requestedOrderIds
+    .map((orderId) => ordersById.get(orderId))
+    .filter((order): order is T => Boolean(order))
+}
+
+function getOrderExpeditionCustomerName(order: OrderExpeditionRawOrder) {
+  const customerName = joinNonEmpty([
+    order.customer?.company_name,
+    order.customer?.first_name,
+    order.customer?.last_name,
+  ])
+
+  if (customerName) {
+    return customerName
+  }
+
+  const shippingName = joinNonEmpty([
+    order.shipping_address?.company,
+    order.shipping_address?.first_name,
+    order.shipping_address?.last_name,
+  ])
+
+  return shippingName || order.customer?.email || order.email || order.id
+}
+
+function formatOrderExpeditionAddress(address?: OrderExpeditionAddress | null) {
+  if (!address) {
+    return []
+  }
+
+  return [
+    joinNonEmpty([address.company]),
+    joinNonEmpty([address.first_name, address.last_name]),
+    joinNonEmpty([address.address_1, address.address_2]),
+    joinNonEmpty([address.postal_code, address.city]),
+    joinNonEmpty([address.province]),
+    joinNonEmpty([address.country_code?.toUpperCase()]),
+  ].filter(Boolean)
+}
+
+function getOrderExpeditionPaymentMethod(order: OrderExpeditionRawOrder) {
+  const providerId = order.payment_collections
+    ?.flatMap((collection) => collection.payments ?? [])
+    .find((payment) => payment.provider_id)?.provider_id
+
+  return providerId ?? order.payment_status ?? "Unknown"
+}
+
+function toOrderExpeditionItemDto(
+  item: OrderExpeditionLineItem
+): OrderExpeditionItemDto {
+  const quantity = Number(item.quantity ?? 0)
+
+  return {
+    id: item.id,
+    title: item.title || item.subtitle || item.id || "Untitled item",
+    quantity: Number.isFinite(quantity) ? quantity : 0,
+    sku: item.variant_sku,
+    variant: item.variant_title,
+  }
+}
+
+function joinNonEmpty(values: Array<string | null | undefined>) {
+  return values
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+}
+
+function normalizeSearchValue(value: unknown): string {
+  return flattenSearchParts(value)
+    .join(" ")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+}
+
+function flattenSearchParts(value: unknown): string[] {
+  if (value === null || value === undefined) {
+    return []
+  }
+
+  if (["string", "number", "boolean"].includes(typeof value)) {
+    return [String(value)]
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap(flattenSearchParts)
+  }
+
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap(
+      flattenSearchParts
+    )
+  }
+
+  return []
+}

--- a/apps/medusa-be/src/workflows/order-expedition/bulk-cancel-orders.ts
+++ b/apps/medusa-be/src/workflows/order-expedition/bulk-cancel-orders.ts
@@ -1,0 +1,42 @@
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  WorkflowResponse,
+} from "@medusajs/framework/workflows-sdk"
+import { cancelOrderWorkflow } from "@medusajs/medusa/core-flows"
+
+type BulkCancelOrdersWorkflowInput = {
+  order_ids: string[]
+}
+
+const bulkCancelOrdersStep = createStep(
+  "bulk-cancel-orders-step",
+  async ({ order_ids }: BulkCancelOrdersWorkflowInput, { container }) => {
+    const canceledOrderIds: string[] = []
+
+    for (const orderId of order_ids) {
+      // Delegate to Medusa's cancel workflow so payment, reservation, event,
+      // and hook side effects stay aligned with the native admin cancel action.
+      await cancelOrderWorkflow(container).run({
+        input: {
+          order_id: orderId,
+        },
+      })
+      canceledOrderIds.push(orderId)
+    }
+
+    return new StepResponse(canceledOrderIds)
+  }
+)
+
+export const bulkCancelOrdersWorkflow = createWorkflow(
+  "bulk-cancel-orders",
+  (input: BulkCancelOrdersWorkflowInput) => {
+    const canceledOrderIds = bulkCancelOrdersStep(input)
+
+    return new WorkflowResponse({
+      order_ids: canceledOrderIds,
+    })
+  }
+)


### PR DESCRIPTION
## Summary

Adds a Medusa Admin order expedition workspace for filtering orders by carrier, explicitly selecting orders, generating a selected-order expedition PDF, and applying bulk status changes to selected orders only.

## What Changed

- Added shared order-expedition DTO, carrier resolution, display ID, and selection helper utilities.
- Added admin API routes for carrier options, paginated order listing with carrier filtering, selected-order PDF generation, and bulk status updates.
- Added request validators and registered order-expedition middlewares in the Medusa backend middleware chain.
- Added a custom bulk cancel workflow that delegates to Medusa's native cancel workflow per order after batch prevalidation.
- Added an Admin route with carrier filtering, checkbox selection, PDF download, target status selection, confirmation UI, and structured blocked-order feedback.
- Added focused Vitest coverage for helper normalization, route behavior, selected-order PDF constraints, and all-or-nothing status prevalidation.

## Validation

- `npx --yes pnpm@10.30.0 exec biome check --write apps/medusa-be/src/api/middlewares.ts apps/medusa-be/src/admin/routes/order-expedition/page.tsx apps/medusa-be/src/api/admin/order-expedition apps/medusa-be/src/utils/order-expedition.ts apps/medusa-be/src/utils/__tests__/order-expedition.unit.spec.ts apps/medusa-be/src/workflows/order-expedition`
- `npx --yes vitest@4.0.18 run apps/medusa-be/src/utils/__tests__/order-expedition.unit.spec.ts apps/medusa-be/src/api/admin/order-expedition/carriers/__tests__/route.unit.spec.ts apps/medusa-be/src/api/admin/order-expedition/orders/__tests__/route.unit.spec.ts apps/medusa-be/src/api/admin/order-expedition/pdf/__tests__/route.unit.spec.ts apps/medusa-be/src/api/admin/order-expedition/status/__tests__/route.unit.spec.ts --environment node`
- `npx --yes pnpm@10.30.0 --filter medusa-be exec tsc --noEmit --pretty false`

Runtime admin smoke remains environment-blocked locally: no Medusa backend was listening on `localhost:9000`, and starting `medusa-be` reached startup but failed to connect to PostgreSQL with `KnexTimeoutError` before binding the admin port.