### PR TITLE
feat(herbatika): add country-aware address validation

### DIFF
--- a/apps/herbatika/src/components/account-settings.tsx
+++ b/apps/herbatika/src/components/account-settings.tsx
@@ -8,6 +8,7 @@ import {
   AccountSkeletonSurface,
   AccountSurface,
 } from "@/components/account/account-surface"
+import { normalizePhoneNumberToSupportedE164 } from "@/lib/forms/address/phone"
 import { useHerbatikaForm } from "@/lib/forms/core/herbatika-form"
 import {
   accountSettingsValidators,
@@ -32,10 +33,13 @@ export function AccountSettings() {
       setSubmitSuccess(null)
 
       try {
+        const normalizedPhone =
+          normalizePhoneNumberToSupportedE164(value.phone, "SK") ??
+          value.phone.trim()
         const payload = {
           first_name: value.first_name.trim(),
           last_name: value.last_name.trim(),
-          phone: value.phone.trim() || undefined,
+          phone: normalizedPhone || undefined,
           company_name: value.company_name.trim() || undefined,
         }
 
@@ -173,15 +177,16 @@ export function AccountSettings() {
           validators={accountSettingsValidators.phone}
         >
           {(field) => (
-            <field.TextField
+            <field.PhoneField
+              defaultCountry="SK"
               id="account-settings-phone"
               label="Telefón"
               onValueChange={() => {
                 setSubmitError(null)
                 setSubmitSuccess(null)
               }}
-              type="tel"
               validationMode="blur"
+              valueMode="e164WhenValid"
             />
           )}
         </form.AppField>

--- a/apps/herbatika/src/components/checkout/sections/checkout-address-section.tsx
+++ b/apps/herbatika/src/components/checkout/sections/checkout-address-section.tsx
@@ -4,6 +4,7 @@ import {
   resolveCheckoutAddressFieldName,
 } from "@/components/checkout/checkout-address.utils"
 import type { CheckoutDetailsFormController } from "@/components/checkout/use-checkout-details-form"
+import { normalizeHerbatikaAddressCountryCode } from "@/lib/forms/address/address-country-rules"
 import { checkoutFieldValidators } from "@/lib/forms/checkout/address-validators"
 import { CheckoutLoginPrompt } from "./checkout-login-prompt"
 import { CheckoutPurchaseTypeToggle } from "./checkout-purchase-type-toggle"
@@ -40,6 +41,10 @@ export function CheckoutAddressSection({
   title,
 }: CheckoutAddressSectionProps) {
   const scopedValidators = checkoutFieldValidators[scope]
+  const phoneDefaultCountry =
+    normalizeHerbatikaAddressCountryCode(
+      checkoutDetailsForm.values[scope].countryCode
+    ) ?? "SK"
 
   return (
     <section className="space-y-300 rounded-sm border border-border-primary bg-surface p-550 font-rubik">
@@ -187,10 +192,12 @@ export function CheckoutAddressSection({
               >
                 {(field) => (
                   <field.PhoneField
+                    defaultCountry={phoneDefaultCountry}
                     id={`${fieldPrefix}-phone`}
                     label="Telefón"
                     required
                     validationMode="blur"
+                    valueMode="e164WhenValid"
                   />
                 )}
               </checkoutDetailsForm.form.AppField>

--- a/apps/herbatika/src/components/checkout/sections/checkout-pickup-point-details-section.tsx
+++ b/apps/herbatika/src/components/checkout/sections/checkout-pickup-point-details-section.tsx
@@ -6,6 +6,7 @@ import {
 import { resolveCheckoutAddressFieldName } from "@/components/checkout/checkout-address.utils"
 import type { CheckoutDetailsFormController } from "@/components/checkout/use-checkout-details-form"
 import { SupportingText } from "@/components/text/supporting-text"
+import { normalizeHerbatikaAddressCountryCode } from "@/lib/forms/address/address-country-rules"
 import { checkoutFieldValidators } from "@/lib/forms/checkout/address-validators"
 import { CheckoutLoginPrompt } from "./checkout-login-prompt"
 import { CheckoutPurchaseTypeToggle } from "./checkout-purchase-type-toggle"
@@ -24,6 +25,10 @@ export function CheckoutPickupPointDetailsSection({
   pickupAddress,
 }: CheckoutPickupPointDetailsSectionProps) {
   const isCompanyPurchase = checkoutDetailsForm.values.isCompanyPurchase
+  const phoneDefaultCountry =
+    normalizeHerbatikaAddressCountryCode(
+      checkoutDetailsForm.values.shipping.countryCode
+    ) ?? "SK"
 
   return (
     <>
@@ -104,10 +109,12 @@ export function CheckoutPickupPointDetailsSection({
             >
               {(field) => (
                 <field.PhoneField
+                  defaultCountry={phoneDefaultCountry}
                   id="checkout-pickup-phone"
                   label="Telefón"
                   required
                   validationMode="blur"
+                  valueMode="e164WhenValid"
                 />
               )}
             </checkoutDetailsForm.form.AppField>

--- a/apps/herbatika/src/components/forms/form-phone-field.tsx
+++ b/apps/herbatika/src/components/forms/form-phone-field.tsx
@@ -3,7 +3,9 @@
 import { Icon } from "@techsio/ui-kit/atoms/icon"
 import {
   PhoneInput,
+  type PhoneInputCountryChangeDetails,
   type PhoneInputCountry,
+  type PhoneInputValueChangeDetails,
 } from "@techsio/ui-kit/molecules/phone-input"
 import { type ReactNode, useState } from "react"
 import {
@@ -16,10 +18,15 @@ type FormPhoneFieldProps = {
   id: string
   label: ReactNode
   countries?: PhoneInputCountry[]
+  country?: PhoneInputCountry["value"]
+  countryName?: string
   defaultCountry?: PhoneInputCountry["value"]
   placeholder?: string
   required?: boolean
   validationMode?: "none" | "blur"
+  valueMode?: "display" | "e164WhenValid"
+  onCountryChange?: (details: PhoneInputCountryChangeDetails) => void
+  onDetailsChange?: (details: PhoneInputValueChangeDetails) => void
   onValueChange?: (value: string) => void
 }
 
@@ -76,12 +83,17 @@ const CHECKOUT_PHONE_COUNTRIES: PhoneInputCountry[] = [
 
 export function FormPhoneField({
   countries = CHECKOUT_PHONE_COUNTRIES,
+  country,
+  countryName,
   defaultCountry = "SK",
   id,
   label,
+  onCountryChange,
+  onDetailsChange,
   onValueChange,
   placeholder = "900 123 456",
   required = false,
+  valueMode = "display",
   validationMode = "blur",
 }: FormPhoneFieldProps) {
   const field = useFieldContext<string>()
@@ -97,9 +109,12 @@ export function FormPhoneField({
   return (
     <PhoneInput
       countries={countries}
+      country={country}
+      countryName={countryName}
       defaultCountry={defaultCountry}
       id={id}
       name={field.name}
+      onCountryChange={onCountryChange}
       onValueChange={(details) => {
         if (
           shouldTrackLiveFieldFeedback({
@@ -110,8 +125,14 @@ export function FormPhoneField({
           setHasChangedSinceBlur(true)
         }
 
-        field.handleChange(details.value)
-        onValueChange?.(details.value)
+        const nextValue =
+          valueMode === "e164WhenValid" && details.e164
+            ? details.e164.toString()
+            : details.value
+
+        field.handleChange(nextValue)
+        onDetailsChange?.(details)
+        onValueChange?.(nextValue)
       }}
       required={required}
       validateStatus={fieldFeedback.validateStatus}

--- a/apps/herbatika/src/lib/auth/auth-form-validators.ts
+++ b/apps/herbatika/src/lib/auth/auth-form-validators.ts
@@ -1,4 +1,5 @@
 import { checkoutAddressFieldValidators } from "@/lib/forms/checkout/address-validators"
+import { createCountryAwarePostalCodeFieldValidators } from "@/lib/forms/address/tanstack-validators"
 import {
   createChangeBlurContextualFieldValidators,
   createChangeBlurFieldValidators,
@@ -53,6 +54,8 @@ type ConfirmPasswordFieldApi = {
     getFieldValue: (name: "password") => unknown
   }
 }
+
+const BILLING_COUNTRY_FIELD_NAME = "billing_country_code"
 
 export const isWholesaleRegistration = (values: RegisterFormValues) =>
   values.account_type === "wholesale"
@@ -131,9 +134,12 @@ export const registerValidators = {
   billing_city: createWholesaleFieldValidators(
     checkoutAddressFieldValidators.city
   ),
-  billing_postal_code: createWholesaleFieldValidators(
-    checkoutAddressFieldValidators.postalCode
-  ),
+  billing_postal_code: createCountryAwarePostalCodeFieldValidators({
+    countryFieldName: BILLING_COUNTRY_FIELD_NAME,
+    getCountryCode: (values: RegisterFormValues) =>
+      values.billing_country_code,
+    shouldValidate: isWholesaleRegistration,
+  }),
   billing_country_code: createWholesaleFieldValidators(
     checkoutAddressFieldValidators.countryCode
   ),

--- a/apps/herbatika/src/lib/auth/register-payload.ts
+++ b/apps/herbatika/src/lib/auth/register-payload.ts
@@ -2,6 +2,7 @@ import {
   isWholesaleRegistration,
   type RegisterFormValues,
 } from "@/lib/auth/auth-form-validators"
+import { formatPostalCodeForCountry } from "@/lib/forms/address/postal-code"
 import { normalizeCountryCode } from "@/lib/forms/country-options"
 import type { AuthRegisterInput } from "@/lib/storefront/auth"
 
@@ -10,6 +11,12 @@ type BuildAuthRegisterInputOptions = {
 }
 
 const trimValue = (value: string) => value.trim()
+
+const normalizeRegisterPostalCode = (values: RegisterFormValues) =>
+  formatPostalCodeForCountry(
+    values.billing_postal_code,
+    values.billing_country_code
+  ) ?? trimValue(values.billing_postal_code)
 
 export const buildAuthRegisterInput = (
   values: RegisterFormValues,
@@ -29,7 +36,7 @@ export const buildAuthRegisterInput = (
             address_1: trimValue(values.billing_address_1),
             address_2: trimValue(values.billing_address_2) || undefined,
             city: trimValue(values.billing_city),
-            postal_code: trimValue(values.billing_postal_code),
+            postal_code: normalizeRegisterPostalCode(values),
             country_code:
               normalizeCountryCode(values.billing_country_code) ??
               trimValue(values.billing_country_code),

--- a/apps/herbatika/src/lib/forms/address/address-country-rules.ts
+++ b/apps/herbatika/src/lib/forms/address/address-country-rules.ts
@@ -1,0 +1,81 @@
+import { normalizeCountryCode } from "../country-options"
+
+export const HERBATIKA_ADDRESS_COUNTRY_CODES = [
+  "SK",
+  "CZ",
+  "AT",
+  "HU",
+] as const
+
+export type HerbatikaAddressCountryCode =
+  (typeof HERBATIKA_ADDRESS_COUNTRY_CODES)[number]
+
+type PostalCodeRule = {
+  digitCount: number
+  example: string
+  groupAfterDigit?: number
+}
+
+type AddressCountryRule = {
+  code: HerbatikaAddressCountryCode
+  label: string
+  postalCode: PostalCodeRule
+}
+
+export const HERBATIKA_ADDRESS_COUNTRY_RULES = {
+  AT: {
+    code: "AT",
+    label: "Rakúsko",
+    postalCode: {
+      digitCount: 4,
+      example: "1010",
+    },
+  },
+  CZ: {
+    code: "CZ",
+    label: "Česko",
+    postalCode: {
+      digitCount: 5,
+      example: "110 00",
+      groupAfterDigit: 3,
+    },
+  },
+  HU: {
+    code: "HU",
+    label: "Maďarsko",
+    postalCode: {
+      digitCount: 4,
+      example: "1051",
+    },
+  },
+  SK: {
+    code: "SK",
+    label: "Slovensko",
+    postalCode: {
+      digitCount: 5,
+      example: "811 01",
+      groupAfterDigit: 3,
+    },
+  },
+} as const satisfies Record<HerbatikaAddressCountryCode, AddressCountryRule>
+
+const supportedCountryCodeSet = new Set<string>(HERBATIKA_ADDRESS_COUNTRY_CODES)
+
+export const isHerbatikaAddressCountryCode = (
+  countryCode: string | null | undefined
+): countryCode is HerbatikaAddressCountryCode =>
+  Boolean(countryCode && supportedCountryCodeSet.has(countryCode))
+
+export const normalizeHerbatikaAddressCountryCode = (
+  countryCode: string | null | undefined
+): HerbatikaAddressCountryCode | null => {
+  const normalized = normalizeCountryCode(countryCode)
+  return isHerbatikaAddressCountryCode(normalized) ? normalized : null
+}
+
+export const getHerbatikaAddressCountryRule = (
+  countryCode: string | null | undefined
+) => {
+  const normalized = normalizeHerbatikaAddressCountryCode(countryCode)
+  return normalized ? HERBATIKA_ADDRESS_COUNTRY_RULES[normalized] : null
+}

--- a/apps/herbatika/src/lib/forms/address/phone.ts
+++ b/apps/herbatika/src/lib/forms/address/phone.ts
@@ -1,0 +1,180 @@
+import {
+  getPhoneInputValueDetails,
+  type PhoneInputValueChangeDetails,
+} from "@techsio/ui-kit/molecules/phone-input"
+import {
+  HERBATIKA_ADDRESS_COUNTRY_CODES,
+  normalizeHerbatikaAddressCountryCode,
+  type HerbatikaAddressCountryCode,
+} from "./address-country-rules"
+
+export type PhoneNumberValidationIssue =
+  | "invalid_country"
+  | "invalid_number"
+  | "required"
+
+export type PhoneNumberValidationResult =
+  | {
+      country: HerbatikaAddressCountryCode
+      details: PhoneInputValueChangeDetails
+      e164: string
+      issue?: never
+      message?: never
+      valid: true
+    }
+  | {
+      country?: HerbatikaAddressCountryCode
+      details?: PhoneInputValueChangeDetails
+      e164?: never
+      issue: PhoneNumberValidationIssue
+      message: string
+      valid: false
+    }
+
+export const validateOptionalPhoneNumberForCountry = (
+  value: string,
+  countryCode: string | null | undefined
+): PhoneNumberValidationResult | undefined => {
+  const trimmedValue = value.trim()
+
+  if (!trimmedValue) {
+    return
+  }
+
+  const normalizedCountryCode = normalizeHerbatikaAddressCountryCode(countryCode)
+  if (!normalizedCountryCode) {
+    return {
+      issue: "invalid_country",
+      message: "Vyberte predvoľbu telefónu.",
+      valid: false,
+    }
+  }
+
+  const details = getPhoneInputValueDetails(trimmedValue, normalizedCountryCode)
+
+  if (!(details.isValid && details.e164)) {
+    return {
+      country: normalizedCountryCode,
+      details,
+      issue: "invalid_number",
+      message: "Zadajte platné telefónne číslo.",
+      valid: false,
+    }
+  }
+
+  return {
+    country: normalizedCountryCode,
+    details,
+    e164: details.e164.toString(),
+    valid: true,
+  }
+}
+
+export const validateRequiredPhoneNumberForCountry = (
+  value: string,
+  countryCode: string | null | undefined
+): PhoneNumberValidationResult => {
+  if (!value.trim()) {
+    return {
+      issue: "required",
+      message: "Zadajte telefón.",
+      valid: false,
+    }
+  }
+
+  return (
+    validateOptionalPhoneNumberForCountry(value, countryCode) ?? {
+      issue: "required",
+      message: "Zadajte telefón.",
+      valid: false,
+    }
+  )
+}
+
+export const validateOptionalPhoneNumberForSupportedCountries = (
+  value: string,
+  preferredCountryCode?: string | null
+): PhoneNumberValidationResult | undefined => {
+  const trimmedValue = value.trim()
+
+  if (!trimmedValue) {
+    return
+  }
+
+  const preferredCountry =
+    normalizeHerbatikaAddressCountryCode(preferredCountryCode)
+  const countryCodes = preferredCountry
+    ? [
+        preferredCountry,
+        ...HERBATIKA_ADDRESS_COUNTRY_CODES.filter(
+          (countryCode) => countryCode !== preferredCountry
+        ),
+      ]
+    : HERBATIKA_ADDRESS_COUNTRY_CODES
+
+  let fallbackResult: PhoneNumberValidationResult | undefined
+
+  for (const countryCode of countryCodes) {
+    const result = validateOptionalPhoneNumberForCountry(
+      trimmedValue,
+      countryCode
+    )
+
+    if (result?.valid) {
+      return result
+    }
+
+    fallbackResult ??= result
+  }
+
+  return (
+    fallbackResult ?? {
+      issue: "invalid_country",
+      message: "Vyberte predvoÄ¾bu telefÃ³nu.",
+      valid: false,
+    }
+  )
+}
+
+export const validateRequiredPhoneNumberForSupportedCountries = (
+  value: string,
+  preferredCountryCode?: string | null
+): PhoneNumberValidationResult => {
+  if (!value.trim()) {
+    return {
+      issue: "required",
+      message: "Zadajte telefÃ³n.",
+      valid: false,
+    }
+  }
+
+  return (
+    validateOptionalPhoneNumberForSupportedCountries(
+      value,
+      preferredCountryCode
+    ) ?? {
+      issue: "required",
+      message: "Zadajte telefÃ³n.",
+      valid: false,
+    }
+  )
+}
+
+export const normalizePhoneNumberToE164 = (
+  value: string,
+  countryCode: string | null | undefined
+) => {
+  const result = validateOptionalPhoneNumberForCountry(value, countryCode)
+  return result?.valid ? result.e164 : null
+}
+
+export const normalizePhoneNumberToSupportedE164 = (
+  value: string,
+  preferredCountryCode?: string | null
+) => {
+  const result = validateOptionalPhoneNumberForSupportedCountries(
+    value,
+    preferredCountryCode
+  )
+  return result?.valid ? result.e164 : null
+}

--- a/apps/herbatika/src/lib/forms/address/phone.ts
+++ b/apps/herbatika/src/lib/forms/address/phone.ts
@@ -130,7 +130,7 @@ export const validateOptionalPhoneNumberForSupportedCountries = (
   return (
     fallbackResult ?? {
       issue: "invalid_country",
-      message: "Vyberte predvoÄ¾bu telefÃ³nu.",
+      message: "Vyberte predvoľbu telefónu.",
       valid: false,
     }
   )
@@ -143,7 +143,7 @@ export const validateRequiredPhoneNumberForSupportedCountries = (
   if (!value.trim()) {
     return {
       issue: "required",
-      message: "Zadajte telefÃ³n.",
+      message: "Zadajte telefón.",
       valid: false,
     }
   }
@@ -154,7 +154,7 @@ export const validateRequiredPhoneNumberForSupportedCountries = (
       preferredCountryCode
     ) ?? {
       issue: "required",
-      message: "Zadajte telefÃ³n.",
+      message: "Zadajte telefón.",
       valid: false,
     }
   )

--- a/apps/herbatika/src/lib/forms/address/phone.ts
+++ b/apps/herbatika/src/lib/forms/address/phone.ts
@@ -160,14 +160,6 @@ export const validateRequiredPhoneNumberForSupportedCountries = (
   )
 }
 
-export const normalizePhoneNumberToE164 = (
-  value: string,
-  countryCode: string | null | undefined
-) => {
-  const result = validateOptionalPhoneNumberForCountry(value, countryCode)
-  return result?.valid ? result.e164 : null
-}
-
 export const normalizePhoneNumberToSupportedE164 = (
   value: string,
   preferredCountryCode?: string | null

--- a/apps/herbatika/src/lib/forms/address/postal-code.ts
+++ b/apps/herbatika/src/lib/forms/address/postal-code.ts
@@ -93,7 +93,7 @@ export const validatePostalCodeForCountry = (
   }
 
   return {
-    formattedValue: formatPostalCodeForCountry(trimmedValue, rule.code) ?? "",
+    formattedValue: formatPostalCodeForCountry(trimmedValue, rule.code)!,
     normalizedDigits,
     valid: true,
   }

--- a/apps/herbatika/src/lib/forms/address/postal-code.ts
+++ b/apps/herbatika/src/lib/forms/address/postal-code.ts
@@ -1,0 +1,100 @@
+import { getHerbatikaAddressCountryRule } from "./address-country-rules"
+
+const POSTAL_CODE_ALLOWED_PATTERN = /^[0-9\s-]+$/
+
+export type PostalCodeValidationIssue =
+  | "invalid_characters"
+  | "invalid_country"
+  | "invalid_length"
+  | "required"
+
+export type PostalCodeValidationResult =
+  | {
+      formattedValue: string
+      issue?: never
+      message?: never
+      normalizedDigits: string
+      valid: true
+    }
+  | {
+      formattedValue?: never
+      issue: PostalCodeValidationIssue
+      message: string
+      normalizedDigits?: string
+      valid: false
+    }
+
+export const normalizePostalCodeDigits = (value: string) =>
+  value.trim().replace(/[\s-]+/g, "")
+
+export const formatPostalCodeForCountry = (
+  value: string,
+  countryCode: string | null | undefined
+) => {
+  const rule = getHerbatikaAddressCountryRule(countryCode)
+  const normalizedDigits = normalizePostalCodeDigits(value)
+
+  if (!rule || normalizedDigits.length !== rule.postalCode.digitCount) {
+    return null
+  }
+
+  const groupAfterDigit =
+    "groupAfterDigit" in rule.postalCode
+      ? rule.postalCode.groupAfterDigit
+      : undefined
+  if (!groupAfterDigit) {
+    return normalizedDigits
+  }
+
+  return `${normalizedDigits.slice(0, groupAfterDigit)} ${normalizedDigits.slice(
+    groupAfterDigit
+  )}`
+}
+
+export const validatePostalCodeForCountry = (
+  value: string,
+  countryCode: string | null | undefined
+): PostalCodeValidationResult => {
+  const trimmedValue = value.trim()
+
+  if (!trimmedValue) {
+    return {
+      issue: "required",
+      message: "Zadajte PSČ.",
+      valid: false,
+    }
+  }
+
+  if (!POSTAL_CODE_ALLOWED_PATTERN.test(trimmedValue)) {
+    return {
+      issue: "invalid_characters",
+      message: "Zadajte platné PSČ.",
+      valid: false,
+    }
+  }
+
+  const rule = getHerbatikaAddressCountryRule(countryCode)
+  if (!rule) {
+    return {
+      issue: "invalid_country",
+      message: "Vyberte krajinu.",
+      valid: false,
+    }
+  }
+
+  const normalizedDigits = normalizePostalCodeDigits(trimmedValue)
+  if (normalizedDigits.length !== rule.postalCode.digitCount) {
+    return {
+      issue: "invalid_length",
+      message: `PSČ pre ${rule.label} musí obsahovať ${rule.postalCode.digitCount} číslic. Príklad: ${rule.postalCode.example}.`,
+      normalizedDigits,
+      valid: false,
+    }
+  }
+
+  return {
+    formattedValue: formatPostalCodeForCountry(trimmedValue, rule.code) ?? "",
+    normalizedDigits,
+    valid: true,
+  }
+}

--- a/apps/herbatika/src/lib/forms/address/tanstack-validators.ts
+++ b/apps/herbatika/src/lib/forms/address/tanstack-validators.ts
@@ -1,0 +1,101 @@
+import { createChangeBlurSubmitContextualFieldValidators } from "@/lib/forms/validators/field-validator-factories"
+import { validateRequiredPhoneNumberForSupportedCountries } from "./phone"
+import { validatePostalCodeForCountry } from "./postal-code"
+
+export type AddressCountryCodeSelector<TFormValues> = (
+  values: TFormValues
+) => string | null | undefined
+
+export type AddressValidationPredicate<TFormValues> = (
+  values: TFormValues
+) => boolean
+
+type CountryAwareFieldValidatorOptions<TFormValues, TListenTo extends string> =
+  {
+    countryFieldName: TListenTo
+    getCountryCode: AddressCountryCodeSelector<TFormValues>
+    shouldValidate?: AddressValidationPredicate<TFormValues>
+  }
+
+export const validateRequiredPostalCodeWithCountry = <TFormValues>({
+  getCountryCode,
+  value,
+  values,
+}: {
+  getCountryCode: AddressCountryCodeSelector<TFormValues>
+  value: string
+  values: TFormValues
+}) => {
+  const result = validatePostalCodeForCountry(value, getCountryCode(values))
+
+  return result.valid ? undefined : result.message
+}
+
+export const validateRequiredPhoneNumberWithSupportedCountries = <TFormValues>({
+  getCountryCode,
+  value,
+  values,
+}: {
+  getCountryCode: AddressCountryCodeSelector<TFormValues>
+  value: string
+  values: TFormValues
+}) => {
+  const result = validateRequiredPhoneNumberForSupportedCountries(
+    value,
+    getCountryCode(values)
+  )
+
+  return result.valid ? undefined : result.message
+}
+
+export const createCountryAwarePostalCodeFieldValidators = <
+  TFormValues,
+  TListenTo extends string,
+>({
+  countryFieldName,
+  getCountryCode,
+  shouldValidate,
+}: CountryAwareFieldValidatorOptions<TFormValues, TListenTo>) =>
+  createChangeBlurSubmitContextualFieldValidators<
+    string,
+    TFormValues,
+    TListenTo
+  >(
+    ({ value, values }) =>
+      validateRequiredPostalCodeWithCountry({
+        getCountryCode,
+        value,
+        values,
+      }),
+    {
+      onBlurListenTo: [countryFieldName],
+      onChangeListenTo: [countryFieldName],
+      shouldValidate,
+    }
+  )
+
+export const createRequiredPhoneNumberFieldValidators = <
+  TFormValues,
+  TListenTo extends string,
+>({
+  countryFieldName,
+  getCountryCode,
+  shouldValidate,
+}: CountryAwareFieldValidatorOptions<TFormValues, TListenTo>) =>
+  createChangeBlurSubmitContextualFieldValidators<
+    string,
+    TFormValues,
+    TListenTo
+  >(
+    ({ value, values }) =>
+      validateRequiredPhoneNumberWithSupportedCountries({
+        getCountryCode,
+        value,
+        values,
+      }),
+    {
+      onBlurListenTo: [countryFieldName],
+      onChangeListenTo: [countryFieldName],
+      shouldValidate,
+    }
+  )

--- a/apps/herbatika/src/lib/forms/checkout/address-validators.ts
+++ b/apps/herbatika/src/lib/forms/checkout/address-validators.ts
@@ -1,3 +1,7 @@
+import {
+  createCountryAwarePostalCodeFieldValidators,
+  createRequiredPhoneNumberFieldValidators,
+} from "@/lib/forms/address/tanstack-validators"
 import type {
   CheckoutAddressValues,
   CheckoutDetailsValues,
@@ -7,13 +11,13 @@ import { createChangeBlurSubmitScopedFieldValidators } from "@/lib/forms/validat
 import {
   validateCustomerName,
   validateEmailAddress,
-  validateOptionalPhoneNumber,
 } from "@/lib/forms/validators/shared"
 
 type CheckoutAddressField = keyof CheckoutAddressValues
 type CheckoutAddressFieldValidator = (value: string) => string | undefined
 
-const POSTAL_CODE_ALLOWED_REGEX = /^[0-9\s-]+$/
+const BILLING_COUNTRY_FIELD_NAME = "billing.countryCode"
+const SHIPPING_COUNTRY_FIELD_NAME = "shipping.countryCode"
 
 const validateBillingFields = (values: CheckoutDetailsValues) =>
   !values.useSameAddress
@@ -43,34 +47,6 @@ const createRequiredTextValidator =
 
     return
   }
-
-const validateRequiredPhoneNumber: CheckoutAddressFieldValidator = (value) => {
-  if (!value.trim()) {
-    return "Zadajte telefón."
-  }
-
-  return validateOptionalPhoneNumber(value)
-}
-
-const validatePostalCode: CheckoutAddressFieldValidator = (value) => {
-  const normalized = value.trim()
-
-  if (!normalized) {
-    return "Zadajte PSČ."
-  }
-
-  if (!POSTAL_CODE_ALLOWED_REGEX.test(normalized)) {
-    return "Zadajte platné PSČ."
-  }
-
-  const digitCount = normalized.replace(/\D/g, "").length
-
-  if (digitCount < 4) {
-    return "PSČ musí obsahovať aspoň 4 číslice."
-  }
-
-  return
-}
 
 const validateCountryCode: CheckoutAddressFieldValidator = (value) => {
   if (!value.trim()) {
@@ -118,8 +94,6 @@ export const checkoutAddressFieldValidators = {
   email: validateEmailAddress,
   firstName: (value: string) => validateCustomerName(value, "Meno"),
   lastName: (value: string) => validateCustomerName(value, "Priezvisko"),
-  phone: validateRequiredPhoneNumber,
-  postalCode: validatePostalCode,
   taxId: (value: string) => validateCompanyIdentifier(value, "DIČ"),
 } as const satisfies Partial<
   Record<CheckoutAddressField, CheckoutAddressFieldValidator>
@@ -152,12 +126,16 @@ const shippingFieldValidators = {
   lastName: createChangeBlurSubmitScopedFieldValidators(
     checkoutAddressFieldValidators.lastName
   ),
-  phone: createChangeBlurSubmitScopedFieldValidators(
-    checkoutAddressFieldValidators.phone
-  ),
-  postalCode: createChangeBlurSubmitScopedFieldValidators(
-    checkoutAddressFieldValidators.postalCode
-  ),
+  phone: createRequiredPhoneNumberFieldValidators({
+    countryFieldName: SHIPPING_COUNTRY_FIELD_NAME,
+    getCountryCode: (values: CheckoutDetailsValues) =>
+      values.shipping.countryCode,
+  }),
+  postalCode: createCountryAwarePostalCodeFieldValidators({
+    countryFieldName: SHIPPING_COUNTRY_FIELD_NAME,
+    getCountryCode: (values: CheckoutDetailsValues) =>
+      values.shipping.countryCode,
+  }),
   taxId: createChangeBlurSubmitScopedFieldValidators(
     checkoutAddressFieldValidators.taxId,
     validateShippingCompanyFields
@@ -193,10 +171,12 @@ const billingFieldValidators = {
     checkoutAddressFieldValidators.lastName,
     validateBillingFields
   ),
-  postalCode: createChangeBlurSubmitScopedFieldValidators(
-    checkoutAddressFieldValidators.postalCode,
-    validateBillingFields
-  ),
+  postalCode: createCountryAwarePostalCodeFieldValidators({
+    countryFieldName: BILLING_COUNTRY_FIELD_NAME,
+    getCountryCode: (values: CheckoutDetailsValues) =>
+      values.billing.countryCode,
+    shouldValidate: validateBillingFields,
+  }),
   taxId: createChangeBlurSubmitScopedFieldValidators(
     checkoutAddressFieldValidators.taxId,
     validateBillingCompanyFields

--- a/apps/herbatika/src/lib/forms/validators/field-validator-factories.ts
+++ b/apps/herbatika/src/lib/forms/validators/field-validator-factories.ts
@@ -1,5 +1,9 @@
 type FieldValueValidator<TValue> = (value: TValue) => string | undefined
 type FieldValidationPredicate<TFormValues> = (values: TFormValues) => boolean
+type ScopedFieldValueValidator<TValue, TFormValues> = (context: {
+  value: TValue
+  values: TFormValues
+}) => string | undefined
 type ValueValidationContext<TValue> = {
   value: TValue
 }
@@ -12,6 +16,11 @@ type ScopedValueValidationContext<TValue, TFormValues> = {
     }
   }
   value: TValue
+}
+type ScopedFieldValidatorOptions<TFormValues, TListenTo extends string> = {
+  onBlurListenTo?: TListenTo[]
+  onChangeListenTo?: TListenTo[]
+  shouldValidate?: FieldValidationPredicate<TFormValues>
 }
 
 export const createChangeBlurFieldValidators = <TValue>(
@@ -61,5 +70,37 @@ export const createChangeBlurSubmitScopedFieldValidators = <
       validateWhenActive(fieldApi.form.state.values)
         ? validator(value)
         : undefined,
+  }
+}
+
+export const createChangeBlurSubmitContextualFieldValidators = <
+  TValue,
+  TFormValues,
+  TListenTo extends string = string,
+>(
+  validator: ScopedFieldValueValidator<TValue, TFormValues>,
+  options: ScopedFieldValidatorOptions<TFormValues, TListenTo> = {}
+) => {
+  const validateWhenActive =
+    options.shouldValidate ?? ((_values: TFormValues) => true)
+  const validate = ({
+    fieldApi,
+    value,
+  }: ScopedValueValidationContext<TValue, TFormValues>) => {
+    const values = fieldApi.form.state.values
+
+    return validateWhenActive(values) ? validator({ value, values }) : undefined
+  }
+
+  return {
+    ...(options.onBlurListenTo
+      ? { onBlurListenTo: options.onBlurListenTo }
+      : {}),
+    ...(options.onChangeListenTo
+      ? { onChangeListenTo: options.onChangeListenTo }
+      : {}),
+    onBlur: validate,
+    onChange: validate,
+    onSubmit: validate,
   }
 }

--- a/apps/herbatika/src/lib/forms/validators/shared.ts
+++ b/apps/herbatika/src/lib/forms/validators/shared.ts
@@ -1,6 +1,5 @@
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const PASSWORD_NUMBER_REGEX = /\d/
-const PHONE_ALLOWED_REGEX = /^[0-9+\s()-]+$/
 
 export const validateCustomerName = (
   value: string,
@@ -63,26 +62,6 @@ export const validatePasswordConfirmation = (
 export const validateRequiredAgreement = (value: boolean, message: string) => {
   if (!value) {
     return message
-  }
-
-  return
-}
-
-export const validateOptionalPhoneNumber = (value: string) => {
-  const normalized = value.trim()
-
-  if (!normalized) {
-    return
-  }
-
-  if (!PHONE_ALLOWED_REGEX.test(normalized)) {
-    return "Zadajte platné telefónne číslo."
-  }
-
-  const digitCount = normalized.replace(/\D/g, "").length
-
-  if (digitCount < 7) {
-    return "Telefónne číslo musí obsahovať aspoň 7 číslic."
   }
 
   return

--- a/apps/herbatika/src/lib/storefront/account-settings-validators.ts
+++ b/apps/herbatika/src/lib/storefront/account-settings-validators.ts
@@ -1,9 +1,7 @@
 import type { HttpTypes } from "@medusajs/types"
+import { validateOptionalPhoneNumberForSupportedCountries } from "@/lib/forms/address/phone"
 import { createChangeBlurFieldValidators } from "@/lib/forms/validators/field-validator-factories"
-import {
-  validateCustomerName,
-  validateOptionalPhoneNumber,
-} from "@/lib/forms/validators/shared"
+import { validateCustomerName } from "@/lib/forms/validators/shared"
 
 export type AccountSettingsValues = {
   first_name: string
@@ -19,7 +17,10 @@ export const accountSettingsValidators = {
   last_name: createChangeBlurFieldValidators((value: string) =>
     validateCustomerName(value, "Priezvisko")
   ),
-  phone: createChangeBlurFieldValidators(validateOptionalPhoneNumber),
+  phone: createChangeBlurFieldValidators((value: string) => {
+    const result = validateOptionalPhoneNumberForSupportedCountries(value, "SK")
+    return result?.valid === false ? result.message : undefined
+  }),
 }
 
 export const toAccountSettingsValues = (

--- a/apps/herbatika/src/lib/storefront/cart/address-adapter.ts
+++ b/apps/herbatika/src/lib/storefront/cart/address-adapter.ts
@@ -6,6 +6,8 @@ import {
   mapMedusaAddressToCheckoutAddress,
 } from "@techsio/storefront-data/checkout/address"
 import type { StorefrontCartAddressAdapter } from "@techsio/storefront-data/shared/address"
+import { formatPostalCodeForCountry } from "@/lib/forms/address/postal-code"
+import { normalizePhoneNumberToSupportedE164 } from "@/lib/forms/address/phone"
 import type { CheckoutAddressValues } from "@/lib/forms/checkout/address.form"
 
 const HERBATIKA_ADDRESS_METADATA_FIELDS = [
@@ -70,12 +72,23 @@ const readMetadataString = (
   key: string
 ) => normalizeOptionalString(metadata?.[key])
 
+const normalizeAddressPhone = (addressForm: CheckoutAddressValues) =>
+  normalizePhoneNumberToSupportedE164(
+    addressForm.phone,
+    addressForm.countryCode
+  ) ??
+  addressForm.phone
+
+const normalizeAddressPostalCode = (addressForm: CheckoutAddressValues) =>
+  formatPostalCodeForCountry(addressForm.postalCode, addressForm.countryCode) ??
+  addressForm.postalCode
+
 export const buildHerbatikaCheckoutAddressInput = (
   addressForm: CheckoutAddressValues
 ): HerbatikaCheckoutAddressInput => ({
   firstName: addressForm.firstName,
   lastName: addressForm.lastName,
-  phone: addressForm.phone,
+  phone: normalizeAddressPhone(addressForm),
   company: addressForm.company,
   companyId: addressForm.companyId,
   taxId: addressForm.taxId,
@@ -83,7 +96,7 @@ export const buildHerbatikaCheckoutAddressInput = (
   street: addressForm.address1,
   street2: addressForm.address2,
   city: addressForm.city,
-  postalCode: addressForm.postalCode,
+  postalCode: normalizeAddressPostalCode(addressForm),
   country: addressForm.countryCode,
   customerNote: addressForm.customerNote,
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Phone and postal code inputs now adapt to the selected country for country-specific formatting and validation (including checkout flows).
* **Bug Fixes**
  * Phone numbers are normalised to a supported E.164 format before saving/submitting.
  * Postal codes are validated and formatted using the correct country rules.
  * Account settings, checkout address, and contact sections now use consistent phone handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->