### PR TITLE
fix(herbatica): fix ui after update search form in libs/ui

### DIFF
--- a/apps/herbatika/src/components/search/search-autocomplete.tsx
+++ b/apps/herbatika/src/components/search/search-autocomplete.tsx
@@ -39,14 +39,22 @@ export function SearchAutocomplete({
         onValueChange={controller.handleValueChange}
         value={controller.value}
       >
-        <SearchForm.Control className="h-search-form border border-border-search bg-fill-secondary">
+        {/*
+        border border-border-search overflow-hidden
+        */}
+        <SearchForm.Control className="h-search-form rounded-base bg-fill-secondary">
           <SearchForm.Input
             aria-activedescendant={controller.activeItemId}
             aria-autocomplete="list"
             aria-controls={controller.hasItems ? controller.panelId : undefined}
             aria-expanded={controller.shouldShowPanel}
             aria-haspopup="listbox"
-            className={`${isMobile ? "px-350 text-sm" : "px-400"} h-full font-verdana`}
+            className={`${isMobile ? "px-350 text-sm" : "px-400"}
+              border-none h-full font-verdana
+             -outline-offset-1 outline outline-border-search
+             focus-visible:outline-offset-0 focus-visible:outline-search-form-focused
+            
+            `}
             maxLength={SEARCH_AUTOCOMPLETE_MAX_QUERY_LENGTH}
             name="q"
             onFocus={controller.handleFocus}
@@ -54,15 +62,15 @@ export function SearchAutocomplete({
             placeholder="Napíšte, čo hľadáte..."
             role="combobox"
           />
-          <SearchForm.ClearButton
-            aria-label="Vymazať vyhľadávanie"
-            className="text-fg-secondary hover:text-fg-primary"
-          />
           <SearchForm.Button
             aria-label="Hľadať"
-            className="rounded-none"
+            className="rounded-none rounded-r-base h-full focus-visible:bg-success focus-visible:outline-offset-0 focus-visible:outline-search-form-focused"
             iconSize={isMobile ? "lg" : "xl"}
             showSearchIcon
+          />
+          <SearchForm.ClearButton
+            aria-label="Vymazať vyhľadávanie"
+            className="text-fg-secondary hover:text-fg-primary right-0"
           />
         </SearchForm.Control>
 

--- a/apps/herbatika/src/components/search/search-autocomplete.tsx
+++ b/apps/herbatika/src/components/search/search-autocomplete.tsx
@@ -39,9 +39,6 @@ export function SearchAutocomplete({
         onValueChange={controller.handleValueChange}
         value={controller.value}
       >
-        {/*
-        border border-border-search overflow-hidden
-        */}
         <SearchForm.Control className="h-search-form rounded-base bg-fill-secondary">
           <SearchForm.Input
             aria-activedescendant={controller.activeItemId}
@@ -49,12 +46,7 @@ export function SearchAutocomplete({
             aria-controls={controller.hasItems ? controller.panelId : undefined}
             aria-expanded={controller.shouldShowPanel}
             aria-haspopup="listbox"
-            className={`${isMobile ? "px-350 text-sm" : "px-400"}
-              border-none h-full font-verdana
-             -outline-offset-1 outline outline-border-search
-             focus-visible:outline-offset-0 focus-visible:outline-search-form-focused
-            
-            `}
+            className={`${isMobile ? "px-350 text-sm" : "px-400"} border-none h-full font-verdana -outline-offset-1 outline outline-border-search focus-visible:outline-offset-0 focus-visible:outline-search-form-border-focused`}
             maxLength={SEARCH_AUTOCOMPLETE_MAX_QUERY_LENGTH}
             name="q"
             onFocus={controller.handleFocus}
@@ -64,7 +56,7 @@ export function SearchAutocomplete({
           />
           <SearchForm.Button
             aria-label="Hľadať"
-            className="rounded-none rounded-r-base h-full focus-visible:bg-success focus-visible:outline-offset-0 focus-visible:outline-search-form-focused"
+            className="rounded-none rounded-r-base h-full focus-visible:bg-search-form-bg-focused focus-visible:outline-offset-0 focus-visible:outline-search-form-border-focused"
             iconSize={isMobile ? "lg" : "xl"}
             showSearchIcon
           />

--- a/apps/herbatika/src/styles/tokens/components/molecules/_herbatika-search-form.css
+++ b/apps/herbatika/src/styles/tokens/components/molecules/_herbatika-search-form.css
@@ -8,5 +8,6 @@
   --color-form-control-border-focus: var(--color-primary);
   --color-form-control-fg-placeholder: var(--color-fg-placeholder);
 
-  --color-search-form-focused: var(--color-black);
+  --color-search-form-border-focused: var(--color-black);
+  --color-search-form-bg-focused: var(--color-button-bg-primary-hover);
 }

--- a/apps/herbatika/src/styles/tokens/components/molecules/_herbatika-search-form.css
+++ b/apps/herbatika/src/styles/tokens/components/molecules/_herbatika-search-form.css
@@ -7,4 +7,6 @@
   --color-form-control-border-hover: var(--color-border-primary);
   --color-form-control-border-focus: var(--color-primary);
   --color-form-control-fg-placeholder: var(--color-fg-placeholder);
+
+  --color-search-form-focused: var(--color-black);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated search form styling with improved focus states and refined outline/focus-visible behaviour.
  * Adjusted search and clear button layout, including clearer focus styling and updated positioning for the clear action.
  * Added a focused-state theme token to control the search form’s border and background appearance during interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->