### PR TITLE
[codex] fix favorite list item quantity

### DIFF
--- a/apps/medusa-be/src/modules/product-list/service.ts
+++ b/apps/medusa-be/src/modules/product-list/service.ts
@@ -178,8 +178,11 @@ class ProductListModuleService extends MedusaService({
     input: CreateProductListItemDTO,
     sharedContext?: Context
   ) {
-    normalizeProductListType(input.list_type)
-    const quantity = normalizePositiveInteger("quantity", input.quantity)
+    const listType = normalizeProductListType(input.list_type)
+    const quantity =
+      listType === "favorite"
+        ? 1
+        : normalizePositiveInteger("quantity", input.quantity)
 
     return await this.createProductListItems(
       {


### PR DESCRIPTION
## Summary

Fixes the regression in product list item creation where favorite-list items started preserving the submitted quantity instead of normalizing it to `1`.

The failing behavior was introduced when `createProductListItemForList` stopped using the normalized list type to branch favorite behavior. As a result, requests adding a favorite item with `quantity: 9` could persist `9`, breaking the expected favorite-list semantics and the existing module test.

This restores the previous behavior:

- normalize `input.list_type` once and keep the result
- force favorite-list item quantity to `1`
- continue validating and preserving custom-list quantities via `normalizePositiveInteger`

## Validation

- ✅ `bunx nx run medusa-be:test -- src/modules/product-list/__tests__/normalizers.unit.spec.ts`
- ⚠️ `TEST_TYPE=integration:modules bunx nx run medusa-be:test -- src/modules/product-list/__tests__/service.spec.ts` could not run locally because Postgres is not available: `connect ECONNREFUSED 127.0.0.1:5432`
