### PR TITLE
[codex] Add checkout account setup emails

### DIFF
--- a/apps/medusa-be/src/modules/resend/templates.ts
+++ b/apps/medusa-be/src/modules/resend/templates.ts
@@ -14,6 +14,7 @@ const defineTemplate = <
 })
 
 export const resendEmailTemplates = {
+  ACCOUNT_SETUP: "account-setup",
   FORGOT_PASSWORD: "user-forgotpwd",
   ORDER_PLACED: "order-placed",
   ORDER_PAYMENT_REMINDER: "order-payment-reminder",
@@ -21,6 +22,13 @@ export const resendEmailTemplates = {
 } as const
 
 export const resendTemplateDefinitions = {
+  [resendEmailTemplates.ACCOUNT_SETUP]: defineTemplate({
+    id: "account-setup",
+    label: "Account setup",
+    optionalVariables: ["customer_id", "customer_name", "order_display_id"],
+    requiredVariables: ["reset_url"],
+    subject: "Dokončenie registrácie",
+  }),
   [resendEmailTemplates.FORGOT_PASSWORD]: defineTemplate({
     id: "user-forgotpwd",
     label: "Forgot password",

--- a/apps/medusa-be/src/subscribers/order-placed.ts
+++ b/apps/medusa-be/src/subscribers/order-placed.ts
@@ -1,5 +1,6 @@
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
 import type { Logger } from "@medusajs/framework/types"
+import { ContainerRegistrationKeys } from "@medusajs/framework/utils"
 import { sendAccountSetupWorkflow } from "../workflows/send-account-setup"
 import { sendOrderReceiptWorkflow } from "../workflows/send-order-receipt"
 
@@ -25,7 +26,7 @@ export default async function orderPlacedHandler({
       },
     })
   } catch (error) {
-    const logger = container.resolve<Logger>("logger")
+    const logger = container.resolve<Logger>(ContainerRegistrationKeys.LOGGER)
     logger.error(
       `Failed to process account setup for order ${data.id}: ${
         error instanceof Error ? error.message : String(error)

--- a/apps/medusa-be/src/subscribers/order-placed.ts
+++ b/apps/medusa-be/src/subscribers/order-placed.ts
@@ -1,4 +1,6 @@
 import type { SubscriberArgs, SubscriberConfig } from "@medusajs/framework"
+import type { Logger } from "@medusajs/framework/types"
+import { sendAccountSetupWorkflow } from "../workflows/send-account-setup"
 import { sendOrderReceiptWorkflow } from "../workflows/send-order-receipt"
 
 type OrderPlacedEvent = {
@@ -15,6 +17,21 @@ export default async function orderPlacedHandler({
       store_name: process.env.STORE_NAME,
     },
   })
+
+  try {
+    await sendAccountSetupWorkflow(container).run({
+      input: {
+        order_id: data.id,
+      },
+    })
+  } catch (error) {
+    const logger = container.resolve<Logger>("logger")
+    logger.error(
+      `Failed to process account setup for order ${data.id}: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    )
+  }
 }
 
 export const config: SubscriberConfig = {

--- a/apps/medusa-be/src/utils/account-setup.ts
+++ b/apps/medusa-be/src/utils/account-setup.ts
@@ -1,0 +1,223 @@
+import crypto from "node:crypto"
+import type {
+  IAuthModuleService,
+  ICustomerModuleService,
+  Query,
+} from "@medusajs/framework/types"
+import { MedusaError } from "@medusajs/framework/utils"
+
+export const EMAIL_PASS_PROVIDER = "emailpass"
+export const ACCOUNT_SETUP_TOKEN_EXPIRES_IN = "15m"
+export const ACCOUNT_SETUP_REQUESTED_METADATA_KEY = "account_setup_requested"
+
+export type AccountSetupOrder = {
+  id: string
+  display_id?: number | null
+  email?: string | null
+  customer_id?: string | null
+  metadata?: Record<string, unknown> | null
+  billing_address?: {
+    first_name?: string | null
+    last_name?: string | null
+  } | null
+  shipping_address?: {
+    first_name?: string | null
+    last_name?: string | null
+  } | null
+  customer?: {
+    id?: string | null
+    email?: string | null
+    first_name?: string | null
+    last_name?: string | null
+    has_account?: boolean | null
+  } | null
+}
+
+export type AccountSetupCustomer = {
+  id: string
+  email?: string | null
+  first_name?: string | null
+  last_name?: string | null
+  has_account?: boolean | null
+}
+
+export type AccountSetupResult = {
+  customer_id?: string
+  email?: string
+  order_id: string
+  customer_name?: string
+  order_display_id?: string
+  reset_url?: string
+  sent: boolean
+  skipped_reason?: "account_exists" | "missing_email" | "not_requested"
+}
+
+export const ACCOUNT_SETUP_ORDER_FIELDS = [
+  "id",
+  "display_id",
+  "email",
+  "customer_id",
+  "metadata",
+  "billing_address.first_name",
+  "billing_address.last_name",
+  "shipping_address.first_name",
+  "shipping_address.last_name",
+  "customer.id",
+  "customer.email",
+  "customer.first_name",
+  "customer.last_name",
+  "customer.has_account",
+]
+
+export function isAccountSetupRequested(
+  metadata: Record<string, unknown> | null | undefined
+) {
+  return metadata?.[ACCOUNT_SETUP_REQUESTED_METADATA_KEY] === true
+}
+
+export function getAccountSetupOrderDisplayId(order: AccountSetupOrder) {
+  return order.display_id ? `#${order.display_id}` : order.id
+}
+
+export function getAccountSetupCustomerName(order: AccountSetupOrder) {
+  const customerName = [order.customer?.first_name, order.customer?.last_name]
+    .filter(Boolean)
+    .join(" ")
+
+  if (customerName) {
+    return customerName
+  }
+
+  const address = order.billing_address ?? order.shipping_address
+
+  return (
+    [address?.first_name, address?.last_name].filter(Boolean).join(" ") ||
+    undefined
+  )
+}
+
+export function buildAccountSetupUrl(email: string, token: string) {
+  const template = process.env.ACCOUNT_SETUP_URL_TEMPLATE
+
+  if (template) {
+    if (!template.includes("{TOKEN}")) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "ACCOUNT_SETUP_URL_TEMPLATE must include {TOKEN} placeholder"
+      )
+    }
+
+    return template
+      .replaceAll("{TOKEN}", encodeURIComponent(token))
+      .replaceAll("{EMAIL}", encodeURIComponent(email))
+  }
+
+  const storefrontUrl = process.env.STOREFRONT_URL
+
+  if (!storefrontUrl) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "STOREFRONT_URL env var is not set — cannot build account setup link"
+    )
+  }
+
+  return `${storefrontUrl}/auth/reset-password?token=${encodeURIComponent(token)}&email=${encodeURIComponent(email)}`
+}
+
+function getCustomerCreateData(order: AccountSetupOrder, email: string) {
+  const address = order.billing_address ?? order.shipping_address
+
+  return {
+    email,
+    first_name: order.customer?.first_name ?? address?.first_name ?? undefined,
+    last_name: order.customer?.last_name ?? address?.last_name ?? undefined,
+    has_account: false,
+  }
+}
+
+function generateTemporaryPassword() {
+  return crypto.randomBytes(32).toString("base64url")
+}
+
+export async function getCustomerForAccountSetup({
+  customerModuleService,
+  email,
+  order,
+}: {
+  customerModuleService: ICustomerModuleService
+  email: string
+  order: AccountSetupOrder
+}): Promise<AccountSetupCustomer> {
+  if (order.customer?.id) {
+    return order.customer as AccountSetupCustomer
+  }
+
+  const [existingCustomer] = await customerModuleService.listCustomers(
+    { email },
+    { take: 1 }
+  )
+
+  if (existingCustomer) {
+    return existingCustomer as AccountSetupCustomer
+  }
+
+  return (await customerModuleService.createCustomers(
+    getCustomerCreateData(order, email)
+  )) as AccountSetupCustomer
+}
+
+async function getExistingEmailPassIdentity(
+  query: Query,
+  email: string
+): Promise<{ auth_identity_id?: string; id: string } | undefined> {
+  const {
+    data: [providerIdentity],
+  } = await query.graph({
+    entity: "provider_identity",
+    fields: ["id", "auth_identity_id"],
+    filters: {
+      entity_id: email,
+      provider: EMAIL_PASS_PROVIDER,
+    },
+  })
+
+  return providerIdentity as
+    | { auth_identity_id?: string; id: string }
+    | undefined
+}
+
+export async function ensureEmailPassAuthIdentity({
+  authModuleService,
+  email,
+  query,
+}: {
+  authModuleService: IAuthModuleService
+  email: string
+  query: Query
+}) {
+  const existingIdentity = await getExistingEmailPassIdentity(query, email)
+
+  if (existingIdentity?.auth_identity_id) {
+    return existingIdentity.auth_identity_id
+  }
+
+  const registration = await authModuleService.register(EMAIL_PASS_PROVIDER, {
+    body: {
+      email,
+      password: generateTemporaryPassword(),
+    },
+  })
+
+  if (
+    registration.error ||
+    !registration.success ||
+    !registration.authIdentity
+  ) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Failed to prepare customer account setup: ${registration.error ?? "unknown error"}`
+    )
+  }
+
+  return registration.authIdentity.id
+}

--- a/apps/medusa-be/src/utils/account-setup.ts
+++ b/apps/medusa-be/src/utils/account-setup.ts
@@ -52,6 +52,11 @@ export type AccountSetupResult = {
   skipped_reason?: "account_exists" | "missing_email" | "not_requested"
 }
 
+type EmailPassProviderIdentity = {
+  auth_identity_id?: string
+  id: string
+}
+
 export const ACCOUNT_SETUP_ORDER_FIELDS = [
   "id",
   "display_id",
@@ -135,6 +140,115 @@ function getCustomerCreateData(order: AccountSetupOrder, email: string) {
   }
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isOptionalNullableString(value: unknown) {
+  return value === undefined || value === null || typeof value === "string"
+}
+
+function isOptionalNullableBoolean(value: unknown) {
+  return value === undefined || value === null || typeof value === "boolean"
+}
+
+function isOptionalNullableAddress(value: unknown) {
+  if (value === undefined || value === null) {
+    return true
+  }
+
+  return (
+    isRecord(value) &&
+    isOptionalNullableString(value.first_name) &&
+    isOptionalNullableString(value.last_name)
+  )
+}
+
+function isOptionalNullableOrderCustomer(value: unknown) {
+  if (value === undefined || value === null) {
+    return true
+  }
+
+  return (
+    isRecord(value) &&
+    isOptionalNullableString(value.id) &&
+    isOptionalNullableString(value.email) &&
+    isOptionalNullableString(value.first_name) &&
+    isOptionalNullableString(value.last_name) &&
+    isOptionalNullableBoolean(value.has_account)
+  )
+}
+
+export function isAccountSetupOrder(
+  value: unknown
+): value is AccountSetupOrder {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.display_id === undefined ||
+      value.display_id === null ||
+      typeof value.display_id === "number") &&
+    isOptionalNullableString(value.email) &&
+    isOptionalNullableString(value.customer_id) &&
+    (value.metadata === undefined ||
+      value.metadata === null ||
+      isRecord(value.metadata)) &&
+    isOptionalNullableAddress(value.billing_address) &&
+    isOptionalNullableAddress(value.shipping_address) &&
+    isOptionalNullableOrderCustomer(value.customer)
+  )
+}
+
+export function assertAccountSetupOrder(
+  value: unknown,
+  source: string
+): asserts value is AccountSetupOrder {
+  if (!isAccountSetupOrder(value)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Invalid account setup order returned from ${source}`
+    )
+  }
+}
+
+export function isAccountSetupCustomer(
+  value: unknown
+): value is AccountSetupCustomer {
+  if (!isRecord(value) || typeof value.id !== "string") {
+    return false
+  }
+
+  return (
+    isOptionalNullableString(value.email) &&
+    isOptionalNullableString(value.first_name) &&
+    isOptionalNullableString(value.last_name) &&
+    isOptionalNullableBoolean(value.has_account)
+  )
+}
+
+export function assertAccountSetupCustomer(
+  value: unknown,
+  source: string
+): asserts value is AccountSetupCustomer {
+  if (!isAccountSetupCustomer(value)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      `Invalid account setup customer returned from ${source}`
+    )
+  }
+}
+
+function isEmailPassProviderIdentity(
+  value: unknown
+): value is EmailPassProviderIdentity {
+  return (
+    isRecord(value) &&
+    typeof value.id === "string" &&
+    (value.auth_identity_id === undefined ||
+      typeof value.auth_identity_id === "string")
+  )
+}
+
 function generateTemporaryPassword() {
   return crypto.randomBytes(32).toString("base64url")
 }
@@ -149,27 +263,48 @@ export async function getCustomerForAccountSetup({
   order: AccountSetupOrder
 }): Promise<AccountSetupCustomer> {
   if (order.customer?.id) {
-    return order.customer as AccountSetupCustomer
+    const orderCustomer: unknown = order.customer
+    assertAccountSetupCustomer(orderCustomer, "order.customer")
+    return orderCustomer
   }
 
-  const [existingCustomer] = await customerModuleService.listCustomers(
+  const listedCustomers: unknown = await customerModuleService.listCustomers(
     { email },
     { take: 1 }
   )
 
-  if (existingCustomer) {
-    return existingCustomer as AccountSetupCustomer
+  if (!Array.isArray(listedCustomers)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Invalid customer list response for account setup"
+    )
   }
 
-  return (await customerModuleService.createCustomers(
+  const [existingCustomer] = listedCustomers
+
+  if (existingCustomer) {
+    assertAccountSetupCustomer(
+      existingCustomer,
+      "customerModuleService.listCustomers"
+    )
+    return existingCustomer
+  }
+
+  const createdCustomer: unknown = await customerModuleService.createCustomers(
     getCustomerCreateData(order, email)
-  )) as AccountSetupCustomer
+  )
+  assertAccountSetupCustomer(
+    createdCustomer,
+    "customerModuleService.createCustomers"
+  )
+
+  return createdCustomer
 }
 
 async function getExistingEmailPassIdentity(
   query: Query,
   email: string
-): Promise<{ auth_identity_id?: string; id: string } | undefined> {
+): Promise<EmailPassProviderIdentity | undefined> {
   const {
     data: [providerIdentity],
   } = await query.graph({
@@ -181,9 +316,20 @@ async function getExistingEmailPassIdentity(
     },
   })
 
-  return providerIdentity as
-    | { auth_identity_id?: string; id: string }
-    | undefined
+  const providerIdentityResult: unknown = providerIdentity
+
+  if (!providerIdentityResult) {
+    return
+  }
+
+  if (!isEmailPassProviderIdentity(providerIdentityResult)) {
+    throw new MedusaError(
+      MedusaError.Types.INVALID_DATA,
+      "Invalid emailpass provider identity returned from query.graph"
+    )
+  }
+
+  return providerIdentityResult
 }
 
 export async function ensureEmailPassAuthIdentity({

--- a/apps/medusa-be/src/workflows/send-account-setup.ts
+++ b/apps/medusa-be/src/workflows/send-account-setup.ts
@@ -1,0 +1,197 @@
+import type {
+  IAuthModuleService,
+  ICustomerModuleService,
+  Logger,
+  Query,
+} from "@medusajs/framework/types"
+import {
+  ContainerRegistrationKeys,
+  generateJwtToken,
+  MedusaError,
+  Modules,
+} from "@medusajs/framework/utils"
+import {
+  createStep,
+  createWorkflow,
+  StepResponse,
+  transform,
+  WorkflowResponse,
+  when,
+} from "@medusajs/framework/workflows-sdk"
+import {
+  ACCOUNT_SETUP_ORDER_FIELDS,
+  ACCOUNT_SETUP_TOKEN_EXPIRES_IN,
+  type AccountSetupOrder,
+  type AccountSetupResult,
+  buildAccountSetupUrl,
+  EMAIL_PASS_PROVIDER,
+  ensureEmailPassAuthIdentity,
+  getAccountSetupCustomerName,
+  getAccountSetupOrderDisplayId,
+  getCustomerForAccountSetup,
+  isAccountSetupRequested,
+} from "../utils/account-setup"
+import { sendNotificationStep } from "./steps/send-notification"
+
+type WorkflowInput = {
+  order_id: string
+}
+
+const prepareAccountSetupStep = createStep(
+  "prepare-account-setup",
+  async (input: WorkflowInput, { container }) => {
+    const query = container.resolve<Query>(ContainerRegistrationKeys.QUERY)
+    const logger = container.resolve<Logger>("logger")
+    const customerModuleService = container.resolve<ICustomerModuleService>(
+      Modules.CUSTOMER
+    )
+    const authModuleService = container.resolve<IAuthModuleService>(
+      Modules.AUTH
+    )
+
+    const {
+      data: [order],
+    } = await query.graph({
+      entity: "order",
+      fields: ACCOUNT_SETUP_ORDER_FIELDS,
+      filters: {
+        id: input.order_id,
+      },
+    })
+
+    if (!order) {
+      throw new MedusaError(MedusaError.Types.NOT_FOUND, "Order was not found")
+    }
+
+    const typedOrder = order as AccountSetupOrder
+
+    if (!isAccountSetupRequested(typedOrder.metadata)) {
+      return new StepResponse<AccountSetupResult>({
+        order_id: typedOrder.id,
+        sent: false,
+        skipped_reason: "not_requested",
+      })
+    }
+
+    const email = typedOrder.email?.trim() || typedOrder.customer?.email?.trim()
+
+    if (!email) {
+      logger.warn(
+        `Order ${typedOrder.id} has no email; account setup email skipped.`
+      )
+      return new StepResponse<AccountSetupResult>({
+        order_id: typedOrder.id,
+        sent: false,
+        skipped_reason: "missing_email",
+      })
+    }
+
+    const customer = await getCustomerForAccountSetup({
+      customerModuleService,
+      email,
+      order: typedOrder,
+    })
+
+    if (customer.has_account) {
+      return new StepResponse<AccountSetupResult>({
+        customer_id: customer.id,
+        email,
+        order_id: typedOrder.id,
+        sent: false,
+        skipped_reason: "account_exists",
+      })
+    }
+
+    const authIdentityId = await ensureEmailPassAuthIdentity({
+      authModuleService,
+      email,
+      query,
+    })
+
+    await authModuleService.updateAuthIdentities({
+      id: authIdentityId,
+      app_metadata: {
+        customer_id: customer.id,
+      },
+    })
+
+    await customerModuleService.updateCustomers(customer.id, {
+      has_account: true,
+    } as unknown as Parameters<ICustomerModuleService["updateCustomers"]>[1])
+
+    const jwtSecret = process.env.JWT_SECRET
+
+    if (!jwtSecret) {
+      throw new MedusaError(
+        MedusaError.Types.INVALID_DATA,
+        "JWT_SECRET env var is not set — cannot generate account setup token"
+      )
+    }
+
+    const token = generateJwtToken(
+      {
+        actor_type: "customer",
+        entity_id: email,
+        provider: EMAIL_PASS_PROVIDER,
+      },
+      {
+        expiresIn: ACCOUNT_SETUP_TOKEN_EXPIRES_IN,
+        secret: jwtSecret,
+      }
+    )
+    const resetUrl = buildAccountSetupUrl(email, token)
+
+    return new StepResponse<AccountSetupResult>({
+      customer_id: customer.id,
+      customer_name: getAccountSetupCustomerName(typedOrder),
+      email,
+      order_display_id: getAccountSetupOrderDisplayId(typedOrder),
+      order_id: typedOrder.id,
+      reset_url: resetUrl,
+      sent: true,
+    })
+  }
+)
+
+export const sendAccountSetupWorkflow = createWorkflow(
+  "send-account-setup",
+  (input: WorkflowInput) => {
+    const accountSetup = prepareAccountSetupStep(input)
+    const notificationInput = transform({ accountSetup }, (data) => {
+      if (
+        !(
+          data.accountSetup.sent &&
+          data.accountSetup.email &&
+          data.accountSetup.reset_url
+        )
+      ) {
+        return []
+      }
+
+      return [
+        {
+          to: data.accountSetup.email,
+          channel: "email",
+          template: "account-setup",
+          data: {
+            customer_id: data.accountSetup.customer_id,
+            customer_name: data.accountSetup.customer_name,
+            order_display_id: data.accountSetup.order_display_id,
+            reset_url: data.accountSetup.reset_url,
+          },
+          resource_id: data.accountSetup.order_id,
+          resource_type: "order",
+          trigger_type: "order.account_setup_requested",
+        },
+      ]
+    })
+    when(
+      accountSetup,
+      (result) => result.sent && Boolean(result.email && result.reset_url)
+    ).then(() => {
+      sendNotificationStep(notificationInput)
+    })
+
+    return new WorkflowResponse(accountSetup)
+  }
+)

--- a/apps/medusa-be/src/workflows/send-account-setup.ts
+++ b/apps/medusa-be/src/workflows/send-account-setup.ts
@@ -21,8 +21,8 @@ import {
 import {
   ACCOUNT_SETUP_ORDER_FIELDS,
   ACCOUNT_SETUP_TOKEN_EXPIRES_IN,
-  type AccountSetupOrder,
   type AccountSetupResult,
+  assertAccountSetupOrder,
   buildAccountSetupUrl,
   EMAIL_PASS_PROVIDER,
   ensureEmailPassAuthIdentity,
@@ -37,11 +37,17 @@ type WorkflowInput = {
   order_id: string
 }
 
+type AccountSetupCustomerUpdate = Parameters<
+  ICustomerModuleService["updateCustomers"]
+>[1] & {
+  has_account: boolean
+}
+
 const prepareAccountSetupStep = createStep(
   "prepare-account-setup",
   async (input: WorkflowInput, { container }) => {
     const query = container.resolve<Query>(ContainerRegistrationKeys.QUERY)
-    const logger = container.resolve<Logger>("logger")
+    const logger = container.resolve<Logger>(ContainerRegistrationKeys.LOGGER)
     const customerModuleService = container.resolve<ICustomerModuleService>(
       Modules.CUSTOMER
     )
@@ -63,24 +69,25 @@ const prepareAccountSetupStep = createStep(
       throw new MedusaError(MedusaError.Types.NOT_FOUND, "Order was not found")
     }
 
-    const typedOrder = order as AccountSetupOrder
+    const graphOrder: unknown = order
+    assertAccountSetupOrder(graphOrder, "query.graph(order)")
 
-    if (!isAccountSetupRequested(typedOrder.metadata)) {
+    if (!isAccountSetupRequested(graphOrder.metadata)) {
       return new StepResponse<AccountSetupResult>({
-        order_id: typedOrder.id,
+        order_id: graphOrder.id,
         sent: false,
         skipped_reason: "not_requested",
       })
     }
 
-    const email = typedOrder.email?.trim() || typedOrder.customer?.email?.trim()
+    const email = graphOrder.email?.trim() || graphOrder.customer?.email?.trim()
 
     if (!email) {
       logger.warn(
-        `Order ${typedOrder.id} has no email; account setup email skipped.`
+        `Order ${graphOrder.id} has no email; account setup email skipped.`
       )
       return new StepResponse<AccountSetupResult>({
-        order_id: typedOrder.id,
+        order_id: graphOrder.id,
         sent: false,
         skipped_reason: "missing_email",
       })
@@ -89,35 +96,18 @@ const prepareAccountSetupStep = createStep(
     const customer = await getCustomerForAccountSetup({
       customerModuleService,
       email,
-      order: typedOrder,
+      order: graphOrder,
     })
 
     if (customer.has_account) {
       return new StepResponse<AccountSetupResult>({
         customer_id: customer.id,
         email,
-        order_id: typedOrder.id,
+        order_id: graphOrder.id,
         sent: false,
         skipped_reason: "account_exists",
       })
     }
-
-    const authIdentityId = await ensureEmailPassAuthIdentity({
-      authModuleService,
-      email,
-      query,
-    })
-
-    await authModuleService.updateAuthIdentities({
-      id: authIdentityId,
-      app_metadata: {
-        customer_id: customer.id,
-      },
-    })
-
-    await customerModuleService.updateCustomers(customer.id, {
-      has_account: true,
-    } as unknown as Parameters<ICustomerModuleService["updateCustomers"]>[1])
 
     const jwtSecret = process.env.JWT_SECRET
 
@@ -141,15 +131,51 @@ const prepareAccountSetupStep = createStep(
     )
     const resetUrl = buildAccountSetupUrl(email, token)
 
+    const authIdentityId = await ensureEmailPassAuthIdentity({
+      authModuleService,
+      email,
+      query,
+    })
+
+    await authModuleService.updateAuthIdentities({
+      id: authIdentityId,
+      app_metadata: {
+        customer_id: customer.id,
+      },
+    })
+
     return new StepResponse<AccountSetupResult>({
       customer_id: customer.id,
-      customer_name: getAccountSetupCustomerName(typedOrder),
+      customer_name: getAccountSetupCustomerName(graphOrder),
       email,
-      order_display_id: getAccountSetupOrderDisplayId(typedOrder),
-      order_id: typedOrder.id,
+      order_display_id: getAccountSetupOrderDisplayId(graphOrder),
+      order_id: graphOrder.id,
       reset_url: resetUrl,
       sent: true,
     })
+  }
+)
+
+const markCustomerHasAccountStep = createStep(
+  "mark-customer-has-account",
+  async (input: { customer_id?: string; sent: boolean }, { container }) => {
+    if (!(input.sent && input.customer_id)) {
+      return new StepResponse({ skipped: true })
+    }
+
+    const customerModuleService = container.resolve<ICustomerModuleService>(
+      Modules.CUSTOMER
+    )
+    const customerUpdate: AccountSetupCustomerUpdate = {
+      has_account: true,
+    }
+
+    await customerModuleService.updateCustomers(
+      input.customer_id,
+      customerUpdate
+    )
+
+    return new StepResponse({ skipped: false })
   }
 )
 
@@ -189,7 +215,16 @@ export const sendAccountSetupWorkflow = createWorkflow(
       accountSetup,
       (result) => result.sent && Boolean(result.email && result.reset_url)
     ).then(() => {
-      sendNotificationStep(notificationInput)
+      const notification = sendNotificationStep(notificationInput)
+      const markCustomerInput = transform(
+        { accountSetup, notification },
+        (data) => ({
+          customer_id: data.accountSetup.customer_id,
+          sent: data.accountSetup.sent,
+        })
+      )
+
+      markCustomerHasAccountStep(markCustomerInput)
     })
 
     return new WorkflowResponse(accountSetup)


### PR DESCRIPTION
## Summary

Adds backend support for sending an account setup email after checkout when the placed order requested account creation.

## Problem

Checkout already has a customer-facing registration opt-in copy, but the backend needed an order-driven way to prepare a customer account and send the customer a password setup link after a successful order. Calling a separate frontend endpoint after checkout is fragile because payment redirects or closed tabs can prevent the follow-up call from running.

## Cause and effect

The order placement event is the reliable point where the backend knows the order exists. By handling account setup from the `order.placed` subscriber, the email send is tied to successful order creation rather than browser lifecycle. Customers who opt in can receive a setup link without the storefront making another post-checkout request.

## Changes

- Adds a Resend `account-setup` template definition requiring `reset_url`.
- Adds account setup helpers for:
  - detecting `account_setup_requested` metadata,
  - resolving account setup URL templates from `ACCOUNT_SETUP_URL_TEMPLATE`,
  - preparing or creating customers,
  - ensuring `emailpass` auth identity exists,
  - formatting optional template variables.
- Adds `sendAccountSetupWorkflow`, which:
  - loads the placed order,
  - skips orders that did not request account setup,
  - skips orders without email,
  - skips customers that already have an account,
  - prepares the customer account and JWT setup token,
  - sends the `account-setup` email.
- Extends the existing `order.placed` subscriber to run the account setup workflow after the order receipt workflow.

## Configuration

`ACCOUNT_SETUP_URL_TEMPLATE` can be used to control the setup URL:

```env
ACCOUNT_SETUP_URL_TEMPLATE=https://shop.example.com/auth/reset-password?token={TOKEN}&email={EMAIL}
```

`{TOKEN}` is required when the template is set. `{EMAIL}` is optional.

If no template is configured, the workflow falls back to:

```txt
{STOREFRONT_URL}/auth/reset-password?token={TOKEN}&email={EMAIL}
```

## Validation

- `pnpm exec biome check --write apps/medusa-be/src/modules/resend/templates.ts apps/medusa-be/src/subscribers/order-placed.ts apps/medusa-be/src/utils/account-setup.ts apps/medusa-be/src/workflows/send-account-setup.ts` passed.
- `bunx nx run medusa-be:build` compiled the backend source successfully, then failed during existing admin frontend bundling on unrelated `@medusajs/admin-shared` resolution from `medusa-order-dashboard-plugin`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added automated account setup email notifications triggered when orders are placed and account setup is requested.
- Implemented a dedicated account setup email template and secure, JWT-based reset link generation for qualifying customers.
- Customers are automatically provisioned/linked to an email-pass authentication identity when sending the account setup email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->