### PR TITLE
fix(herbatika): sync checkout payment provider selection

### DIFF
--- a/apps/herbatika/src/components/checkout/checkout-payment-collection-reuse.ts
+++ b/apps/herbatika/src/components/checkout/checkout-payment-collection-reuse.ts
@@ -1,0 +1,74 @@
+import type { HttpTypes } from "@medusajs/types"
+import {
+  resolveExistingPaymentCollection,
+} from "@techsio/storefront-data/shared/checkout-flow-utils"
+import {
+  asFiniteNumber,
+  resolveCartTotalAmount,
+} from "@/lib/storefront/cart-calculations"
+
+const PAYMENT_AMOUNT_EPSILON = 0.0001
+
+const areAmountsEqual = (left: number, right: number) =>
+  Math.abs(left - right) < PAYMENT_AMOUNT_EPSILON
+
+const resolveProviderPaymentSession = (
+  paymentCollection: HttpTypes.StorePaymentCollection,
+  selectedPaymentProviderId: string
+) => {
+  const paymentSessions = paymentCollection.payment_sessions
+  if (!paymentSessions?.length) {
+    return null
+  }
+
+  return (
+    paymentSessions.find(
+      (session) =>
+        session.provider_id === selectedPaymentProviderId &&
+        (session as { is_selected?: unknown }).is_selected === true
+    ) ??
+    paymentSessions.find(
+      (session) => session.provider_id === selectedPaymentProviderId
+    ) ??
+    null
+  )
+}
+
+export const resolveReusablePaymentCollection = ({
+  cart,
+  selectedPaymentProviderId,
+}: {
+  cart?: HttpTypes.StoreCart | null
+  selectedPaymentProviderId: string
+}): HttpTypes.StorePaymentCollection | null => {
+  const paymentCollection = resolveExistingPaymentCollection(
+    cart,
+    selectedPaymentProviderId
+  )
+  if (!paymentCollection) {
+    return null
+  }
+
+  const cartTotalAmount = resolveCartTotalAmount(cart)
+  const paymentCollectionAmount = asFiniteNumber(paymentCollection.amount)
+  if (
+    paymentCollectionAmount === null ||
+    !areAmountsEqual(paymentCollectionAmount, cartTotalAmount)
+  ) {
+    return null
+  }
+
+  const selectedPaymentSession = resolveProviderPaymentSession(
+    paymentCollection,
+    selectedPaymentProviderId
+  )
+  const paymentSessionAmount = asFiniteNumber(selectedPaymentSession?.amount)
+  if (
+    paymentSessionAmount === null ||
+    !areAmountsEqual(paymentSessionAmount, cartTotalAmount)
+  ) {
+    return null
+  }
+
+  return paymentCollection
+}

--- a/apps/herbatika/src/components/checkout/checkout-payment-selection-storage.ts
+++ b/apps/herbatika/src/components/checkout/checkout-payment-selection-storage.ts
@@ -1,6 +1,15 @@
 "use client"
 
+import { useSyncExternalStore } from "react"
+
 const STORAGE_PREFIX = "herbatika.payment-provider"
+const listeners = new Set<() => void>()
+
+const emitPaymentProviderSelectionChange = () => {
+  for (const listener of listeners) {
+    listener()
+  }
+}
 
 export function readStoredPaymentProviderSelection(cartId?: string | null) {
   if (!cartId || typeof window === "undefined") {
@@ -33,6 +42,7 @@ export function writeStoredPaymentProviderSelection({
   }
 
   window.sessionStorage.setItem(createStorageKey(cartId), normalizedProviderId)
+  emitPaymentProviderSelectionChange()
 }
 
 export function clearStoredPaymentProviderSelection(cartId?: string | null) {
@@ -41,6 +51,38 @@ export function clearStoredPaymentProviderSelection(cartId?: string | null) {
   }
 
   window.sessionStorage.removeItem(createStorageKey(cartId))
+  emitPaymentProviderSelectionChange()
+}
+
+export function useStoredPaymentProviderSelection(cartId?: string | null) {
+  return useSyncExternalStore(
+    subscribeStoredPaymentProviderSelection,
+    () => readStoredPaymentProviderSelection(cartId),
+    () => null
+  )
+}
+
+function subscribeStoredPaymentProviderSelection(listener: () => void) {
+  listeners.add(listener)
+
+  if (typeof window === "undefined") {
+    return () => {
+      listeners.delete(listener)
+    }
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key?.startsWith(STORAGE_PREFIX)) {
+      listener()
+    }
+  }
+
+  window.addEventListener("storage", handleStorage)
+
+  return () => {
+    listeners.delete(listener)
+    window.removeEventListener("storage", handleStorage)
+  }
 }
 
 function createStorageKey(cartId: string) {

--- a/apps/herbatika/src/components/checkout/use-checkout-actions.ts
+++ b/apps/herbatika/src/components/checkout/use-checkout-actions.ts
@@ -10,18 +10,19 @@ import {
   resolveCompleteCartFailure,
   resolveOrderId,
 } from "./checkout-completion.utils"
+import { resolveReusablePaymentCollection } from "./checkout-payment-collection-reuse"
 import { resolvePaymentRedirectUrl } from "./checkout-payment-redirect.utils"
 
 type UseCheckoutActionsProps = {
+  cart?: HttpTypes.StoreCart | null
   cartId?: string
-  cartPaymentProviderId?: string | null
   completedOrderId: string | null
   onCompletedOrderIdChange: (orderId: string | null) => void
   onOrderCompletionAbort: () => void
   onOrderCompletionStart: () => void
   onPaymentRedirect: (url: string) => void
   itemCount: number
-  paymentCollection?: HttpTypes.StorePaymentCollection | null
+  refreshCart?: () => Promise<HttpTypes.StoreCart | null>
   canInitiatePayment: boolean
   selectedPaymentProviderId?: string | null
   selectedShippingMethodId?: string | null
@@ -63,28 +64,9 @@ const resolveOrderCompletionBlocker = ({
   return null
 }
 
-const resolveReusablePaymentCollection = ({
-  cartPaymentProviderId,
-  paymentCollection,
-  selectedPaymentProviderId,
-}: Pick<
-  UseCheckoutActionsProps,
-  "cartPaymentProviderId" | "paymentCollection" | "selectedPaymentProviderId"
->) => {
-  if (
-    !paymentCollection ||
-    !selectedPaymentProviderId ||
-    cartPaymentProviderId !== selectedPaymentProviderId
-  ) {
-    return null
-  }
-
-  return paymentCollection
-}
-
 export function useCheckoutActions({
+  cart,
   cartId,
-  cartPaymentProviderId,
   canInitiatePayment,
   completedOrderId,
   completeCart,
@@ -96,7 +78,7 @@ export function useCheckoutActions({
   onOrderCompletionStart,
   onPaymentProviderSelect,
   onPaymentRedirect,
-  paymentCollection,
+  refreshCart,
   selectedPaymentProviderId,
   selectedShippingMethodId,
   setShippingMethod,
@@ -170,12 +152,15 @@ export function useCheckoutActions({
     onOrderCompletionStart()
 
     try {
+      const latestCart = (await refreshCart?.()) ?? cart
+      const reusablePaymentCollection = resolveReusablePaymentCollection({
+        cart: latestCart,
+        selectedPaymentProviderId,
+      })
+
       const resolvedPaymentCollection =
-        resolveReusablePaymentCollection({
-          cartPaymentProviderId,
-          paymentCollection,
-          selectedPaymentProviderId,
-        }) ?? (await initiatePayment(selectedPaymentProviderId))
+        reusablePaymentCollection ??
+        (await initiatePayment(selectedPaymentProviderId))
       const paymentRedirectUrl = resolvePaymentRedirectUrl(
         resolvedPaymentCollection
       )

--- a/apps/herbatika/src/components/checkout/use-checkout-actions.ts
+++ b/apps/herbatika/src/components/checkout/use-checkout-actions.ts
@@ -1,5 +1,6 @@
 "use client"
 
+import type { HttpTypes } from "@medusajs/types"
 import { resolveErrorMessage } from "@/lib/storefront/error-utils"
 import {
   clearStoredCarrierPickupSelection,
@@ -13,12 +14,14 @@ import { resolvePaymentRedirectUrl } from "./checkout-payment-redirect.utils"
 
 type UseCheckoutActionsProps = {
   cartId?: string
+  cartPaymentProviderId?: string | null
   completedOrderId: string | null
   onCompletedOrderIdChange: (orderId: string | null) => void
   onOrderCompletionAbort: () => void
   onOrderCompletionStart: () => void
   onPaymentRedirect: (url: string) => void
   itemCount: number
+  paymentCollection?: HttpTypes.StorePaymentCollection | null
   canInitiatePayment: boolean
   selectedPaymentProviderId?: string | null
   selectedShippingMethodId?: string | null
@@ -60,8 +63,28 @@ const resolveOrderCompletionBlocker = ({
   return null
 }
 
+const resolveReusablePaymentCollection = ({
+  cartPaymentProviderId,
+  paymentCollection,
+  selectedPaymentProviderId,
+}: Pick<
+  UseCheckoutActionsProps,
+  "cartPaymentProviderId" | "paymentCollection" | "selectedPaymentProviderId"
+>) => {
+  if (
+    !paymentCollection ||
+    !selectedPaymentProviderId ||
+    cartPaymentProviderId !== selectedPaymentProviderId
+  ) {
+    return null
+  }
+
+  return paymentCollection
+}
+
 export function useCheckoutActions({
   cartId,
+  cartPaymentProviderId,
   canInitiatePayment,
   completedOrderId,
   completeCart,
@@ -73,6 +96,7 @@ export function useCheckoutActions({
   onOrderCompletionStart,
   onPaymentProviderSelect,
   onPaymentRedirect,
+  paymentCollection,
   selectedPaymentProviderId,
   selectedShippingMethodId,
   setShippingMethod,
@@ -146,8 +170,15 @@ export function useCheckoutActions({
     onOrderCompletionStart()
 
     try {
-      const paymentCollection = await initiatePayment(selectedPaymentProviderId)
-      const paymentRedirectUrl = resolvePaymentRedirectUrl(paymentCollection)
+      const resolvedPaymentCollection =
+        resolveReusablePaymentCollection({
+          cartPaymentProviderId,
+          paymentCollection,
+          selectedPaymentProviderId,
+        }) ?? (await initiatePayment(selectedPaymentProviderId))
+      const paymentRedirectUrl = resolvePaymentRedirectUrl(
+        resolvedPaymentCollection
+      )
 
       if (paymentRedirectUrl) {
         onPaymentRedirect(paymentRedirectUrl)

--- a/apps/herbatika/src/components/checkout/use-checkout-controller.ts
+++ b/apps/herbatika/src/components/checkout/use-checkout-controller.ts
@@ -51,7 +51,7 @@ import { resolveHasStoredAddress } from "./checkout-address.utils"
 import { resolveOrderId } from "./checkout-completion.utils"
 import {
   clearStoredPaymentProviderSelection,
-  readStoredPaymentProviderSelection,
+  useStoredPaymentProviderSelection,
   writeStoredPaymentProviderSelection,
 } from "./checkout-payment-selection-storage"
 import { useCheckoutActions } from "./use-checkout-actions"
@@ -74,11 +74,6 @@ export function useCheckoutController() {
   const [completedOrderId, setCompletedOrderId] = useState<string | null>(null)
   const [marketingConsent, setMarketingConsent] = useState(false)
   const [heurekaConsent, setHeurekaConsent] = useState(false)
-  const [selectedPaymentProviderState, setSelectedPaymentProviderState] =
-    useState<{ cartId?: string | null; providerId: string | null }>({
-      cartId: null,
-      providerId: null,
-    })
   const saveAddressSucceededRef = useRef(false)
 
   const cartQuery = useCart({
@@ -125,39 +120,12 @@ export function useCheckoutController() {
   const cartSelectedPaymentProviderId = resolveSelectedPaymentProviderId(
     cartQuery.cart
   )
-  const storedPaymentProviderId = readStoredPaymentProviderSelection(
+  const storedPaymentProviderId = useStoredPaymentProviderSelection(
     cartQuery.cart?.id
   )
-  const selectedPaymentProviderId =
-    selectedPaymentProviderState.cartId === cartQuery.cart?.id
-      ? selectedPaymentProviderState.providerId
-      : null
   const effectiveSelectedPaymentProviderId =
-    selectedPaymentProviderId ??
     storedPaymentProviderId ??
     cartSelectedPaymentProviderId
-
-  useEffect(() => {
-    const cartId = cartQuery.cart?.id
-    if (!cartId) {
-      return
-    }
-
-    const providerId =
-      readStoredPaymentProviderSelection(cartId) ??
-      cartSelectedPaymentProviderId
-
-    setSelectedPaymentProviderState((current) => {
-      if (current.cartId === cartId && current.providerId) {
-        return current
-      }
-
-      return {
-        cartId,
-        providerId: providerId ?? null,
-      }
-    })
-  }, [cartQuery.cart?.id, cartSelectedPaymentProviderId])
 
   useEffect(() => {
     const cartId = cartQuery.cart?.id
@@ -210,8 +178,8 @@ export function useCheckoutController() {
   )
 
   const actions = useCheckoutActions({
+    cart: cartQuery.cart,
     cartId: cartQuery.cart?.id,
-    cartPaymentProviderId: cartSelectedPaymentProviderId,
     canInitiatePayment: checkoutPaymentQuery.canInitiatePayment,
     completedOrderId,
     completeCart: async () => {
@@ -254,10 +222,6 @@ export function useCheckoutController() {
     },
     onCheckoutErrorChange: setCheckoutError,
     onPaymentProviderSelect: (providerId) => {
-      setSelectedPaymentProviderState({
-        cartId: cartQuery.cart?.id,
-        providerId,
-      })
       writeStoredPaymentProviderSelection({
         cartId: cartQuery.cart?.id,
         providerId,
@@ -266,7 +230,10 @@ export function useCheckoutController() {
     onPaymentRedirect: (url) => {
       window.location.assign(url)
     },
-    paymentCollection: cartQuery.cart?.payment_collection,
+    refreshCart: async () => {
+      const result = await cartQuery.query.refetch()
+      return result.data ?? null
+    },
     selectedPaymentProviderId: effectiveSelectedPaymentProviderId,
     selectedShippingMethodId: checkoutShippingQuery.selectedShippingMethodId,
     setShippingMethod: checkoutShippingQuery.setShipping,

--- a/apps/herbatika/src/components/checkout/use-checkout-controller.ts
+++ b/apps/herbatika/src/components/checkout/use-checkout-controller.ts
@@ -134,8 +134,8 @@ export function useCheckoutController() {
       : null
   const effectiveSelectedPaymentProviderId =
     selectedPaymentProviderId ??
-    cartSelectedPaymentProviderId ??
-    storedPaymentProviderId
+    storedPaymentProviderId ??
+    cartSelectedPaymentProviderId
 
   useEffect(() => {
     const cartId = cartQuery.cart?.id
@@ -144,8 +144,8 @@ export function useCheckoutController() {
     }
 
     const providerId =
-      cartSelectedPaymentProviderId ??
-      readStoredPaymentProviderSelection(cartId)
+      readStoredPaymentProviderSelection(cartId) ??
+      cartSelectedPaymentProviderId
 
     setSelectedPaymentProviderState((current) => {
       if (current.cartId === cartId && current.providerId) {
@@ -154,7 +154,7 @@ export function useCheckoutController() {
 
       return {
         cartId,
-        providerId,
+        providerId: providerId ?? null,
       }
     })
   }, [cartQuery.cart?.id, cartSelectedPaymentProviderId])
@@ -211,6 +211,7 @@ export function useCheckoutController() {
 
   const actions = useCheckoutActions({
     cartId: cartQuery.cart?.id,
+    cartPaymentProviderId: cartSelectedPaymentProviderId,
     canInitiatePayment: checkoutPaymentQuery.canInitiatePayment,
     completedOrderId,
     completeCart: async () => {
@@ -265,6 +266,7 @@ export function useCheckoutController() {
     onPaymentRedirect: (url) => {
       window.location.assign(url)
     },
+    paymentCollection: cartQuery.cart?.payment_collection,
     selectedPaymentProviderId: effectiveSelectedPaymentProviderId,
     selectedShippingMethodId: checkoutShippingQuery.selectedShippingMethodId,
     setShippingMethod: checkoutShippingQuery.setShipping,

--- a/apps/herbatika/src/lib/storefront/storefront-config.ts
+++ b/apps/herbatika/src/lib/storefront/storefront-config.ts
@@ -93,6 +93,7 @@ export const CART_FIELDS = [
   "region.*",
   "promotions.*",
   "payment_collection.*",
+  "payment_collection.payment_sessions.*",
   "*items",
   "items.tax_lines.*",
   "items.adjustments.*",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved checkout payment collection reuse to better support returning customers and prevent unnecessary new payment collection creation when possible.
  * Updated payment-provider selection to stay in sync across the checkout flow, including after cart refreshes.
  * Enhanced payment session matching to ensure the selected session aligns with the cart total before redirecting to payment.  
* **New Features**
  * Added live updates for stored payment-provider selection, including support for cross-tab changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->