### PR TITLE
SS-01: Add Smart Suggest Cloudflare app shell

### DIFF
--- a/apps/smart-suggest/CONFIG.md
+++ b/apps/smart-suggest/CONFIG.md
@@ -1,0 +1,52 @@
+# Smart Suggest App Config
+
+`apps/smart-suggest` is a Cloudflare Worker app shell. This PR only proves the runtime and route structure; it does not implement suggestions, provider calls, storage, or Module Federation.
+
+## Local Runtime
+
+Run the Worker with Cloudflare tooling:
+
+```bash
+pnpm --dir apps/smart-suggest dev
+```
+
+Health endpoint:
+
+```bash
+curl http://localhost:8787/api/v1/health
+```
+
+`/sdk/*` is reserved for a future old-core global vanilla SDK asset. It currently returns `501` and must not be treated as implemented.
+
+## Variables
+
+| Name | Required | Purpose |
+| --- | --- | --- |
+| `SMART_SUGGEST_ENV` | No | Runtime name: `local`, `preview`, `staging`, `production`, or `test`. Defaults to `local`. |
+| `SMART_SUGGEST_VERSION` | No | Service version returned by `/api/v1/health`. Defaults to `0.0.0`. |
+| `SMART_SUGGEST_BUILD_ID` | No | Build identifier returned by `/api/v1/health`. Defaults to `local`. |
+| `SMART_SUGGEST_ALLOWED_ORIGINS` | No | Comma-separated HTTP(S) origins allowed for CORS. Defaults to local storefront ports. Use `*` only for intentionally public non-credentialed environments. |
+| `SMART_SUGGEST_DEFAULT_TENANT_ID` | No | Default tenant id used until API-key/tenant storage lands. Defaults to `default`. |
+| `SMART_SUGGEST_TENANT_HEADER` | No | Header used by future API clients to select a tenant. Defaults to `x-tenant-id`. |
+| `SMART_SUGGEST_PROVIDER_PRIORITY` | No | Comma-separated provider ids for future routing, for example `owned-data,mapy`. No provider calls exist in this PR. |
+
+## Bindings
+
+Future issues should use these binding names so route code stays stable:
+
+| Binding | Cloudflare type | Purpose |
+| --- | --- | --- |
+| `SMART_SUGGEST_DB` | D1 | Runtime tables owned by SS-02 and later. |
+| `SMART_SUGGEST_CONFIG` | KV | Tenant/API config snapshots when needed outside D1. |
+| `SMART_SUGGEST_CACHE` | KV | Owned-data/search cache metadata. |
+| `SMART_SUGGEST_PROVIDER_CACHE` | KV | External provider result cache, governed by explicit provider cache policy. |
+
+## Secrets
+
+Provider API keys must be configured with `wrangler secret put`, not committed in `wrangler.toml`.
+
+| Secret | Purpose |
+| --- | --- |
+| `SMART_SUGGEST_MAPY_API_KEY` | Future Mapy provider access. This PR does not read it for provider calls. |
+
+Raw user queries must not be logged or stored. This app shell has no query endpoint yet.

--- a/apps/smart-suggest/package.json
+++ b/apps/smart-suggest/package.json
@@ -12,7 +12,8 @@
     "dev": "wrangler dev --port 8787",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run",
-    "lint": "pnpm -w exec biome check --write apps/smart-suggest --diagnostic-level=error"
+    "lint": "pnpm -w exec biome check apps/smart-suggest --diagnostic-level=error",
+    "lint:fix": "pnpm -w exec biome check --write apps/smart-suggest --diagnostic-level=error"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/apps/smart-suggest/package.json
+++ b/apps/smart-suggest/package.json
@@ -7,12 +7,16 @@
     "node": "24.x"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && pnpm run deploy:dry-run",
+    "deploy:dry-run": "wrangler deploy --dry-run --outdir dist/worker",
+    "dev": "wrangler dev --port 8787",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "test": "pnpm run typecheck",
-    "lint": "pnpm -w exec biome lint apps/smart-suggest/src --diagnostic-level=error"
+    "test": "vitest run",
+    "lint": "pnpm -w exec biome check --write apps/smart-suggest --diagnostic-level=error"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.5",
+    "wrangler": "^4.100.0"
   }
 }

--- a/apps/smart-suggest/project.json
+++ b/apps/smart-suggest/project.json
@@ -14,6 +14,13 @@
         "command": "pnpm run build"
       }
     },
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/smart-suggest",
+        "command": "pnpm run dev"
+      }
+    },
     "typecheck": {
       "executor": "nx:run-commands",
       "options": {
@@ -26,6 +33,13 @@
       "options": {
         "cwd": "apps/smart-suggest",
         "command": "pnpm run test"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "apps/smart-suggest",
+        "command": "pnpm run lint"
       }
     }
   }

--- a/apps/smart-suggest/src/cloudflare-runtime.ts
+++ b/apps/smart-suggest/src/cloudflare-runtime.ts
@@ -1,0 +1,37 @@
+export type SmartSuggestD1Database = {
+  readonly prepare: (query: string) => SmartSuggestD1PreparedStatement
+}
+
+export type SmartSuggestD1PreparedStatement = {
+  readonly bind: (
+    ...values: readonly unknown[]
+  ) => SmartSuggestD1PreparedStatement
+  readonly first: <
+    Row extends Record<string, unknown> = Record<string, unknown>,
+  >() => Promise<Row | null>
+  readonly all: <
+    Row extends Record<string, unknown> = Record<string, unknown>,
+  >() => Promise<{
+    readonly results: readonly Row[]
+  }>
+  readonly run: () => Promise<unknown>
+}
+
+export type SmartSuggestKvNamespace = {
+  readonly get: (key: string) => Promise<string | null>
+  readonly put: (
+    key: string,
+    value: string,
+    options?: SmartSuggestKvPutOptions
+  ) => Promise<void>
+  readonly delete: (key: string) => Promise<void>
+}
+
+export type SmartSuggestKvPutOptions = {
+  readonly expirationTtl?: number
+  readonly metadata?: Record<string, unknown>
+}
+
+export type SmartSuggestWorkerHandler<Env> = {
+  readonly fetch: (request: Request, env: Env) => Response | Promise<Response>
+}

--- a/apps/smart-suggest/src/config.ts
+++ b/apps/smart-suggest/src/config.ts
@@ -168,14 +168,15 @@ function parseAllowedOrigins(
     return defaultAllowedOrigins
   }
 
-  for (const origin of origins) {
-    if (origin !== "*" && !isValidHttpOrigin(origin)) {
-      issues.push({
-        code: "invalid_origin",
-        message:
-          "SMART_SUGGEST_ALLOWED_ORIGINS must contain HTTP(S) origins or *.",
-      })
-    }
+  const invalidOrigins = origins.filter(
+    (origin) => origin !== "*" && !isValidHttpOrigin(origin)
+  )
+
+  if (invalidOrigins.length > 0) {
+    issues.push({
+      code: "invalid_origin",
+      message: `SMART_SUGGEST_ALLOWED_ORIGINS must contain HTTP(S) origins or *. Invalid: ${invalidOrigins.join(", ")}`,
+    })
   }
 
   return origins

--- a/apps/smart-suggest/src/config.ts
+++ b/apps/smart-suggest/src/config.ts
@@ -1,0 +1,268 @@
+import type {
+  SmartSuggestD1Database,
+  SmartSuggestKvNamespace,
+} from "./cloudflare-runtime"
+
+export type SmartSuggestRuntimeEnvironment =
+  | "local"
+  | "preview"
+  | "staging"
+  | "production"
+  | "test"
+
+export type SmartSuggestEnv = {
+  readonly SMART_SUGGEST_ENV?: string
+  readonly SMART_SUGGEST_VERSION?: string
+  readonly SMART_SUGGEST_BUILD_ID?: string
+  readonly SMART_SUGGEST_ALLOWED_ORIGINS?: string
+  readonly SMART_SUGGEST_DEFAULT_TENANT_ID?: string
+  readonly SMART_SUGGEST_TENANT_HEADER?: string
+  readonly SMART_SUGGEST_PROVIDER_PRIORITY?: string
+  readonly SMART_SUGGEST_DB?: SmartSuggestD1Database
+  readonly SMART_SUGGEST_CONFIG?: SmartSuggestKvNamespace
+  readonly SMART_SUGGEST_CACHE?: SmartSuggestKvNamespace
+  readonly SMART_SUGGEST_PROVIDER_CACHE?: SmartSuggestKvNamespace
+  readonly SMART_SUGGEST_MAPY_API_KEY?: string
+}
+
+export type SmartSuggestConfig = {
+  readonly serviceName: "smart-suggest"
+  readonly version: string
+  readonly buildId: string
+  readonly environment: SmartSuggestRuntimeEnvironment
+  readonly allowedOrigins: readonly string[]
+  readonly tenant: {
+    readonly defaultTenantId: string
+    readonly tenantHeader: string
+  }
+  readonly providerPriority: readonly string[]
+  readonly bindings: {
+    readonly d1: boolean
+    readonly configKv: boolean
+    readonly cacheKv: boolean
+    readonly providerCacheKv: boolean
+  }
+  readonly providerSecrets: {
+    readonly mapyApiKey: boolean
+  }
+}
+
+export type SmartSuggestConfigIssue = {
+  readonly code:
+    | "invalid_environment"
+    | "invalid_origin"
+    | "invalid_provider_id"
+    | "invalid_tenant_header"
+    | "invalid_tenant_id"
+  readonly message: string
+}
+
+export type SmartSuggestConfigResult =
+  | {
+      readonly ok: true
+      readonly config: SmartSuggestConfig
+    }
+  | {
+      readonly ok: false
+      readonly issues: readonly SmartSuggestConfigIssue[]
+    }
+
+const defaultAllowedOrigins = [
+  "http://localhost:3000",
+  "http://localhost:3001",
+] as const
+
+const providerIdPattern = /^[a-z][a-z0-9-]*$/
+const tenantHeaderPattern = /^[a-z0-9-]+$/
+const tenantIdPattern = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+export function loadSmartSuggestConfig(
+  env: SmartSuggestEnv
+): SmartSuggestConfigResult {
+  const issues: SmartSuggestConfigIssue[] = []
+  const environment = parseRuntimeEnvironment(env.SMART_SUGGEST_ENV, issues)
+  const allowedOrigins = parseAllowedOrigins(
+    env.SMART_SUGGEST_ALLOWED_ORIGINS,
+    issues
+  )
+  const defaultTenantId = parseDefaultTenantId(
+    env.SMART_SUGGEST_DEFAULT_TENANT_ID,
+    issues
+  )
+  const tenantHeader = parseTenantHeader(
+    env.SMART_SUGGEST_TENANT_HEADER,
+    issues
+  )
+  const providerPriority = parseProviderPriority(
+    env.SMART_SUGGEST_PROVIDER_PRIORITY,
+    issues
+  )
+
+  if (issues.length > 0) {
+    return {
+      ok: false,
+      issues,
+    }
+  }
+
+  return {
+    ok: true,
+    config: {
+      serviceName: "smart-suggest",
+      version: normalizeOptionalText(env.SMART_SUGGEST_VERSION) ?? "0.0.0",
+      buildId: normalizeOptionalText(env.SMART_SUGGEST_BUILD_ID) ?? "local",
+      environment,
+      allowedOrigins,
+      tenant: {
+        defaultTenantId,
+        tenantHeader,
+      },
+      providerPriority,
+      bindings: {
+        d1: Boolean(env.SMART_SUGGEST_DB),
+        configKv: Boolean(env.SMART_SUGGEST_CONFIG),
+        cacheKv: Boolean(env.SMART_SUGGEST_CACHE),
+        providerCacheKv: Boolean(env.SMART_SUGGEST_PROVIDER_CACHE),
+      },
+      providerSecrets: {
+        mapyApiKey: Boolean(
+          normalizeOptionalText(env.SMART_SUGGEST_MAPY_API_KEY)
+        ),
+      },
+    },
+  }
+}
+
+function parseRuntimeEnvironment(
+  value: string | undefined,
+  issues: SmartSuggestConfigIssue[]
+): SmartSuggestRuntimeEnvironment {
+  const normalized = normalizeOptionalText(value) ?? "local"
+
+  if (
+    normalized === "local" ||
+    normalized === "preview" ||
+    normalized === "staging" ||
+    normalized === "production" ||
+    normalized === "test"
+  ) {
+    return normalized
+  }
+
+  issues.push({
+    code: "invalid_environment",
+    message:
+      "SMART_SUGGEST_ENV must be local, preview, staging, production, or test.",
+  })
+
+  return "local"
+}
+
+function parseAllowedOrigins(
+  value: string | undefined,
+  issues: SmartSuggestConfigIssue[]
+): readonly string[] {
+  const origins = splitCommaList(value)
+
+  if (origins.length === 0) {
+    return defaultAllowedOrigins
+  }
+
+  for (const origin of origins) {
+    if (origin !== "*" && !isValidHttpOrigin(origin)) {
+      issues.push({
+        code: "invalid_origin",
+        message:
+          "SMART_SUGGEST_ALLOWED_ORIGINS must contain HTTP(S) origins or *.",
+      })
+    }
+  }
+
+  return origins
+}
+
+function parseDefaultTenantId(
+  value: string | undefined,
+  issues: SmartSuggestConfigIssue[]
+): string {
+  const tenantId = normalizeOptionalText(value) ?? "default"
+
+  if (!tenantIdPattern.test(tenantId)) {
+    issues.push({
+      code: "invalid_tenant_id",
+      message:
+        "SMART_SUGGEST_DEFAULT_TENANT_ID must be 1-64 lowercase letters, numbers, underscores, or hyphens.",
+    })
+  }
+
+  return tenantId
+}
+
+function parseTenantHeader(
+  value: string | undefined,
+  issues: SmartSuggestConfigIssue[]
+): string {
+  const tenantHeader =
+    normalizeOptionalText(value)?.toLowerCase() ?? "x-tenant-id"
+
+  if (!tenantHeaderPattern.test(tenantHeader)) {
+    issues.push({
+      code: "invalid_tenant_header",
+      message:
+        "SMART_SUGGEST_TENANT_HEADER must be a lowercase HTTP header token.",
+    })
+  }
+
+  return tenantHeader
+}
+
+function parseProviderPriority(
+  value: string | undefined,
+  issues: SmartSuggestConfigIssue[]
+): readonly string[] {
+  const providerIds = splitCommaList(value)
+
+  for (const providerId of providerIds) {
+    if (!providerIdPattern.test(providerId)) {
+      issues.push({
+        code: "invalid_provider_id",
+        message:
+          "SMART_SUGGEST_PROVIDER_PRIORITY must contain provider ids like owned-data or mapy.",
+      })
+    }
+  }
+
+  return providerIds
+}
+
+function splitCommaList(value: string | undefined): readonly string[] {
+  const normalized = normalizeOptionalText(value)
+
+  if (!normalized) {
+    return []
+  }
+
+  return normalized
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0)
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  const normalized = value?.trim()
+
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
+
+function isValidHttpOrigin(value: string): boolean {
+  try {
+    const url = new URL(value)
+
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      url.origin === value
+    )
+  } catch {
+    return false
+  }
+}

--- a/apps/smart-suggest/src/health.ts
+++ b/apps/smart-suggest/src/health.ts
@@ -1,0 +1,38 @@
+import type { SmartSuggestConfig } from "./config"
+
+export type SmartSuggestHealthPayload = {
+  readonly service: "smart-suggest"
+  readonly version: string
+  readonly buildId: string
+  readonly environment: SmartSuggestConfig["environment"]
+  readonly timestamp: string
+  readonly bindings: {
+    readonly d1: "configured" | "missing"
+    readonly configKv: "configured" | "missing"
+    readonly cacheKv: "configured" | "missing"
+    readonly providerCacheKv: "configured" | "missing"
+  }
+}
+
+export function createHealthPayload(
+  config: SmartSuggestConfig,
+  now: Date = new Date()
+): SmartSuggestHealthPayload {
+  return {
+    service: config.serviceName,
+    version: config.version,
+    buildId: config.buildId,
+    environment: config.environment,
+    timestamp: now.toISOString(),
+    bindings: {
+      d1: toBindingStatus(config.bindings.d1),
+      configKv: toBindingStatus(config.bindings.configKv),
+      cacheKv: toBindingStatus(config.bindings.cacheKv),
+      providerCacheKv: toBindingStatus(config.bindings.providerCacheKv),
+    },
+  }
+}
+
+function toBindingStatus(value: boolean): "configured" | "missing" {
+  return value ? "configured" : "missing"
+}

--- a/apps/smart-suggest/src/http.ts
+++ b/apps/smart-suggest/src/http.ts
@@ -40,7 +40,10 @@ function applyCorsHeaders(
 
   headers.set("vary", "Origin")
   headers.set("access-control-allow-methods", "GET, OPTIONS")
-  headers.set("access-control-allow-headers", "content-type")
+  headers.set(
+    "access-control-allow-headers",
+    `content-type, ${config.tenant.tenantHeader}`
+  )
   headers.set("access-control-max-age", "600")
 
   if (allowedOrigin) {

--- a/apps/smart-suggest/src/http.ts
+++ b/apps/smart-suggest/src/http.ts
@@ -1,0 +1,64 @@
+import type { SmartSuggestConfig } from "./config"
+
+export function jsonResponse(
+  request: Request,
+  config: SmartSuggestConfig,
+  body: unknown,
+  init: ResponseInit = {}
+): Response {
+  const headers = new Headers(init.headers)
+  headers.set("content-type", "application/json; charset=utf-8")
+
+  applyCorsHeaders(request, config, headers)
+
+  return new Response(JSON.stringify(body), {
+    ...init,
+    headers,
+  })
+}
+
+export function emptyCorsResponse(
+  request: Request,
+  config: SmartSuggestConfig
+): Response {
+  const headers = new Headers()
+  applyCorsHeaders(request, config, headers)
+
+  return new Response(null, {
+    status: 204,
+    headers,
+  })
+}
+
+function applyCorsHeaders(
+  request: Request,
+  config: SmartSuggestConfig,
+  headers: Headers
+): void {
+  const origin = request.headers.get("origin")
+  const allowedOrigin = resolveAllowedOrigin(origin, config.allowedOrigins)
+
+  headers.set("vary", "Origin")
+  headers.set("access-control-allow-methods", "GET, OPTIONS")
+  headers.set("access-control-allow-headers", "content-type")
+  headers.set("access-control-max-age", "600")
+
+  if (allowedOrigin) {
+    headers.set("access-control-allow-origin", allowedOrigin)
+  }
+}
+
+function resolveAllowedOrigin(
+  origin: string | null,
+  allowedOrigins: readonly string[]
+): string | undefined {
+  if (!origin) {
+    return
+  }
+
+  if (allowedOrigins.includes("*")) {
+    return origin
+  }
+
+  return allowedOrigins.includes(origin) ? origin : undefined
+}

--- a/apps/smart-suggest/src/index.ts
+++ b/apps/smart-suggest/src/index.ts
@@ -1,4 +1,9 @@
 export type SmartSuggestAppBoundary = {
   readonly appName: "smart-suggest"
-  readonly status: "scaffold"
+  readonly runtime: "cloudflare-worker"
 }
+
+export const smartSuggestAppBoundary = {
+  appName: "smart-suggest",
+  runtime: "cloudflare-worker",
+} satisfies SmartSuggestAppBoundary

--- a/apps/smart-suggest/src/worker.test.ts
+++ b/apps/smart-suggest/src/worker.test.ts
@@ -62,6 +62,23 @@ describe("smart-suggest worker", () => {
     expect(response.headers.get("access-control-allow-origin")).toBeNull()
   })
 
+  it("allows the configured tenant header in CORS preflight", () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/api/v1/health", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://shop.example",
+        },
+      }),
+      validEnv
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-headers")).toBe(
+      "content-type, x-smart-suggest-tenant"
+    )
+  })
+
   it("keeps the old-core SDK path reserved but unimplemented", async () => {
     const response = handleRequest(
       new Request("https://smart-suggest.example/sdk/smart-suggest.global.js"),
@@ -85,6 +102,20 @@ describe("smart-suggest worker", () => {
     expect(response.status).toBe(500)
     expect(isRecord(body)).toBe(true)
   })
+
+  it("reports invalid origins once with offending values", async () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/api/v1/health"),
+      {
+        ...validEnv,
+        SMART_SUGGEST_ALLOWED_ORIGINS: "not-a-url,also-bad",
+      } satisfies SmartSuggestEnv
+    )
+    const body: unknown = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(hasInvalidOriginIssue(body)).toBe(true)
+  })
 })
 
 function isHealthBody(value: unknown): value is HealthBody {
@@ -103,4 +134,28 @@ function isHealthBody(value: unknown): value is HealthBody {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
+}
+
+function hasInvalidOriginIssue(value: unknown): boolean {
+  if (!(isRecord(value) && isRecord(value.error))) {
+    return false
+  }
+
+  const issues = value.error.issues
+
+  if (!Array.isArray(issues)) {
+    return false
+  }
+
+  return issues.some((issue) => {
+    if (!isRecord(issue)) {
+      return false
+    }
+
+    return (
+      issue.code === "invalid_origin" &&
+      issue.message ===
+        "SMART_SUGGEST_ALLOWED_ORIGINS must contain HTTP(S) origins or *. Invalid: not-a-url, also-bad"
+    )
+  })
 }

--- a/apps/smart-suggest/src/worker.test.ts
+++ b/apps/smart-suggest/src/worker.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import type { SmartSuggestEnv } from "./config"
+import { handleRequest } from "./worker"
+
+type HealthBody = {
+  readonly service: string
+  readonly version: string
+  readonly buildId: string
+  readonly environment: string
+  readonly timestamp: string
+}
+
+const validEnv = {
+  SMART_SUGGEST_ENV: "test",
+  SMART_SUGGEST_VERSION: "0.1.0",
+  SMART_SUGGEST_BUILD_ID: "test-build",
+  SMART_SUGGEST_ALLOWED_ORIGINS: "https://shop.example",
+  SMART_SUGGEST_DEFAULT_TENANT_ID: "demo",
+  SMART_SUGGEST_TENANT_HEADER: "x-smart-suggest-tenant",
+} satisfies SmartSuggestEnv
+
+describe("smart-suggest worker", () => {
+  it("returns the health payload", async () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/api/v1/health", {
+        headers: {
+          origin: "https://shop.example",
+        },
+      }),
+      validEnv
+    )
+    const body: unknown = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "https://shop.example"
+    )
+    expect(isHealthBody(body)).toBe(true)
+
+    if (!isHealthBody(body)) {
+      return
+    }
+
+    expect(body.service).toBe("smart-suggest")
+    expect(body.version).toBe("0.1.0")
+    expect(body.buildId).toBe("test-build")
+    expect(body.environment).toBe("test")
+    expect(Date.parse(body.timestamp)).not.toBeNaN()
+  })
+
+  it("does not allow unconfigured origins", () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/api/v1/health", {
+        headers: {
+          origin: "https://unknown.example",
+        },
+      }),
+      validEnv
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  it("keeps the old-core SDK path reserved but unimplemented", async () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/sdk/smart-suggest.global.js"),
+      validEnv
+    )
+    const body: unknown = await response.json()
+
+    expect(response.status).toBe(501)
+    expect(isRecord(body)).toBe(true)
+  })
+
+  it("fails closed for invalid runtime config", async () => {
+    const response = handleRequest(
+      new Request("https://smart-suggest.example/api/v1/health"),
+      {
+        SMART_SUGGEST_ENV: "demo",
+      } satisfies SmartSuggestEnv
+    )
+    const body: unknown = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(isRecord(body)).toBe(true)
+  })
+})
+
+function isHealthBody(value: unknown): value is HealthBody {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  return (
+    typeof value.service === "string" &&
+    typeof value.version === "string" &&
+    typeof value.buildId === "string" &&
+    typeof value.environment === "string" &&
+    typeof value.timestamp === "string"
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/apps/smart-suggest/src/worker.ts
+++ b/apps/smart-suggest/src/worker.ts
@@ -1,0 +1,107 @@
+import type { SmartSuggestWorkerHandler } from "./cloudflare-runtime"
+import {
+  loadSmartSuggestConfig,
+  type SmartSuggestConfig,
+  type SmartSuggestEnv,
+} from "./config"
+import { createHealthPayload } from "./health"
+import { emptyCorsResponse, jsonResponse } from "./http"
+
+const healthPath = "/api/v1/health"
+const sdkPathPrefix = "/sdk/"
+
+const worker = {
+  fetch(request: Request, env: SmartSuggestEnv): Response {
+    return handleRequest(request, env)
+  },
+} satisfies SmartSuggestWorkerHandler<SmartSuggestEnv>
+
+export default worker
+
+export function handleRequest(
+  request: Request,
+  env: SmartSuggestEnv
+): Response {
+  const configResult = loadSmartSuggestConfig(env)
+
+  if (!configResult.ok) {
+    return new Response(
+      JSON.stringify({
+        error: {
+          code: "invalid_runtime_config",
+          issues: configResult.issues,
+        },
+      }),
+      {
+        status: 500,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+      }
+    )
+  }
+
+  const config = configResult.config
+
+  if (request.method === "OPTIONS") {
+    return emptyCorsResponse(request, config)
+  }
+
+  const url = new URL(request.url)
+
+  if (url.pathname === healthPath) {
+    return handleHealth(request, config)
+  }
+
+  if (url.pathname.startsWith(sdkPathPrefix)) {
+    return jsonResponse(
+      request,
+      config,
+      {
+        error: {
+          code: "sdk_surface_reserved",
+          message:
+            "The old-core global vanilla SDK surface is reserved for a later issue.",
+        },
+      },
+      {
+        status: 501,
+      }
+    )
+  }
+
+  return jsonResponse(
+    request,
+    config,
+    {
+      error: {
+        code: "not_found",
+      },
+    },
+    {
+      status: 404,
+    }
+  )
+}
+
+function handleHealth(request: Request, config: SmartSuggestConfig): Response {
+  if (request.method !== "GET") {
+    return jsonResponse(
+      request,
+      config,
+      {
+        error: {
+          code: "method_not_allowed",
+        },
+      },
+      {
+        status: 405,
+        headers: {
+          allow: "GET, OPTIONS",
+        },
+      }
+    )
+  }
+
+  return jsonResponse(request, config, createHealthPayload(config))
+}

--- a/apps/smart-suggest/src/worker.ts
+++ b/apps/smart-suggest/src/worker.ts
@@ -2,6 +2,7 @@ import type { SmartSuggestWorkerHandler } from "./cloudflare-runtime"
 import {
   loadSmartSuggestConfig,
   type SmartSuggestConfig,
+  type SmartSuggestConfigResult,
   type SmartSuggestEnv,
 } from "./config"
 import { createHealthPayload } from "./health"
@@ -9,6 +10,10 @@ import { emptyCorsResponse, jsonResponse } from "./http"
 
 const healthPath = "/api/v1/health"
 const sdkPathPrefix = "/sdk/"
+const configResultsByEnv = new WeakMap<
+  SmartSuggestEnv,
+  SmartSuggestConfigResult
+>()
 
 const worker = {
   fetch(request: Request, env: SmartSuggestEnv): Response {
@@ -22,7 +27,7 @@ export function handleRequest(
   request: Request,
   env: SmartSuggestEnv
 ): Response {
-  const configResult = loadSmartSuggestConfig(env)
+  const configResult = loadConfigResult(env)
 
   if (!configResult.ok) {
     return new Response(
@@ -104,4 +109,17 @@ function handleHealth(request: Request, config: SmartSuggestConfig): Response {
   }
 
   return jsonResponse(request, config, createHealthPayload(config))
+}
+
+function loadConfigResult(env: SmartSuggestEnv): SmartSuggestConfigResult {
+  const cachedConfigResult = configResultsByEnv.get(env)
+
+  if (cachedConfigResult) {
+    return cachedConfigResult
+  }
+
+  const configResult = loadSmartSuggestConfig(env)
+  configResultsByEnv.set(env, configResult)
+
+  return configResult
 }

--- a/apps/smart-suggest/tsconfig.build.json
+++ b/apps/smart-suggest/tsconfig.build.json
@@ -4,5 +4,6 @@
     "emitDeclarationOnly": false,
     "noEmit": false
   },
-  "include": ["src"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/apps/smart-suggest/tsconfig.json
+++ b/apps/smart-suggest/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2024"],
+    "lib": ["ES2024", "WebWorker"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "rootDir": "src",
     "outDir": "dist"
   },
-  "include": ["src"],
+  "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/apps/smart-suggest/wrangler.toml
+++ b/apps/smart-suggest/wrangler.toml
@@ -1,0 +1,31 @@
+name = "smart-suggest"
+main = "src/worker.ts"
+compatibility_date = "2026-06-18"
+workers_dev = true
+
+[vars]
+SMART_SUGGEST_ENV = "local"
+SMART_SUGGEST_VERSION = "0.0.0"
+SMART_SUGGEST_BUILD_ID = "local"
+SMART_SUGGEST_ALLOWED_ORIGINS = "http://localhost:3000,http://localhost:3001"
+SMART_SUGGEST_DEFAULT_TENANT_ID = "default"
+SMART_SUGGEST_TENANT_HEADER = "x-smart-suggest-tenant"
+SMART_SUGGEST_PROVIDER_PRIORITY = ""
+
+# Future SS-02 bindings:
+# [[d1_databases]]
+# binding = "SMART_SUGGEST_DB"
+# database_name = "smart-suggest-local"
+# database_id = "00000000-0000-0000-0000-000000000000"
+#
+# [[kv_namespaces]]
+# binding = "SMART_SUGGEST_CONFIG"
+# id = "00000000000000000000000000000000"
+#
+# [[kv_namespaces]]
+# binding = "SMART_SUGGEST_CACHE"
+# id = "00000000000000000000000000000000"
+#
+# [[kv_namespaces]]
+# binding = "SMART_SUGGEST_PROVIDER_CACHE"
+# id = "00000000000000000000000000000000"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -830,6 +830,12 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.5)(happy-dom@20.9.0)(jsdom@27.4.0)(msw@2.12.10(@types/node@24.12.4)(typescript@5.9.3))(vite@8.0.11(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(less@4.1.3)(sass@1.84.0)(stylus@0.64.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.8.3))
+      wrangler:
+        specifier: ^4.100.0
+        version: 4.100.0
 
   apps/zane-operator:
     dependencies:
@@ -2296,6 +2302,49 @@ packages:
 
   '@clack/prompts@0.11.0':
     resolution: {integrity: sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw==}
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260611.1':
+    resolution: {integrity: sha512-iJICldmi4sBGgi7IrQles8cStOGXM/Tmv95C4OODVs6VIbMsJPqThUM5h3uYVQNULuJ8I/aVvnJ3Eh/wZCKwuA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260611.1':
+    resolution: {integrity: sha512-yBbVXvbZyltR3I7NJdC4C4ItkItjZSiabcA/3HzEWOUQjLVKFqRh4so6ToHr70VCYh8VGeR8EDZL23igLhXqFQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260611.1':
+    resolution: {integrity: sha512-PfNjpxOlaIgZFYuhD7+neEEewCN2Ud993wEEN0fmbtSOax1AK53LGqmXUDvFhnbkHxJLFAxYCSNISW8QbzaAIg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260611.1':
+    resolution: {integrity: sha512-GEp4XbuIKjlF8pakqXcUDJfKiJosD/Q7S83J0d+r+z9XIlYGfF3ntm08e2aiF5TFTwp3fnG4yMoPUAKNhNJpvQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260611.1':
+    resolution: {integrity: sha512-S6JkS0kEbcCKs19RGqEPhjCRbP8GBkQwqYLp2fhBJtD/KTlwqLzOJ9E6PQ7gQKgWHtxy1NBG3oXarlNFRNU/dw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@codemirror/autocomplete@6.20.2':
     resolution: {integrity: sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==}
@@ -6489,6 +6538,15 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@posthog/core@1.28.7':
     resolution: {integrity: sha512-JmV2wN5sE7u2JWxwNNw6CBrPu5xDzIAMWR9zKBar8Pk/8TRrvbFPlXehap8xOtDslfnilY+/urpHeVHpbXMo4w==}
 
@@ -8402,6 +8460,10 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -8590,6 +8652,9 @@ packages:
 
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -10288,6 +10353,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   blamer@1.0.7:
     resolution: {integrity: sha512-GbBStl/EVlSWkiJQBZps3H1iARBrC7vt++Jb/TTmCNu/jZ04VW7tSN1nScbFXBUy1AN+jzeL7Zep9sbQxLhXKA==}
     engines: {node: '>=8.9'}
@@ -11720,6 +11788,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
@@ -14494,6 +14565,11 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  miniflare@4.20260611.0:
+    resolution: {integrity: sha512-i+JwEo8vN96naz1WL3ntFgFyRluBDYL408zwhHKvR2jefJ464KsZ/gCmJAQ5k+oaWeb5Ug+s7yne5AyiAEswjg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
     engines: {node: 20 || >=22}
@@ -17095,6 +17171,10 @@ packages:
     resolution: {integrity: sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==}
     engines: {node: '>=18'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -17702,6 +17782,13 @@ packages:
     resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
     engines: {node: '>=20.18.1'}
 
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -18180,6 +18267,21 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  workerd@1.20260611.1:
+    resolution: {integrity: sha512-CS/640T7pIJ2HYX6x2DwKFGbcSckAWN3tgcdq+ptB6SaqjWUhlzIgA/YhPuwIU+/NnMnGpqOFX/hC18Oyge63w==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.100.0:
+    resolution: {integrity: sha512-dSQO7DO+mD6XDzkVWIWBoGLO3yw+lacWSc/KhFvd7pgfpth+kX98qb5SGRHZN8ACCDhhfwzDLXwB6qHsIHhfBg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260611.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -18232,6 +18334,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -18368,6 +18482,12 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
@@ -19998,6 +20118,29 @@ snapshots:
       '@clack/core': 0.5.0
       picocolors: 1.1.1
       sisteransi: 1.0.5
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260611.1
+
+  '@cloudflare/workerd-darwin-64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260611.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260611.1':
+    optional: true
 
   '@codemirror/autocomplete@6.20.2':
     dependencies:
@@ -25666,6 +25809,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@posthog/core@1.28.7':
     dependencies:
       '@posthog/types': 1.373.2
@@ -27643,6 +27798,8 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@sinonjs/commons@3.0.1':
@@ -27878,6 +28035,8 @@ snapshots:
       text-hex: 1.0.0
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -30010,6 +30169,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
   blamer@1.0.7:
     dependencies:
       execa: 4.1.0
@@ -31302,6 +31463,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   error-stack-parser@2.1.4:
     dependencies:
@@ -34934,6 +35097,18 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  miniflare@4.20260611.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260611.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.0.3:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
@@ -38106,6 +38281,8 @@ snapshots:
       make-asynchronous: 1.0.1
       time-span: 5.1.0
 
+  supports-color@10.2.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -38690,6 +38867,12 @@ snapshots:
   undici@7.24.4: {}
 
   undici@7.24.6: {}
+
+  undici@7.24.8: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -39320,6 +39503,30 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  workerd@1.20260611.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260611.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260611.1
+      '@cloudflare/workerd-linux-64': 1.20260611.1
+      '@cloudflare/workerd-linux-arm64': 1.20260611.1
+      '@cloudflare/workerd-windows-64': 1.20260611.1
+
+  wrangler@4.100.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260611.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260611.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260611.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -39363,6 +39570,8 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.19.0: {}
+
+  ws@8.20.1: {}
 
   wsl-utils@0.1.0:
     dependencies:
@@ -39494,6 +39703,19 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   yoctocolors@2.1.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zip-stream@4.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ publicHoistPattern:
   - '@iconify/tailwind4'
   - vite
   - vitest
+  - wrangler
   - '@vitejs/*'
   - storybook
   - storybook-*
@@ -113,3 +114,4 @@ allowBuilds:
   puppeteer: false
   sharp: true
   unrs-resolver: true
+  workerd: true


### PR DESCRIPTION
## Summary
- adds the Smart Suggest Cloudflare Worker shell with health, CORS, config validation, and reserved /sdk/* handling
- documents the runtime config contract for origins, tenant config, future D1/KV bindings, and provider secrets
- wires Smart Suggest lint/typecheck/test/build targets to Vitest and Wrangler dry-run deploy

## Stack
- Stacked on #475 / smart-suggest/ss-00-scaffold
- Retarget this PR to master after #475 merges

## Strictness
- No provider calls, Module Federation, storage workflows, or SDK implementation are included
- No TypeScript or lint suppressions; no broad any usage
- Wrangler is hoisted as a workspace tool binary so scripts resolve the locked 4.100.0 version, not a global install

## Verification
- CI=true pnpm install --frozen-lockfile
- pnpm exec nx run-many -t lint,typecheck,test,build --projects=smart-suggest
- rg -n "@ts-(ignore|expect-error|nocheck)|biome-ignore|eslint-disable|\bany\b" apps/smart-suggest pnpm-workspace.yaml
- git diff --check
- pnpm --dir apps/smart-suggest exec wrangler dev --port 8789 --ip 127.0.0.1
- curl -sS -D - http://127.0.0.1:8789/api/v1/health