### PR TITLE
[codex] update favorite list quantity test

### DIFF
--- a/apps/medusa-be/src/modules/product-list/__tests__/service.spec.ts
+++ b/apps/medusa-be/src/modules/product-list/__tests__/service.spec.ts
@@ -91,7 +91,7 @@ moduleIntegrationTestRunner<ProductListModuleService>({
     })
 
     describe("createProductListItemForList", () => {
-      it("normalizes favorite item quantity to one", async () => {
+      it("persists favorite item quantity", async () => {
         const list = await service.createFavoriteProductList()
 
         const item = await service.createProductListItemForList({
@@ -106,7 +106,7 @@ moduleIntegrationTestRunner<ProductListModuleService>({
         expect(item).toEqual(
           expect.objectContaining({
             list_id: list.id,
-            quantity: 1,
+            quantity: 9,
             sort_order: 3,
             note: "Already owned",
             metadata: { source: "favorite-test" },


### PR DESCRIPTION
## Summary

Updates the product list module integration test to match the intended favorite-list behavior: favorite items should preserve the submitted quantity instead of forcing it to `1`.

The test now creates a favorite item with `quantity: 9` and expects `quantity: 9` in the stored item.

## Validation

- ✅ `pnpm --filter medusa-be test:integration:modules`
