### PR TITLE
[codex] product card supplier

### DIFF
--- a/apps/medusa-be/src/admin/widgets/product-producers.tsx
+++ b/apps/medusa-be/src/admin/widgets/product-producers.tsx
@@ -28,6 +28,15 @@ import { useDebouncedValue } from "../lib/use-debounced-value"
 type ProductProducersWidgetProps = Partial<DetailWidgetProps<AdminProduct>>
 
 const PAGE_SIZE = 20
+const SUPPLIER_ATTRIBUTE_NAME = "supplier"
+
+const getProducerAttributeValue = (
+  producer: Producer | undefined,
+  attributeName: string
+) =>
+  producer?.attributes.find(
+    (attribute) => attribute.name.toLowerCase() === attributeName
+  )?.value
 
 const ProducerSelectionRows = ({
   currentProducerId,
@@ -375,6 +384,13 @@ const ProductProducersWidget = ({
   )
   const activeProducer = producers.find((producer) => !producer.deleted_at)
   const hasInactiveProducer = producers.some((producer) => producer.deleted_at)
+  const supplier =
+    getProducerAttributeValue(activeProducer, SUPPLIER_ATTRIBUTE_NAME) ??
+    producers
+      .map((producer) =>
+        getProducerAttributeValue(producer, SUPPLIER_ATTRIBUTE_NAME)
+      )
+      .find((value): value is string => !!value)
   let statusText = t("products.notLinked")
 
   if (hasInactiveProducer) {
@@ -411,6 +427,14 @@ const ProductProducersWidget = ({
             producers={producers}
           />
         </div>
+        <div className="flex items-center justify-between gap-3 px-6 py-4">
+          <Text size="small" weight="plus">
+            {t("fields.supplier")}
+          </Text>
+          <Text className="text-ui-fg-subtle" size="small">
+            {supplier ?? "-"}
+          </Text>
+        </div>
       </Container>
       <ProducerAssignmentDrawer
         currentProducer={activeProducer}
@@ -423,7 +447,7 @@ const ProductProducersWidget = ({
 }
 
 export const config = defineWidgetConfig({
-  zone: "product.details.side.after",
+  zone: "product.details.after",
 })
 
 export default ProductProducersWidget

--- a/apps/medusa-be/src/admin/widgets/product-producers.tsx
+++ b/apps/medusa-be/src/admin/widgets/product-producers.tsx
@@ -384,13 +384,20 @@ const ProductProducersWidget = ({
   )
   const activeProducer = producers.find((producer) => !producer.deleted_at)
   const hasInactiveProducer = producers.some((producer) => producer.deleted_at)
+  const activeProducerSupplier = getProducerAttributeValue(
+    activeProducer,
+    SUPPLIER_ATTRIBUTE_NAME
+  )
   const supplier =
-    getProducerAttributeValue(activeProducer, SUPPLIER_ATTRIBUTE_NAME) ??
-    producers
-      .map((producer) =>
-        getProducerAttributeValue(producer, SUPPLIER_ATTRIBUTE_NAME)
-      )
-      .find((value): value is string => !!value)
+    activeProducerSupplier && activeProducerSupplier.trim().length > 0
+      ? activeProducerSupplier.trim()
+      : producers
+          .filter((producer) => producer.id !== activeProducer?.id)
+          .map((producer) =>
+            getProducerAttributeValue(producer, SUPPLIER_ATTRIBUTE_NAME)
+          )
+          .map((value) => value?.trim())
+          .find((value): value is string => !!value)
   let statusText = t("products.notLinked")
 
   if (hasInactiveProducer) {

--- a/apps/medusa-be/src/modules/producer/admin/i18n.ts
+++ b/apps/medusa-be/src/modules/producer/admin/i18n.ts
@@ -65,7 +65,10 @@ export type ProducerAdminI18nNamespace = {
     | "saveProductsFailed",
     string
   >
-  fields: Record<"attribute" | "handle" | "title" | "value", string>
+  fields: Record<
+    "attribute" | "handle" | "supplier" | "title" | "value",
+    string
+  >
   filters: Record<"activeOnly" | "allStatuses", string>
   form: Record<"createProducer" | "editProducer" | "handlePlaceholder", string>
   menuItem: string
@@ -211,6 +214,7 @@ export const producerAdminI18n = {
     fields: {
       attribute: "Atribut",
       handle: "Handle",
+      supplier: "Dodavatel",
       title: "Název",
       value: "Hodnota",
     },
@@ -380,6 +384,7 @@ export const producerAdminI18n = {
     fields: {
       attribute: "Attribute",
       handle: "Handle",
+      supplier: "Supplier",
       title: "Title",
       value: "Value",
     },


### PR DESCRIPTION
## What
Show the supplier value on the product details card in Medusa Admin.

## Why
Merchants need the supplier visible directly on the product page instead of digging into producer details.

## How
- Move the producer widget into the visible product details zone.
- Read the supplier from the linked producer's `supplier` attribute.
- Keep the label localized in the producer admin i18n bundle.

## Validation
- `bunx biome check --write apps/medusa-be/src/admin/widgets/product-producers.tsx apps/medusa-be/src/modules/producer/admin/i18n.ts`
- `bunx nx run medusa-be:build` (repo-wide build still fails in `medusa-symmy-plugin` with an unrelated `@medusajs/admin-sdk` resolution error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Supplier information now displayed in the product producers widget with intelligent fallback logic to ensure availability
  * Supplier field now available in multiple languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->