### PR TITLE
ci: skip Storybook a11y for UI docs

### DIFF
--- a/.github/workflows/storybook-a11y-baseline.yml
+++ b/.github/workflows/storybook-a11y-baseline.yml
@@ -5,9 +5,21 @@ on:
     branches:
       - master
     paths:
-      - "libs/ui/**"
+      - "libs/ui/.storybook/**"
+      - "libs/ui/assets/**"
+      - "libs/ui/package.json"
+      - "libs/ui/playwright.config.cts"
+      - "libs/ui/postcss.config.mjs"
+      - "libs/ui/project.json"
+      - "libs/ui/rslib.config.ts"
+      - "libs/ui/scripts/storybook-a11y*"
+      - "libs/ui/src/**"
+      - "libs/ui/stories/**"
+      - "libs/ui/tsconfig.json"
       - ".github/workflows/storybook-a11y.yml"
       - ".github/workflows/storybook-a11y-baseline.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "libs/ui/**"
       - ".github/workflows/storybook-a11y.yml"
+      - ".github/workflows/storybook-a11y-baseline.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
     inputs:
       failOnViolations:
@@ -19,7 +22,56 @@ permissions:
   checks: write
 
 jobs:
+  detect-a11y-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.changed-paths.outputs.should-run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed paths
+        id: changed-paths
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "should-run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          should_run=false
+          while IFS= read -r file; do
+            case "$file" in
+              .github/workflows/storybook-a11y.yml|\
+              .github/workflows/storybook-a11y-baseline.yml|\
+              package.json|\
+              pnpm-lock.yaml|\
+              libs/ui/.storybook/*|\
+              libs/ui/assets/*|\
+              libs/ui/package.json|\
+              libs/ui/playwright.config.cts|\
+              libs/ui/postcss.config.mjs|\
+              libs/ui/project.json|\
+              libs/ui/rslib.config.ts|\
+              libs/ui/scripts/storybook-a11y*|\
+              libs/ui/src/*|\
+              libs/ui/stories/*|\
+              libs/ui/tsconfig.json)
+                should_run=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")
+
+          echo "should-run=$should_run" >> "$GITHUB_OUTPUT"
+          if [ "$should_run" = "false" ]; then
+            echo "No Storybook a11y-relevant paths changed; skipping Storybook build and scan." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   storybook-a11y:
+    needs: detect-a11y-changes
+    if: needs.detect-a11y-changes.outputs.should-run == 'true'
     uses: TechsioCZ/storybook-addons/.github/workflows/storybook-a11y.yml@b52eaf44688051b19eb989fab7b6ab721ce1a2d1 # storybook-a11y-workflow-v0.1.9
     with:
       node-version: "24"

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -47,16 +47,16 @@ jobs:
               .github/workflows/storybook-a11y-baseline.yml|\
               package.json|\
               pnpm-lock.yaml|\
-              libs/ui/.storybook/*|\
-              libs/ui/assets/*|\
+              libs/ui/.storybook/**|\
+              libs/ui/assets/**|\
               libs/ui/package.json|\
               libs/ui/playwright.config.cts|\
               libs/ui/postcss.config.mjs|\
               libs/ui/project.json|\
               libs/ui/rslib.config.ts|\
               libs/ui/scripts/storybook-a11y*|\
-              libs/ui/src/*|\
-              libs/ui/stories/*|\
+              libs/ui/src/**|\
+              libs/ui/stories/**|\
               libs/ui/tsconfig.json)
                 should_run=true
                 break

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       should-run: ${{ steps.changed-paths.outputs.should-run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Summary
- add a lightweight path detector before the PR Storybook a11y reusable workflow
- skip the expensive Storybook build/scan when changes are limited to non-a11y UI docs such as libs/ui/skills Markdown/YAML
- narrow the master baseline trigger to Storybook/UI source, config, package, and workflow files

## Validation
- actionlint .github/workflows/storybook-a11y.yml .github/workflows/storybook-a11y-baseline.yml
- ruby YAML parser for both workflow files
- local shell simulation: libs/ui/skills Markdown/YAML => skip, libs/ui/src change => run

Note: Biome is configured to ignore these workflow files, so it reported that no files were processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised continuous integration pipelines with enhanced path filtering and selective job execution for improved build efficiency; accessibility testing workflows now trigger only when changes are detected to specific UI component directories, Storybook configuration, or dependency management files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->