### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,12 @@ jobs:
       NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_MEDUSA_PUBLISHABLE_KEY }}
       NX_NO_CLOUD: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -31,7 +32,7 @@ jobs:
 
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'

--- a/.github/workflows/medusa-be-tests-after-ci.yml
+++ b/.github/workflows/medusa-be-tests-after-ci.yml
@@ -24,23 +24,28 @@ jobs:
       head_sha: ${{ github.event.workflow_run.head_sha }}
     steps:
       - name: Checkout workflow head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine Medusa BE test scope
         id: scope
         shell: bash
+        env:
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_EVENT_NAME: ${{ github.event.workflow_run.event }}
+          WORKFLOW_PR_BASE_SHA: ${{ github.event.workflow_run.pull_requests[0].base.sha || '' }}
         run: |
           set -euo pipefail
 
-          head_sha="${{ github.event.workflow_run.head_sha }}"
-          event_name="${{ github.event.workflow_run.event }}"
+          head_sha="$WORKFLOW_HEAD_SHA"
+          event_name="$WORKFLOW_EVENT_NAME"
           base_sha=""
 
-          if [[ "$event_name" == "pull_request" ]] && [[ -n "${{ github.event.workflow_run.pull_requests[0].base.sha || '' }}" ]]; then
-            base_sha="${{ github.event.workflow_run.pull_requests[0].base.sha }}"
+          if [[ "$event_name" == "pull_request" ]] && [[ -n "$WORKFLOW_PR_BASE_SHA" ]]; then
+            base_sha="$WORKFLOW_PR_BASE_SHA"
           else
             base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || git rev-list --max-parents=0 "$head_sha")"
           fi
@@ -65,14 +70,20 @@ jobs:
 
       - name: Preflight summary
         if: always()
+        env:
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_EVENT_NAME: ${{ github.event.workflow_run.event }}
+          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_SHA: ${{ steps.scope.outputs.base_sha || 'n/a' }}
+          SHOULD_RUN: ${{ steps.scope.outputs.should_run || 'n/a' }}
         run: |
           {
-            echo "## Medusa BE Tests Preflight"
-            echo "- Triggering workflow: ${{ github.event.workflow_run.name }}"
-            echo "- Event: ${{ github.event.workflow_run.event }}"
-            echo "- Head SHA: ${{ github.event.workflow_run.head_sha }}"
-            echo "- Base SHA: ${{ steps.scope.outputs.base_sha }}"
-            echo "- Ready to run: ${{ steps.scope.outputs.should_run }}"
+            printf '%s\n' "## Medusa BE Tests Preflight"
+            printf '%s\n' "- Triggering workflow: $WORKFLOW_RUN_NAME"
+            printf '%s\n' "- Event: $WORKFLOW_EVENT_NAME"
+            printf '%s\n' "- Head SHA: $WORKFLOW_HEAD_SHA"
+            printf '%s\n' "- Base SHA: $BASE_SHA"
+            printf '%s\n' "- Ready to run: $SHOULD_RUN"
           } >> "$GITHUB_STEP_SUMMARY"
 
   unit:
@@ -83,13 +94,14 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout workflow head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -128,13 +140,14 @@ jobs:
       DB_TEMP_NAME: medusa_test
     steps:
       - name: Checkout workflow head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -155,13 +168,14 @@ jobs:
       MEDUSA_E2E_PROJECT_NAME: medusa-be-e2e-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout workflow head SHA
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.preflight.outputs.head_sha }}
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/storybook-a11y-baseline.yml
+++ b/.github/workflows/storybook-a11y-baseline.yml
@@ -29,14 +29,15 @@ jobs:
   build-storybook:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -48,7 +49,7 @@ jobs:
         run: pnpm -C libs/ui run build:storybook
 
       - name: Upload Storybook static
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: storybook-static
           path: libs/ui/storybook-static
@@ -67,14 +68,15 @@ jobs:
       A11Y_REPORT_WRITE_JUNIT: "true"
       A11Y_REPORT_WAIT_MS: "30000"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -86,7 +88,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Download Storybook static
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: storybook-static
           path: libs/ui/storybook-static
@@ -127,7 +129,7 @@ jobs:
 
       - name: Upload baseline report (${{ matrix.theme }})
         if: always() && hashFiles(format('libs/ui/a11y-report/{0}/report.json', matrix.theme)) != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: storybook-a11y-baseline-${{ matrix.theme }}
           path: libs/ui/a11y-report/${{ matrix.theme }}/report.json

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -16,10 +16,7 @@ on:
         default: "true"
 
 permissions:
-  actions: read
   contents: read
-  pull-requests: write
-  checks: write
 
 jobs:
   detect-a11y-changes:
@@ -30,6 +27,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check changed paths
         id: changed-paths
@@ -72,6 +70,11 @@ jobs:
   storybook-a11y:
     needs: detect-a11y-changes
     if: needs.detect-a11y-changes.outputs.should-run == 'true'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      checks: write
     uses: TechsioCZ/storybook-addons/.github/workflows/storybook-a11y.yml@b52eaf44688051b19eb989fab7b6ab721ce1a2d1 # storybook-a11y-workflow-v0.1.9
     with:
       node-version: "24"

--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -27,14 +27,15 @@ jobs:
       is_affected: ${{ steps.check.outputs.is_affected }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
@@ -79,15 +80,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/zaneops-main-after-ci.yml
+++ b/.github/workflows/zaneops-main-after-ci.yml
@@ -31,14 +31,15 @@ jobs:
       requires_downtime_approval: ${{ steps.scope_data.outputs.requires_downtime_approval }}
       downtime_service_ids: ${{ steps.scope_data.outputs.downtime_service_ids }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -60,14 +61,17 @@ jobs:
 
       - name: Resolve main scope
         id: scope_data
+        env:
+          BASE_SHA: ${{ steps.base.outputs.base_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           node apps/new-engine-ctl/dist/cli.js scope \
             --lane main \
-            --base-sha "${{ steps.base.outputs.base_sha }}" \
-            --head-sha "${{ github.event.workflow_run.head_sha }}"
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"
 
       - name: Upload new-engine-ctl artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist/cli.js
@@ -75,16 +79,24 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASE_SHA: ${{ steps.base.outputs.base_sha || 'n/a' }}
+          PROJECTS_CSV: ${{ steps.scope_data.outputs.projects_csv || 'n/a' }}
+          SERVICES_CSV: ${{ steps.scope_data.outputs.services_csv || 'n/a' }}
+          NX_STATUS: ${{ steps.scope_data.outputs.nx_status || 'n/a' }}
+          REQUIRES_DOWNTIME_APPROVAL: ${{ steps.scope_data.outputs.requires_downtime_approval || 'false' }}
+          DOWNTIME_SERVICE_IDS: ${{ steps.scope_data.outputs.downtime_service_ids || 'n/a' }}
         run: |
           {
-            echo "## Main Scope"
-            echo "- Head SHA: ${{ github.event.workflow_run.head_sha }}"
-            echo "- Base SHA: ${{ steps.base.outputs.base_sha || 'n/a' }}"
-            echo "- Affected projects: ${{ steps.scope_data.outputs.projects_csv || 'n/a' }}"
-            echo "- Affected services: ${{ steps.scope_data.outputs.services_csv || 'n/a' }}"
-            echo "- Nx status: ${{ steps.scope_data.outputs.nx_status || 'n/a' }}"
-            echo "- Requires downtime approval: ${{ steps.scope_data.outputs.requires_downtime_approval || 'false' }}"
-            echo "- Downtime-risk services: ${{ steps.scope_data.outputs.downtime_service_ids || 'n/a' }}"
+            printf '%s\n' "## Main Scope"
+            printf '%s\n' "- Head SHA: $HEAD_SHA"
+            printf '%s\n' "- Base SHA: $BASE_SHA"
+            printf '%s\n' "- Affected projects: $PROJECTS_CSV"
+            printf '%s\n' "- Affected services: $SERVICES_CSV"
+            printf '%s\n' "- Nx status: $NX_STATUS"
+            printf '%s\n' "- Requires downtime approval: $REQUIRES_DOWNTIME_APPROVAL"
+            printf '%s\n' "- Downtime-risk services: $DOWNTIME_SERVICE_IDS"
           } >> "$GITHUB_STEP_SUMMARY"
 
   approval:
@@ -95,10 +107,12 @@ jobs:
       name: zaneops-main-downtime
     steps:
       - name: Summary
+        env:
+          DOWNTIME_SERVICE_IDS: ${{ needs.scope.outputs.downtime_service_ids || 'n/a' }}
         run: |
           {
-            echo "## Main Downtime Approval"
-            echo "- Approved downtime-risk services: ${{ needs.scope.outputs.downtime_service_ids || 'n/a' }}"
+            printf '%s\n' "## Main Downtime Approval"
+            printf '%s\n' "- Approved downtime-risk services: $DOWNTIME_SERVICE_IDS"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -125,16 +139,17 @@ jobs:
       runtime_provider_outputs_json: ${{ steps.run_deploy.outputs.runtime_provider_outputs_json }}
       deployments_json: ${{ steps.run_deploy.outputs.deployments_json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -152,6 +167,7 @@ jobs:
         env:
           SERVICES_CSV: ${{ needs.scope.outputs.services_csv }}
           REQUIRES_DOWNTIME_APPROVAL: ${{ needs.scope.outputs.requires_downtime_approval }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           ZANE_OPERATOR_BASE_URL: ${{ secrets.ZANEOPS_ZANE_OPERATOR_BASE_URL }}
           ZANE_OPERATOR_API_TOKEN: ${{ secrets.ZANEOPS_ZANE_OPERATOR_API_TOKEN }}
           ZANEOPS_ZANE_PROJECT_SLUG: ${{ secrets.ZANEOPS_ZANE_PROJECT_SLUG }}
@@ -165,21 +181,28 @@ jobs:
 
           node apps/new-engine-ctl/dist/cli.js deploy-main \
             --environment-name "$ZANE_PRODUCTION_ENVIRONMENT_NAME" \
-            --git-commit-sha "${{ github.event.workflow_run.head_sha }}" \
+            --git-commit-sha "$HEAD_SHA" \
             --services-csv "$SERVICES_CSV" \
             "${downtime_args[@]}"
 
       - name: Summary
         if: always()
+        env:
+          ENVIRONMENT_NAME: ${{ steps.run_deploy.outputs.environment_name || 'n/a' }}
+          REQUESTED_SERVICES_CSV: ${{ steps.run_deploy.outputs.requested_services_csv || 'n/a' }}
+          DEPLOY_SERVICES_CSV: ${{ steps.run_deploy.outputs.deploy_services_csv || 'n/a' }}
+          TRIGGERED_SERVICES_CSV: ${{ steps.run_deploy.outputs.triggered_services_csv || 'n/a' }}
+          SKIPPED_SERVICES_CSV: ${{ steps.run_deploy.outputs.skipped_services_csv || 'n/a' }}
+          RUNTIME_PROVIDER_OUTPUT_KEYS_CSV: ${{ steps.run_deploy.outputs.runtime_provider_output_keys_csv || 'n/a' }}
         run: |
           {
-            echo "## Main Deploy"
-            echo "- Environment: ${{ steps.run_deploy.outputs.environment_name || 'n/a' }}"
-            echo "- Requested services: ${{ steps.run_deploy.outputs.requested_services_csv || 'n/a' }}"
-            echo "- Deploy services: ${{ steps.run_deploy.outputs.deploy_services_csv || 'n/a' }}"
-            echo "- Triggered services: ${{ steps.run_deploy.outputs.triggered_services_csv || 'n/a' }}"
-            echo "- Skipped services: ${{ steps.run_deploy.outputs.skipped_services_csv || 'n/a' }}"
-            echo "- Runtime provider outputs: ${{ steps.run_deploy.outputs.runtime_provider_output_keys_csv || 'n/a' }}"
+            printf '%s\n' "## Main Deploy"
+            printf '%s\n' "- Environment: $ENVIRONMENT_NAME"
+            printf '%s\n' "- Requested services: $REQUESTED_SERVICES_CSV"
+            printf '%s\n' "- Deploy services: $DEPLOY_SERVICES_CSV"
+            printf '%s\n' "- Triggered services: $TRIGGERED_SERVICES_CSV"
+            printf '%s\n' "- Skipped services: $SKIPPED_SERVICES_CSV"
+            printf '%s\n' "- Runtime provider outputs: $RUNTIME_PROVIDER_OUTPUT_KEYS_CSV"
           } >> "$GITHUB_STEP_SUMMARY"
 
   verify:
@@ -188,16 +211,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -235,11 +259,16 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          ENVIRONMENT_NAME: ${{ needs.deploy.outputs.environment_name || secrets.ZANEOPS_ZANE_PRODUCTION_ENVIRONMENT_NAME || 'n/a' }}
+          REQUESTED_SERVICES_CSV: ${{ needs.deploy.outputs.requested_services_csv || 'n/a' }}
+          DEPLOY_SERVICES_CSV: ${{ needs.deploy.outputs.deploy_services_csv || 'n/a' }}
+          TRIGGERED_SERVICES_CSV: ${{ needs.deploy.outputs.triggered_services_csv || 'n/a' }}
         run: |
           {
-            echo "## Main Verify"
-            echo "- Environment: ${{ needs.deploy.outputs.environment_name || secrets.ZANEOPS_ZANE_PRODUCTION_ENVIRONMENT_NAME || 'n/a' }}"
-            echo "- Requested services: ${{ needs.deploy.outputs.requested_services_csv || 'n/a' }}"
-            echo "- Deploy services: ${{ needs.deploy.outputs.deploy_services_csv || 'n/a' }}"
-            echo "- Triggered services: ${{ needs.deploy.outputs.triggered_services_csv || 'n/a' }}"
+            printf '%s\n' "## Main Verify"
+            printf '%s\n' "- Environment: $ENVIRONMENT_NAME"
+            printf '%s\n' "- Requested services: $REQUESTED_SERVICES_CSV"
+            printf '%s\n' "- Deploy services: $DEPLOY_SERVICES_CSV"
+            printf '%s\n' "- Triggered services: $TRIGGERED_SERVICES_CSV"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zaneops-preview-after-ci.yml
+++ b/.github/workflows/zaneops-preview-after-ci.yml
@@ -36,14 +36,15 @@ jobs:
       requires_preview_db: ${{ steps.scope_data.outputs.requires_preview_db }}
       preview_db_service_ids: ${{ steps.scope_data.outputs.preview_db_service_ids }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -56,7 +57,9 @@ jobs:
 
       - name: Resolve PR number
         id: pr
-        run: echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+        env:
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Read preview commit state
         id: preview_commit_state
@@ -65,32 +68,38 @@ jobs:
           ZANE_OPERATOR_API_TOKEN: ${{ secrets.ZANEOPS_ZANE_OPERATOR_API_TOKEN }}
           ZANEOPS_ZANE_PROJECT_SLUG: ${{ secrets.ZANEOPS_ZANE_PROJECT_SLUG }}
           ZANE_PROJECT_SLUG: ${{ secrets.ZANEOPS_ZANE_PROJECT_SLUG }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           node apps/new-engine-ctl/dist/cli.js preview-commit-state \
-            --pr-number "${{ steps.pr.outputs.number }}"
+            --pr-number "$PR_NUMBER"
 
       - name: Resolve preview scope base SHA
         id: scope_base
+        env:
+          LAST_DEPLOYED_COMMIT_SHA: ${{ steps.preview_commit_state.outputs.last_deployed_commit_sha }}
+          PR_BASE_SHA: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
         run: |
-          BASE_SHA="${{ steps.preview_commit_state.outputs.last_deployed_commit_sha }}"
+          BASE_SHA="$LAST_DEPLOYED_COMMIT_SHA"
           if [[ -z "$BASE_SHA" ]]; then
-            BASE_SHA="${{ github.event.workflow_run.pull_requests[0].base.sha }}"
+            BASE_SHA="$PR_BASE_SHA"
           fi
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Resolve preview scope
         id: scope_data
         env:
+          BASE_SHA: ${{ steps.scope_base.outputs.base_sha }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PREVIEW_BASELINE_COMPLETE: ${{ steps.preview_commit_state.outputs.baseline_complete || 'false' }}
         run: |
           node apps/new-engine-ctl/dist/cli.js scope \
             --lane preview \
-            --base-sha "${{ steps.scope_base.outputs.base_sha }}" \
-            --head-sha "${{ github.event.workflow_run.head_sha }}" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA" \
             --preview-baseline-complete "$PREVIEW_BASELINE_COMPLETE"
 
       - name: Upload new-engine-ctl artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist/cli.js
@@ -98,18 +107,28 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BASELINE_SHA: ${{ steps.scope_base.outputs.base_sha || 'n/a' }}
+          BASELINE_COMPLETE: ${{ steps.preview_commit_state.outputs.baseline_complete || 'false' }}
+          PROJECTS_CSV: ${{ steps.scope_data.outputs.projects_csv || 'n/a' }}
+          SERVICES_CSV: ${{ steps.scope_data.outputs.services_csv || 'n/a' }}
+          NX_STATUS: ${{ steps.scope_data.outputs.nx_status || 'n/a' }}
+          SHOULD_PREPARE: ${{ steps.scope_data.outputs.should_prepare || 'false' }}
+          REQUIRES_PREVIEW_DB: ${{ steps.scope_data.outputs.requires_preview_db || 'false' }}
         run: |
           {
-            echo "## Preview Scope"
-            echo "- PR: #${{ steps.pr.outputs.number }}"
-            echo "- Head SHA: ${{ github.event.workflow_run.head_sha }}"
-            echo "- Baseline SHA: ${{ steps.scope_base.outputs.base_sha }}"
-            echo "- Baseline complete: ${{ steps.preview_commit_state.outputs.baseline_complete || 'false' }}"
-            echo "- Affected projects: ${{ steps.scope_data.outputs.projects_csv || 'n/a' }}"
-            echo "- Affected services: ${{ steps.scope_data.outputs.services_csv || 'n/a' }}"
-            echo "- Nx status: ${{ steps.scope_data.outputs.nx_status || 'n/a' }}"
-            echo "- Should prepare: ${{ steps.scope_data.outputs.should_prepare || 'false' }}"
-            echo "- Requires preview DB: ${{ steps.scope_data.outputs.requires_preview_db || 'false' }}"
+            printf '%s\n' "## Preview Scope"
+            printf '%s\n' "- PR: #$PR_NUMBER"
+            printf '%s\n' "- Head SHA: $HEAD_SHA"
+            printf '%s\n' "- Baseline SHA: $BASELINE_SHA"
+            printf '%s\n' "- Baseline complete: $BASELINE_COMPLETE"
+            printf '%s\n' "- Affected projects: $PROJECTS_CSV"
+            printf '%s\n' "- Affected services: $SERVICES_CSV"
+            printf '%s\n' "- Nx status: $NX_STATUS"
+            printf '%s\n' "- Should prepare: $SHOULD_PREPARE"
+            printf '%s\n' "- Requires preview DB: $REQUIRES_PREVIEW_DB"
           } >> "$GITHUB_STEP_SUMMARY"
 
   prepare:
@@ -126,16 +145,17 @@ jobs:
       preview_db_user: ${{ steps.run_prepare.outputs.preview_db_user }}
       preview_db_password: ${{ steps.run_prepare.outputs.preview_db_password }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -161,13 +181,18 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ needs.scope.outputs.pr_number }}
+          REQUIRES_PREVIEW_DB: ${{ needs.scope.outputs.requires_preview_db || 'n/a' }}
+          PREVIEW_DB_CREATED: ${{ steps.run_prepare.outputs.preview_db_created || 'n/a' }}
+          PREVIEW_DB_NAME: ${{ steps.run_prepare.outputs.preview_db_name || 'n/a' }}
         run: |
           {
-            echo "## Preview Prepare"
-            echo "- PR: #${{ needs.scope.outputs.pr_number }}"
-            echo "- Requires preview DB: ${{ needs.scope.outputs.requires_preview_db }}"
-            echo "- Preview DB created: ${{ steps.run_prepare.outputs.preview_db_created || 'n/a' }}"
-            echo "- Preview DB name: ${{ steps.run_prepare.outputs.preview_db_name || 'n/a' }}"
+            printf '%s\n' "## Preview Prepare"
+            printf '%s\n' "- PR: #$PR_NUMBER"
+            printf '%s\n' "- Requires preview DB: $REQUIRES_PREVIEW_DB"
+            printf '%s\n' "- Preview DB created: $PREVIEW_DB_CREATED"
+            printf '%s\n' "- Preview DB name: $PREVIEW_DB_NAME"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
@@ -200,16 +225,17 @@ jobs:
       preview_random_once_secrets_json: ${{ steps.run_deploy.outputs.preview_random_once_secrets_json }}
       deployments_json: ${{ steps.run_deploy.outputs.deployments_json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -249,20 +275,32 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ needs.scope.outputs.pr_number }}
+          ENVIRONMENT_NAME: ${{ steps.run_deploy.outputs.environment_name || 'n/a' }}
+          ENVIRONMENT_CREATED: ${{ steps.run_deploy.outputs.environment_created || 'n/a' }}
+          ENVIRONMENT_READY: ${{ steps.run_deploy.outputs.environment_ready || 'n/a' }}
+          ENVIRONMENT_WARNING_COUNT: ${{ steps.run_deploy.outputs.environment_warning_count || '0' }}
+          TARGET_COMMIT_SHA: ${{ steps.run_deploy.outputs.target_commit_sha || 'n/a' }}
+          LAST_DEPLOYED_COMMIT_SHA: ${{ steps.run_deploy.outputs.last_deployed_commit_sha || 'n/a' }}
+          RUNTIME_PROVIDER_OUTPUT_KEYS_CSV: ${{ steps.run_deploy.outputs.runtime_provider_output_keys_csv || 'n/a' }}
+          REQUESTED_SERVICES_CSV: ${{ steps.run_deploy.outputs.requested_services_csv || 'n/a' }}
+          DEPLOY_SERVICES_CSV: ${{ steps.run_deploy.outputs.deploy_services_csv || 'n/a' }}
+          TRIGGERED_SERVICES_CSV: ${{ steps.run_deploy.outputs.triggered_services_csv || 'n/a' }}
         run: |
           {
-            echo "## Preview Deploy"
-            echo "- PR: #${{ needs.scope.outputs.pr_number }}"
-            echo "- Environment: ${{ steps.run_deploy.outputs.environment_name || 'n/a' }}"
-            echo "- Environment created: ${{ steps.run_deploy.outputs.environment_created || 'n/a' }}"
-            echo "- Environment ready: ${{ steps.run_deploy.outputs.environment_ready || 'n/a' }}"
-            echo "- Environment warnings: ${{ steps.run_deploy.outputs.environment_warning_count || '0' }}"
-            echo "- Target SHA: ${{ steps.run_deploy.outputs.target_commit_sha || 'n/a' }}"
-            echo "- Last deployed SHA: ${{ steps.run_deploy.outputs.last_deployed_commit_sha || 'n/a' }}"
-            echo "- Runtime provider outputs: ${{ steps.run_deploy.outputs.runtime_provider_output_keys_csv || 'n/a' }}"
-            echo "- Requested services: ${{ steps.run_deploy.outputs.requested_services_csv || 'n/a' }}"
-            echo "- Deploy services: ${{ steps.run_deploy.outputs.deploy_services_csv || 'n/a' }}"
-            echo "- Triggered services: ${{ steps.run_deploy.outputs.triggered_services_csv || 'n/a' }}"
+            printf '%s\n' "## Preview Deploy"
+            printf '%s\n' "- PR: #$PR_NUMBER"
+            printf '%s\n' "- Environment: $ENVIRONMENT_NAME"
+            printf '%s\n' "- Environment created: $ENVIRONMENT_CREATED"
+            printf '%s\n' "- Environment ready: $ENVIRONMENT_READY"
+            printf '%s\n' "- Environment warnings: $ENVIRONMENT_WARNING_COUNT"
+            printf '%s\n' "- Target SHA: $TARGET_COMMIT_SHA"
+            printf '%s\n' "- Last deployed SHA: $LAST_DEPLOYED_COMMIT_SHA"
+            printf '%s\n' "- Runtime provider outputs: $RUNTIME_PROVIDER_OUTPUT_KEYS_CSV"
+            printf '%s\n' "- Requested services: $REQUESTED_SERVICES_CSV"
+            printf '%s\n' "- Deploy services: $DEPLOY_SERVICES_CSV"
+            printf '%s\n' "- Triggered services: $TRIGGERED_SERVICES_CSV"
           } >> "$GITHUB_STEP_SUMMARY"
 
   verify:
@@ -271,16 +309,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -330,12 +369,18 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ needs.scope.outputs.pr_number }}
+          ENVIRONMENT_NAME: ${{ needs.deploy.outputs.environment_name || 'n/a' }}
+          REQUESTED_SERVICES_CSV: ${{ needs.deploy.outputs.requested_services_csv || 'n/a' }}
+          DEPLOY_SERVICES_CSV: ${{ needs.deploy.outputs.deploy_services_csv || 'n/a' }}
+          TRIGGERED_SERVICES_CSV: ${{ needs.deploy.outputs.triggered_services_csv || 'n/a' }}
         run: |
           {
-            echo "## Preview Verify"
-            echo "- PR: #${{ needs.scope.outputs.pr_number }}"
-            echo "- Environment: ${{ needs.deploy.outputs.environment_name || 'n/a' }}"
-            echo "- Requested services: ${{ needs.deploy.outputs.requested_services_csv || 'n/a' }}"
-            echo "- Deploy services: ${{ needs.deploy.outputs.deploy_services_csv || 'n/a' }}"
-            echo "- Triggered services: ${{ needs.deploy.outputs.triggered_services_csv || 'n/a' }}"
+            printf '%s\n' "## Preview Verify"
+            printf '%s\n' "- PR: #$PR_NUMBER"
+            printf '%s\n' "- Environment: $ENVIRONMENT_NAME"
+            printf '%s\n' "- Requested services: $REQUESTED_SERVICES_CSV"
+            printf '%s\n' "- Deploy services: $DEPLOY_SERVICES_CSV"
+            printf '%s\n' "- Triggered services: $TRIGGERED_SERVICES_CSV"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/zaneops-preview-teardown.yml
+++ b/.github/workflows/zaneops-preview-teardown.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build_cli:
@@ -15,11 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: pnpm
@@ -33,7 +34,7 @@ jobs:
         run: NX_ISOLATE_PLUGINS=false ./node_modules/.bin/nubx --node nx run new-engine-ctl:build
 
       - name: Upload new-engine-ctl artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist/cli.js
@@ -48,14 +49,16 @@ jobs:
       group: zaneops-preview-teardown-pr-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: new-engine-ctl-dist
           path: apps/new-engine-ctl/dist
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
 
@@ -82,20 +85,32 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SKIPPED: ${{ steps.run_teardown.outcome == 'skipped' && 'true' || 'false' }}
+          ENVIRONMENT_OUTCOME: ${{ steps.run_teardown.outputs.environment_outcome || 'n/a' }}
+          ENVIRONMENT_HTTP_CODE: ${{ steps.run_teardown.outputs.environment_http_code || 'n/a' }}
+          ENVIRONMENT_NAME: ${{ steps.run_teardown.outputs.environment_name || 'n/a' }}
+          ENVIRONMENT_NOOP: ${{ steps.run_teardown.outputs.environment_noop || 'n/a' }}
+          PREVIEW_DB_OUTCOME: ${{ steps.run_teardown.outputs.preview_db_outcome || 'n/a' }}
+          PREVIEW_DB_HTTP_CODE: ${{ steps.run_teardown.outputs.preview_db_http_code || 'n/a' }}
+          PREVIEW_DB_STATUS: ${{ steps.run_teardown.outputs.preview_db_status || 'n/a' }}
+          PREVIEW_DB_NAME: ${{ steps.run_teardown.outputs.preview_db_name || 'n/a' }}
+          PREVIEW_DB_NOOP: ${{ steps.run_teardown.outputs.preview_db_noop || 'n/a' }}
         run: |
           {
-            echo "## Preview Teardown"
-            echo "- PR: #${{ github.event.pull_request.number }}"
-            echo "- Skipped: ${{ steps.run_teardown.outcome == 'skipped' && 'true' || 'false' }}"
-            echo "- Environment outcome: ${{ steps.run_teardown.outputs.environment_outcome || 'n/a' }}"
-            echo "- Environment HTTP: ${{ steps.run_teardown.outputs.environment_http_code || 'n/a' }}"
-            echo "- Environment name: ${{ steps.run_teardown.outputs.environment_name || 'n/a' }}"
-            echo "- Environment noop: ${{ steps.run_teardown.outputs.environment_noop || 'n/a' }}"
-            echo "- DB outcome: ${{ steps.run_teardown.outputs.preview_db_outcome || 'n/a' }}"
-            echo "- DB HTTP: ${{ steps.run_teardown.outputs.preview_db_http_code || 'n/a' }}"
-            echo "- DB status: ${{ steps.run_teardown.outputs.preview_db_status || 'n/a' }}"
-            echo "- DB name: ${{ steps.run_teardown.outputs.preview_db_name || 'n/a' }}"
-            echo "- DB noop: ${{ steps.run_teardown.outputs.preview_db_noop || 'n/a' }}"
+            printf '%s\n' "## Preview Teardown"
+            printf '%s\n' "- PR: #$PR_NUMBER"
+            printf '%s\n' "- Skipped: $SKIPPED"
+            printf '%s\n' "- Environment outcome: $ENVIRONMENT_OUTCOME"
+            printf '%s\n' "- Environment HTTP: $ENVIRONMENT_HTTP_CODE"
+            printf '%s\n' "- Environment name: $ENVIRONMENT_NAME"
+            printf '%s\n' "- Environment noop: $ENVIRONMENT_NOOP"
+            printf '%s\n' "- DB outcome: $PREVIEW_DB_OUTCOME"
+            printf '%s\n' "- DB HTTP: $PREVIEW_DB_HTTP_CODE"
+            printf '%s\n' "- DB status: $PREVIEW_DB_STATUS"
+            printf '%s\n' "- DB name: $PREVIEW_DB_NAME"
+            printf '%s\n' "- DB noop: $PREVIEW_DB_NOOP"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail when teardown failed


### PR DESCRIPTION
## Summary
- pin GitHub Actions references to immutable SHAs
- route GitHub context values through environment variables before shell use
- set checkout `persist-credentials: false` where jobs do not need git credentials
- narrow workflow/job permissions around deployment and reusable workflow jobs

## Verification
- `uvx zizmor -q --format json --no-progress --no-exit-codes --collect=workflows .github/workflows`
  - before: 154 findings, H74/M19/L1/I60
  - after: 2 findings, H1/M0/L1/I0
- `/Users/satan/side/experiments/skills/actionlint/scripts/run_actionlint.sh /Users/satan/worktrees/new-engine-zizmor-actions`
- `git diff --check`

## Remaining zizmor findings
- `dangerous-triggers` in `.github/workflows/medusa-be-tests-after-ci.yml`: existing `workflow_run` behavior is preserved because changing the trigger would alter CI semantics.
- `adhoc-packages` in `.github/workflows/ui-release.yml`: existing `npm install -g npm@latest` release setup is preserved to avoid changing publishing behavior.