### PR TITLE
feat(herbatika): add fullscreen product gallery

### DIFF
--- a/apps/herbatika/src/components/homepage/sections/homepage-hero-carousel-section.tsx
+++ b/apps/herbatika/src/components/homepage/sections/homepage-hero-carousel-section.tsx
@@ -124,10 +124,11 @@ function HeroCarousel({
   spacing = HERO_SLIDE_SPACING,
 }: HeroCarouselProps) {
   const didDragRef = useRef(false)
-  const handleSlidePointerDownCapture: PointerEventHandler<HTMLAnchorElement> =
-    () => {
-      didDragRef.current = false
-    }
+  const handleSlidePointerDownCapture: PointerEventHandler<
+    HTMLAnchorElement
+  > = () => {
+    didDragRef.current = false
+  }
   const handleSlideClickCapture: MouseEventHandler<HTMLAnchorElement> = (
     event
   ) => {
@@ -157,16 +158,16 @@ function HeroCarousel({
       className="w-full"
       key={restoreKey}
       loop={hasOverflow}
-      size="full"
-      slideCount={slides.length}
-      slidesPerMove={1}
-      slidesPerPage={slidesPerPage}
-      spacing={spacing}
       onDragStatusChange={(details) => {
         if (details.type === "dragging") {
           didDragRef.current = true
         }
       }}
+      size="full"
+      slideCount={slides.length}
+      slidesPerMove={1}
+      slidesPerPage={slidesPerPage}
+      spacing={spacing}
     >
       <Carousel.Slides className={slidesClassName} slides={slides} />
       {hasOverflow ? (

--- a/apps/herbatika/src/components/product-detail.tsx
+++ b/apps/herbatika/src/components/product-detail.tsx
@@ -25,9 +25,7 @@ export function ProductDetail({ handle }: ProductDetailProps) {
   const controller = useProductDetailController({ handle })
   const [activeInfoSection, setActiveInfoSection] = useState<
     string | undefined
-  >(
-    controller.defaultInfoSectionValue
-  )
+  >(controller.defaultInfoSectionValue)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: `controller.product?.id` is an intentional trigger — re-syncs the active section when navigating to a different product (App Router reuses the component).
   useEffect(() => {

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
@@ -119,8 +119,8 @@ export function ProductDetailGalleryLightbox({
                     className="pointer-events-none absolute inset-x-200 top-1/2 z-1 -translate-y-1/2 justify-between bg-transparent p-0 max-md:text-fg-primary"
                     controlPosition="unset"
                   >
-                    <Carousel.Previous className="pointer-events-auto bg-white rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
-                    <Carousel.Next className="pointer-events-auto bg-white rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                    <Carousel.Previous className="pointer-events-auto bg-base rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                    <Carousel.Next className="pointer-events-auto bg-base rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
                   </Carousel.Control>
                 ) : null}
               </Gallery.Carousel>

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import { ActionIcon } from "@techsio/ui-kit/atoms/action-icon"
+import { Carousel } from "@techsio/ui-kit/molecules/carousel"
+import { Dialog } from "@techsio/ui-kit/molecules/dialog"
+import {
+  Gallery,
+  type GalleryItem,
+  type GalleryValueChangeDetails,
+} from "@techsio/ui-kit/organisms/gallery"
+import { FallbackImage } from "@/components/fallback-image"
+import { FALLBACK_IMAGE_SRC } from "@/components/fallback-image.constants"
+
+type ProductDetailGalleryLightboxProps = {
+  items: GalleryItem[]
+  onOpenChange: (open: boolean) => void
+  onValueChange: (value: number) => void
+  open: boolean
+  value: number
+}
+
+export function ProductDetailGalleryLightbox({
+  items,
+  onOpenChange,
+  onValueChange,
+  open,
+  value,
+}: ProductDetailGalleryLightboxProps) {
+  const maxIndex = Math.max(items.length - 1, 0)
+  const safeValue = Math.min(value, maxIndex)
+  const hasMultipleImages = items.length > 1
+  const lightboxItems: GalleryItem[] = items.map((item, index) => {
+    const imageSrc = item.src || FALLBACK_IMAGE_SRC
+    const imageAlt = item.alt || `Produkt (${index + 1})`
+
+    return {
+      ...item,
+      alt: imageAlt,
+      content: (
+        <span className="flex h-full w-full items-center justify-center">
+          <FallbackImage
+            alt={imageAlt}
+            className="h-full w-full object-contain"
+            height={1200}
+            loading={index === safeValue ? "eager" : "lazy"}
+            quality={90}
+            sizes="100vw"
+            src={imageSrc}
+            width={1200}
+          />
+        </span>
+      ),
+      src: imageSrc,
+    }
+  })
+
+  if (items.length === 0) {
+    return null
+  }
+
+  const handleOpenChange = ({ open: nextOpen }: { open: boolean }) => {
+    onOpenChange(nextOpen)
+  }
+
+  const handleValueChange = ({ value: nextValue }: GalleryValueChangeDetails) => {
+    onValueChange(nextValue)
+  }
+
+  const handleClose = () => {
+    onOpenChange(false)
+  }
+
+  return (
+    <div className="[&_[data-part=backdrop]]:z-[80] [&_[data-part=backdrop]]:bg-fg-strong/85 [&_[data-part=positioner]]:z-[90]">
+      <Dialog
+        className="h-full w-full max-w-none overflow-hidden rounded-none border-0 bg-transparent p-0 shadow-none [&_[data-part=title]]:sr-only"
+        customTrigger
+        hideCloseButton
+        onOpenChange={handleOpenChange}
+        open={open}
+        placement="right"
+        portal={false}
+        title="Galéria produktu"
+      >
+        <div className="relative h-dvh max-h-dvh overflow-hidden p-300 text-fg-reverse">
+          <ActionIcon
+            aria-label="Zavrieť galériu"
+            className="absolute top-300 right-300 z-2 bg-transparent text-fg-reverse hover:text-primary active:bg-fg-reverse/25 focus-visible:outline-fg-reverse"
+            icon="token-icon-close"
+            onClick={handleClose}
+            size="lg"
+          />
+          <Gallery
+            carouselProps={{
+              allowMouseDrag: true,
+              aspectRatio: "none",
+              height: "100%",
+              loop: hasMultipleImages,
+              objectFit: "contain",
+              size: "full",
+              width: "100%",
+            }}
+            className="h-full min-h-0"
+            getThumbnailAriaLabel={({ index }) =>
+              `Zobraziť obrázok ${index + 1} v galérii`
+            }
+            items={lightboxItems}
+            onValueChange={handleValueChange}
+            orientation="horizontal"
+            showThumbnails={hasMultipleImages}
+            thumbnailSize={64}
+            value={safeValue}
+          >
+            <Gallery.Main className="h-full min-h-0 flex-1 overflow-hidden bg-transparent">
+              <Gallery.Carousel className="h-full min-h-0 w-full">
+                <Gallery.Slides className="h-full" />
+                {hasMultipleImages ? (
+                  <Carousel.Control
+                    className="pointer-events-none absolute inset-x-200 top-1/2 z-1 -translate-y-1/2 justify-between bg-transparent p-0 max-md:text-fg-primary"
+                    controlPosition="unset"
+                  >
+                    <Carousel.Previous className="pointer-events-auto bg-white rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                    <Carousel.Next className="pointer-events-auto bg-white rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                  </Carousel.Control>
+                ) : null}
+              </Gallery.Carousel>
+            </Gallery.Main>
+
+            {hasMultipleImages ? (
+              <Gallery.Thumbnails
+                className="shrink-0"
+                listClassName="justify-center gap-100"
+              />
+            ) : null}
+          </Gallery>
+        </div>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-gallery-lightbox.tsx
@@ -62,7 +62,9 @@ export function ProductDetailGalleryLightbox({
     onOpenChange(nextOpen)
   }
 
-  const handleValueChange = ({ value: nextValue }: GalleryValueChangeDetails) => {
+  const handleValueChange = ({
+    value: nextValue,
+  }: GalleryValueChangeDetails) => {
     onValueChange(nextValue)
   }
 
@@ -85,7 +87,7 @@ export function ProductDetailGalleryLightbox({
         <div className="relative h-dvh max-h-dvh overflow-hidden p-300 text-fg-reverse">
           <ActionIcon
             aria-label="Zavrieť galériu"
-            className="absolute top-300 right-300 z-2 bg-transparent text-fg-reverse hover:text-primary active:bg-fg-reverse/25 focus-visible:outline-fg-reverse"
+            className="absolute top-300 right-300 z-2 bg-transparent text-fg-reverse hover:text-primary focus-visible:outline-fg-reverse active:bg-fg-reverse/25"
             icon="token-icon-close"
             onClick={handleClose}
             size="lg"
@@ -116,11 +118,11 @@ export function ProductDetailGalleryLightbox({
                 <Gallery.Slides className="h-full" />
                 {hasMultipleImages ? (
                   <Carousel.Control
-                    className="pointer-events-none absolute inset-x-200 top-1/2 z-1 -translate-y-1/2 justify-between bg-transparent p-0 max-md:text-fg-primary"
+                    className="-translate-y-1/2 pointer-events-none absolute inset-x-200 top-1/2 z-1 justify-between bg-transparent p-0 max-md:text-fg-primary"
                     controlPosition="unset"
                   >
-                    <Carousel.Previous className="pointer-events-auto bg-base rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
-                    <Carousel.Next className="pointer-events-auto bg-base rounded-full aspect-square max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                    <Carousel.Previous className="pointer-events-auto aspect-square rounded-full bg-base max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
+                    <Carousel.Next className="pointer-events-auto aspect-square rounded-full bg-base max-md:shadow-md md:bg-transparent md:hover:bg-transparent" />
                   </Carousel.Control>
                 ) : null}
               </Gallery.Carousel>

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
@@ -1,18 +1,15 @@
 "use client"
 
 import { Badge } from "@techsio/ui-kit/atoms/badge"
-import { Button } from "@techsio/ui-kit/atoms/button"
 import { Icon } from "@techsio/ui-kit/atoms/icon"
 import { Link } from "@techsio/ui-kit/atoms/link"
 import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
 import { Gallery, type GalleryItem } from "@techsio/ui-kit/organisms/gallery"
 import NextImage from "next/image"
 import NextLink from "next/link"
-import { type MouseEvent, type PointerEvent, useRef, useState } from "react"
-import { FallbackImage } from "@/components/fallback-image"
-import { FALLBACK_IMAGE_SRC } from "@/components/fallback-image.constants"
 import type { ProductMediaFact } from "@/components/product-detail/product-detail.types"
 import { ProductDetailGalleryLightbox } from "@/components/product-detail/sections/product-detail-gallery-lightbox"
+import { useProductDetailGalleryState } from "@/components/product-detail/sections/use-product-detail-gallery-state"
 import { SupportingText } from "@/components/text/supporting-text"
 import { useMediaQuery } from "@/hooks/use-media-query"
 
@@ -29,99 +26,14 @@ export function ProductDetailMediaColumn({
 }: ProductDetailMediaColumnProps) {
   const isDesktopGallery = useMediaQuery("md")
   const carouselOrientation = isDesktopGallery ? "vertical" : "horizontal"
-  const [selectedImageIndex, setSelectedImageIndex] = useState(0)
-  const [isLightboxOpen, setIsLightboxOpen] = useState(false)
-  const pendingOpenImageIndexRef = useRef<number | null>(null)
-  const cancelPendingOpen = () => {
-    pendingOpenImageIndexRef.current = null
-  }
-  const handleMainImagePointerDown = (
-    event: PointerEvent<HTMLButtonElement>,
-    index: number
-  ) => {
-    if (event.button !== 0) {
-      cancelPendingOpen()
-      return
-    }
-
-    pendingOpenImageIndexRef.current = index
-  }
-  const handleMainImagePointerUp = () => {
-    const pendingIndex = pendingOpenImageIndexRef.current
-    cancelPendingOpen()
-
-    if (pendingIndex !== null) {
-      handleOpenLightbox(pendingIndex)
-    }
-  }
-  const handleOpenLightbox = (index: number) => {
-    setSelectedImageIndex(index)
-    setIsLightboxOpen(true)
-  }
-  const handleMainImageClick = (
-    event: MouseEvent<HTMLButtonElement>,
-    index: number
-  ) => {
-    if (event.detail === 0) {
-      handleOpenLightbox(index)
-    }
-  }
-  const galleryItemsWithFallback: GalleryItem[] = galleryItems.map(
-    (item, index) => {
-      const imageSrc = item.src || FALLBACK_IMAGE_SRC
-      const imageAlt = item.alt || "Produkt"
-      const imageContent = item.content ?? (
-        <FallbackImage
-          alt={imageAlt}
-          className="h-full w-full object-contain"
-          height={408}
-          loading="eager"
-          quality={75}
-          sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
-          src={imageSrc}
-          width={408}
-        />
-      )
-
-      return {
-        ...item,
-        alt: imageAlt,
-        src: imageSrc,
-        content: (
-          <Button
-            aria-label={`Otvoriť obrázok ${index + 1} v galérii`}
-            className="flex h-full w-full cursor-zoom-in items-center justify-center p-0 active:cursor-grabbing"
-            onClick={(event) => handleMainImageClick(event, index)}
-            onPointerCancel={cancelPendingOpen}
-            onPointerDown={(event) => handleMainImagePointerDown(event, index)}
-            onPointerUp={handleMainImagePointerUp}
-            size="current"
-            theme="unstyled"
-            type="button"
-          >
-            {imageContent}
-          </Button>
-        ),
-        thumbnailContent: item.thumbnailContent ?? (
-          <span className="flex h-full w-full items-center justify-center">
-            <FallbackImage
-              alt={item.thumbnailAlt || imageAlt}
-              className="h-full w-full object-contain"
-              height={88}
-              quality={60}
-              sizes="88px"
-              src={item.thumbnailSrc || imageSrc}
-              width={88}
-            />
-          </span>
-        ),
-      }
-    }
-  )
-  const safeSelectedImageIndex = Math.min(
-    selectedImageIndex,
-    Math.max(galleryItemsWithFallback.length - 1, 0)
-  )
+  const {
+    cancelPendingOpen,
+    galleryItemsWithFallback,
+    isLightboxOpen,
+    safeSelectedImageIndex,
+    setIsLightboxOpen,
+    setSelectedImageIndex,
+  } = useProductDetailGalleryState({ galleryItems })
 
   return (
     <div className="min-w-0 space-y-300">

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
@@ -1,16 +1,18 @@
 "use client"
 
 import { Badge } from "@techsio/ui-kit/atoms/badge"
+import { Button } from "@techsio/ui-kit/atoms/button"
 import { Icon } from "@techsio/ui-kit/atoms/icon"
 import { Link } from "@techsio/ui-kit/atoms/link"
 import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
 import { Gallery, type GalleryItem } from "@techsio/ui-kit/organisms/gallery"
 import NextImage from "next/image"
 import NextLink from "next/link"
-import { useMemo } from "react"
+import { type MouseEvent, type PointerEvent, useRef, useState } from "react"
 import { FallbackImage } from "@/components/fallback-image"
 import { FALLBACK_IMAGE_SRC } from "@/components/fallback-image.constants"
 import type { ProductMediaFact } from "@/components/product-detail/product-detail.types"
+import { ProductDetailGalleryLightbox } from "@/components/product-detail/sections/product-detail-gallery-lightbox"
 import { SupportingText } from "@/components/text/supporting-text"
 import { useMediaQuery } from "@/hooks/use-media-query"
 
@@ -27,46 +29,95 @@ export function ProductDetailMediaColumn({
 }: ProductDetailMediaColumnProps) {
   const isDesktopGallery = useMediaQuery("md")
   const carouselOrientation = isDesktopGallery ? "vertical" : "horizontal"
-  const galleryItemsWithFallback = useMemo<GalleryItem[]>(
-    () =>
-      galleryItems.map((item) => {
-        const imageSrc = item.src || FALLBACK_IMAGE_SRC
-        const imageAlt = item.alt || "Produkt"
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0)
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false)
+  const pendingOpenImageIndexRef = useRef<number | null>(null)
+  const cancelPendingOpen = () => {
+    pendingOpenImageIndexRef.current = null
+  }
+  const handleMainImagePointerDown = (
+    event: PointerEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (event.button !== 0) {
+      cancelPendingOpen()
+      return
+    }
 
-        return {
-          ...item,
-          alt: imageAlt,
-          src: imageSrc,
-          content: item.content ?? (
-            <span className="flex h-full w-full items-center justify-center">
-              <FallbackImage
-                alt={imageAlt}
-                className="h-full w-full object-contain"
-                height={408}
-                loading="eager"
-                quality={75}
-                sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
-                src={imageSrc}
-                width={408}
-              />
-            </span>
-          ),
-          thumbnailContent: item.thumbnailContent ?? (
-            <span className="flex h-full w-full items-center justify-center">
-              <FallbackImage
-                alt={item.thumbnailAlt || imageAlt}
-                className="h-full w-full object-contain"
-                height={88}
-                quality={60}
-                sizes="88px"
-                src={item.thumbnailSrc || imageSrc}
-                width={88}
-              />
-            </span>
-          ),
-        }
-      }),
-    [galleryItems]
+    pendingOpenImageIndexRef.current = index
+  }
+  const handleMainImagePointerUp = () => {
+    const pendingIndex = pendingOpenImageIndexRef.current
+    cancelPendingOpen()
+
+    if (pendingIndex !== null) {
+      handleOpenLightbox(pendingIndex)
+    }
+  }
+  const handleOpenLightbox = (index: number) => {
+    setSelectedImageIndex(index)
+    setIsLightboxOpen(true)
+  }
+  const handleMainImageClick = (
+    event: MouseEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (event.detail === 0) {
+      handleOpenLightbox(index)
+    }
+  }
+  const galleryItemsWithFallback: GalleryItem[] = galleryItems.map(
+    (item, index) => {
+      const imageSrc = item.src || FALLBACK_IMAGE_SRC
+      const imageAlt = item.alt || "Produkt"
+
+      return {
+        ...item,
+        alt: imageAlt,
+        src: imageSrc,
+        content: item.content ?? (
+          <Button
+            aria-label={`Otvoriť obrázok ${index + 1} v galérii`}
+            className="flex h-full w-full cursor-zoom-in items-center justify-center p-0 active:cursor-grabbing"
+            onClick={(event) => handleMainImageClick(event, index)}
+            onPointerCancel={cancelPendingOpen}
+            onPointerDown={(event) => handleMainImagePointerDown(event, index)}
+            onPointerUp={handleMainImagePointerUp}
+            size="current"
+            theme="unstyled"
+            type="button"
+          >
+            <FallbackImage
+              alt={imageAlt}
+              className="h-full w-full object-contain"
+              height={408}
+              loading="eager"
+              quality={75}
+              sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
+              src={imageSrc}
+              width={408}
+            />
+          </Button>
+        ),
+        thumbnailContent: item.thumbnailContent ?? (
+          <span className="flex h-full w-full items-center justify-center">
+            <FallbackImage
+              alt={item.thumbnailAlt || imageAlt}
+              className="h-full w-full object-contain"
+              height={88}
+              quality={60}
+              sizes="88px"
+              src={item.thumbnailSrc || imageSrc}
+              width={88}
+            />
+          </span>
+        ),
+      }
+    }
+  )
+  const safeSelectedImageIndex = Math.min(
+    selectedImageIndex,
+    Math.max(galleryItemsWithFallback.length - 1, 0)
   )
 
   return (
@@ -74,17 +125,24 @@ export function ProductDetailMediaColumn({
       <Gallery
         carouselProps={{
           aspectRatio: "square",
-          loop: true,
+          loop: galleryItemsWithFallback.length > 1,
           objectFit: "contain",
           orientation: carouselOrientation,
           size: "full",
           width: "100%",
+          onDragStatusChange: (details) => {
+            if (details.type === "dragging") {
+              cancelPendingOpen()
+            }
+          },
         }}
         className="min-w-0 md:grid-cols-[auto_minmax(0,1fr)]"
         hideThumbnailsWhenSingle={false}
         items={galleryItemsWithFallback}
+        onValueChange={({ value }) => setSelectedImageIndex(value)}
         orientation="vertical"
         thumbnailSize={88}
+        value={safeSelectedImageIndex}
       >
         <Gallery.Thumbnails
           className="md:col-start-1 md:row-start-1"
@@ -125,6 +183,14 @@ export function ProductDetailMediaColumn({
         </Gallery.Main>
       </Gallery>
 
+      <ProductDetailGalleryLightbox
+        items={galleryItemsWithFallback}
+        onOpenChange={setIsLightboxOpen}
+        onValueChange={setSelectedImageIndex}
+        open={isLightboxOpen}
+        value={safeSelectedImageIndex}
+      />
+
       <div className="flex min-w-0 flex-wrap items-center justify-between gap-250 rounded-base border border-primary/20 bg-surface p-400 md:flex-nowrap lg:max-xl:grid lg:max-xl:grid-cols-2 xl:flex-wrap">
         <div className="flex min-w-0 items-center gap-150 lg:max-xl:col-span-2">
           <NextImage
@@ -161,7 +227,7 @@ export function ProductDetailMediaColumn({
         <LinkButton
           as={NextLink}
           className="min-h-chat-button shrink-0 px-350 py-150"
-          href="/kontakt"
+          href="/"
           size="sm"
           theme="outlined"
           variant="primary"

--- a/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/product-detail-media-column.tsx
@@ -70,12 +70,24 @@ export function ProductDetailMediaColumn({
     (item, index) => {
       const imageSrc = item.src || FALLBACK_IMAGE_SRC
       const imageAlt = item.alt || "Produkt"
+      const imageContent = item.content ?? (
+        <FallbackImage
+          alt={imageAlt}
+          className="h-full w-full object-contain"
+          height={408}
+          loading="eager"
+          quality={75}
+          sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
+          src={imageSrc}
+          width={408}
+        />
+      )
 
       return {
         ...item,
         alt: imageAlt,
         src: imageSrc,
-        content: item.content ?? (
+        content: (
           <Button
             aria-label={`Otvoriť obrázok ${index + 1} v galérii`}
             className="flex h-full w-full cursor-zoom-in items-center justify-center p-0 active:cursor-grabbing"
@@ -87,16 +99,7 @@ export function ProductDetailMediaColumn({
             theme="unstyled"
             type="button"
           >
-            <FallbackImage
-              alt={imageAlt}
-              className="h-full w-full object-contain"
-              height={408}
-              loading="eager"
-              quality={75}
-              sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
-              src={imageSrc}
-              width={408}
-            />
+            {imageContent}
           </Button>
         ),
         thumbnailContent: item.thumbnailContent ?? (

--- a/apps/herbatika/src/components/product-detail/sections/use-product-detail-gallery-state.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/use-product-detail-gallery-state.tsx
@@ -55,6 +55,10 @@ export function useProductDetailGalleryState({
       handleOpenLightbox(index)
     }
   }
+  const safeSelectedImageIndex = Math.min(
+    selectedImageIndex,
+    Math.max(galleryItems.length - 1, 0)
+  )
 
   const galleryItemsWithFallback: GalleryItem[] = galleryItems.map(
     (item, index) => {
@@ -65,7 +69,7 @@ export function useProductDetailGalleryState({
           alt={imageAlt}
           className="h-full w-full object-contain"
           height={408}
-          loading="eager"
+          loading={index === safeSelectedImageIndex ? "eager" : "lazy"}
           quality={75}
           sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
           src={imageSrc}
@@ -107,10 +111,6 @@ export function useProductDetailGalleryState({
         ),
       }
     }
-  )
-  const safeSelectedImageIndex = Math.min(
-    selectedImageIndex,
-    Math.max(galleryItemsWithFallback.length - 1, 0)
   )
 
   return {

--- a/apps/herbatika/src/components/product-detail/sections/use-product-detail-gallery-state.tsx
+++ b/apps/herbatika/src/components/product-detail/sections/use-product-detail-gallery-state.tsx
@@ -1,0 +1,124 @@
+"use client"
+
+import { Button } from "@techsio/ui-kit/atoms/button"
+import type { GalleryItem } from "@techsio/ui-kit/organisms/gallery"
+import { type MouseEvent, type PointerEvent, useRef, useState } from "react"
+import { FallbackImage } from "@/components/fallback-image"
+import { FALLBACK_IMAGE_SRC } from "@/components/fallback-image.constants"
+
+type UseProductDetailGalleryStateProps = {
+  galleryItems: GalleryItem[]
+}
+
+export function useProductDetailGalleryState({
+  galleryItems,
+}: UseProductDetailGalleryStateProps) {
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0)
+  const [isLightboxOpen, setIsLightboxOpen] = useState(false)
+  const pendingOpenImageIndexRef = useRef<number | null>(null)
+
+  const cancelPendingOpen = () => {
+    pendingOpenImageIndexRef.current = null
+  }
+
+  const handleOpenLightbox = (index: number) => {
+    setSelectedImageIndex(index)
+    setIsLightboxOpen(true)
+  }
+
+  const handleMainImagePointerDown = (
+    event: PointerEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (event.button !== 0) {
+      cancelPendingOpen()
+      return
+    }
+
+    pendingOpenImageIndexRef.current = index
+  }
+
+  const handleMainImagePointerUp = () => {
+    const pendingIndex = pendingOpenImageIndexRef.current
+    cancelPendingOpen()
+
+    if (pendingIndex !== null) {
+      handleOpenLightbox(pendingIndex)
+    }
+  }
+
+  const handleMainImageClick = (
+    event: MouseEvent<HTMLButtonElement>,
+    index: number
+  ) => {
+    if (event.detail === 0) {
+      handleOpenLightbox(index)
+    }
+  }
+
+  const galleryItemsWithFallback: GalleryItem[] = galleryItems.map(
+    (item, index) => {
+      const imageSrc = item.src || FALLBACK_IMAGE_SRC
+      const imageAlt = item.alt || "Produkt"
+      const imageContent = item.content ?? (
+        <FallbackImage
+          alt={imageAlt}
+          className="h-full w-full object-contain"
+          height={408}
+          loading="eager"
+          quality={75}
+          sizes="(max-width: 767px) 60vw, (max-width: 1023px) 408px, 32vw"
+          src={imageSrc}
+          width={408}
+        />
+      )
+
+      return {
+        ...item,
+        alt: imageAlt,
+        src: imageSrc,
+        content: (
+          <Button
+            aria-label={`Otvoriť obrázok ${index + 1} v galérii`}
+            className="flex h-full w-full cursor-zoom-in items-center justify-center p-0 active:cursor-grabbing"
+            onClick={(event) => handleMainImageClick(event, index)}
+            onPointerCancel={cancelPendingOpen}
+            onPointerDown={(event) => handleMainImagePointerDown(event, index)}
+            onPointerUp={handleMainImagePointerUp}
+            size="current"
+            theme="unstyled"
+            type="button"
+          >
+            {imageContent}
+          </Button>
+        ),
+        thumbnailContent: item.thumbnailContent ?? (
+          <span className="flex h-full w-full items-center justify-center">
+            <FallbackImage
+              alt={item.thumbnailAlt || imageAlt}
+              className="h-full w-full object-contain"
+              height={88}
+              quality={60}
+              sizes="88px"
+              src={item.thumbnailSrc || imageSrc}
+              width={88}
+            />
+          </span>
+        ),
+      }
+    }
+  )
+  const safeSelectedImageIndex = Math.min(
+    selectedImageIndex,
+    Math.max(galleryItemsWithFallback.length - 1, 0)
+  )
+
+  return {
+    cancelPendingOpen,
+    galleryItemsWithFallback,
+    isLightboxOpen,
+    safeSelectedImageIndex,
+    setIsLightboxOpen,
+    setSelectedImageIndex,
+  }
+}


### PR DESCRIPTION
 ## Summary

  Adds a fullscreen product gallery/lightbox to PDP images.

  - Opens the active product image in an overlay gallery
  - Supports larger image preview, thumbnails, close action, and carousel navigation
  - Keeps the current gallery selection in sync between PDP and lightbox
  - Preserves drag behavior so dragging the product gallery does not accidentally open the lightbox
  - Adds keyboard-accessible opening for the main product image
  - Uses fallback image data and clamps the selected index to avoid invalid selection states

  ## Task

  Notion: https://www.notion.so/pegak/Galerie-na-product-detailu-38b36e86b6ce80fca851cd1344efd705?v=36536e86b6ce805ca18a000cce0316d2&source=copy_link

  ## Inspiration

  Chakra UI lightbox carousel pattern:
  https://chakra-ui.com/docs/components/carousel#lightbox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a client-side full-screen product image lightbox for the product gallery, with optional thumbnails and carousel controls when multiple images are available.
* **Bug Fixes**
  * Clamped the selected gallery index for safer navigation, handled empty image sets gracefully, and improved image loading by eagerly loading the active slide while lazily loading the rest.
  * Refined carousel dragging and lightbox coordination to reduce unintended open/close behaviour.
* **Chores**
  * Centralised product gallery and lightbox state management into a dedicated hook and reused it across the product media components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->