### PR TITLE
chore(next): switch apps to Rust React Compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Generate Next.js types (n1)
         id: generate_next_types_n1
         if: contains(steps.determine_affected.outputs.projects_csv, ',n1,')
-        run: pnpm --filter=n1 exec next typegen
+        run: TURBOPACK=1 pnpm --filter=n1 exec next typegen
 
       # Prepend any command with "nx-cloud record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx-cloud record -- echo Hello World

--- a/apps/frontend-demo/next.config.js
+++ b/apps/frontend-demo/next.config.js
@@ -1,14 +1,11 @@
 /** @type {import('next').NextConfig} */
-const isTurbopack = Boolean(process.env.TURBOPACK)
-const turbopackRustCompiler = isTurbopack
-  ? { turbopackRustReactCompiler: true }
-  : {}
-
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["ui"],
-  reactCompiler: isTurbopack,
-  experimental: turbopackRustCompiler,
+  reactCompiler: true,
+  experimental: {
+    turbopackRustReactCompiler: true,
+  },
   // Removed 'output: export' to enable SSG with dynamic functions
   images: {
     remotePatterns: [

--- a/apps/frontend-demo/next.config.js
+++ b/apps/frontend-demo/next.config.js
@@ -1,8 +1,14 @@
 /** @type {import('next').NextConfig} */
+const isTurbopack = Boolean(process.env.TURBOPACK)
+const turbopackRustCompiler = isTurbopack
+  ? { turbopackRustReactCompiler: true }
+  : {}
+
 const nextConfig = {
   reactStrictMode: true,
   transpilePackages: ["ui"],
-  reactCompiler: true,
+  reactCompiler: isTurbopack,
+  experimental: turbopackRustCompiler,
   // Removed 'output: export' to enable SSG with dynamic functions
   images: {
     remotePatterns: [

--- a/apps/frontend-demo/package.json
+++ b/apps/frontend-demo/package.json
@@ -39,7 +39,6 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
-    "babel-plugin-react-compiler": "1.0.0",
     "dotenv": "^16.6.0",
     "postcss": "^8.5.6",
     "postcss-import": "^16.1.1",

--- a/apps/frontend-demo/package.json
+++ b/apps/frontend-demo/package.json
@@ -7,10 +7,10 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "next dev -p 3000",
-    "build": "next build",
-    "build:static": "next build",
-    "build:no-types": "cross-env SKIP_TYPE_CHECK=1 next build",
+    "dev": "next dev --turbopack -p 3000",
+    "build": "next build --turbopack",
+    "build:static": "next build --turbopack",
+    "build:no-types": "cross-env SKIP_TYPE_CHECK=1 next build --turbopack",
     "start": "next start -p 3000",
     "check:unused": "node scripts/check-unused-exports.js",
     "generate:categories": "node scripts/generate-categories.mjs",

--- a/apps/herbatika/next.config.ts
+++ b/apps/herbatika/next.config.ts
@@ -27,11 +27,16 @@ const resolveMedusaImageRemotePattern = () =>
 const resolvePayloadImageRemotePattern = () =>
   resolveImageRemotePattern(process.env.NEXT_PUBLIC_PAYLOAD_BASE_URL)
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+const turbopackRustCompiler = isTurbopack
+  ? ({ turbopackRustReactCompiler: true } as const)
+  : {}
+
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
   transpilePackages: ["@techsio/ui-kit", "@techsio/storefront-data"],
-  reactCompiler: true,
+  reactCompiler: isTurbopack,
   cacheComponents: true,
   outputFileTracingRoot: join(__dirname, "../../"),
   outputFileTracingExcludes: {
@@ -78,6 +83,7 @@ const nextConfig: NextConfig = {
   experimental: {
     typedEnv: true,
     cpus: 1,
+    ...turbopackRustCompiler,
     webpackMemoryOptimizations: true,
   },
 }

--- a/apps/herbatika/next.config.ts
+++ b/apps/herbatika/next.config.ts
@@ -77,7 +77,6 @@ const nextConfig: NextConfig = {
 
   experimental: {
     typedEnv: true,
-    cpus: 1,
     turbopackRustReactCompiler: true,
   },
 }

--- a/apps/herbatika/next.config.ts
+++ b/apps/herbatika/next.config.ts
@@ -27,16 +27,11 @@ const resolveMedusaImageRemotePattern = () =>
 const resolvePayloadImageRemotePattern = () =>
   resolveImageRemotePattern(process.env.NEXT_PUBLIC_PAYLOAD_BASE_URL)
 
-const isTurbopack = Boolean(process.env.TURBOPACK)
-const turbopackRustCompiler = isTurbopack
-  ? ({ turbopackRustReactCompiler: true } as const)
-  : {}
-
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: "standalone",
   transpilePackages: ["@techsio/ui-kit", "@techsio/storefront-data"],
-  reactCompiler: isTurbopack,
+  reactCompiler: true,
   cacheComponents: true,
   outputFileTracingRoot: join(__dirname, "../../"),
   outputFileTracingExcludes: {
@@ -83,8 +78,7 @@ const nextConfig: NextConfig = {
   experimental: {
     typedEnv: true,
     cpus: 1,
-    ...turbopackRustCompiler,
-    webpackMemoryOptimizations: true,
+    turbopackRustReactCompiler: true,
   },
 }
 

--- a/apps/herbatika/package.json
+++ b/apps/herbatika/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
-    "build": "next build",
+    "dev": "next dev --turbopack -p 3001",
+    "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",

--- a/apps/herbatika/package.json
+++ b/apps/herbatika/package.json
@@ -45,7 +45,6 @@
     "@types/qrcode": "1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "babel-plugin-react-compiler": "1.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4",
     "tailwindcss-animate": "^1.0.7",

--- a/apps/n1/next.config.ts
+++ b/apps/n1/next.config.ts
@@ -1,17 +1,12 @@
 import { join } from "node:path"
 import type { NextConfig } from "next"
 
-const isTurbopack = Boolean(process.env.TURBOPACK)
-const turbopackRustCompiler = isTurbopack
-  ? ({ turbopackRustReactCompiler: true } as const)
-  : {}
-
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["n1.medusa.localhost"],
   reactStrictMode: true,
   output: "standalone",
   transpilePackages: ["@new-engine/ui", "@techsio/analytics"],
-  reactCompiler: isTurbopack,
+  reactCompiler: true,
   cacheComponents: true,
   outputFileTracingRoot: join(__dirname, "../../"),
   outputFileTracingExcludes: {
@@ -48,7 +43,7 @@ const nextConfig: NextConfig = {
 
   experimental: {
     typedEnv: true,
-    ...turbopackRustCompiler,
+    turbopackRustReactCompiler: true,
   },
 
   // Security headers

--- a/apps/n1/next.config.ts
+++ b/apps/n1/next.config.ts
@@ -1,12 +1,17 @@
 import { join } from "node:path"
 import type { NextConfig } from "next"
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+const turbopackRustCompiler = isTurbopack
+  ? ({ turbopackRustReactCompiler: true } as const)
+  : {}
+
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["n1.medusa.localhost"],
   reactStrictMode: true,
   output: "standalone",
   transpilePackages: ["@new-engine/ui", "@techsio/analytics"],
-  reactCompiler: true,
+  reactCompiler: isTurbopack,
   cacheComponents: true,
   outputFileTracingRoot: join(__dirname, "../../"),
   outputFileTracingExcludes: {
@@ -43,6 +48,7 @@ const nextConfig: NextConfig = {
 
   experimental: {
     typedEnv: true,
+    ...turbopackRustCompiler,
   },
 
   // Security headers

--- a/apps/n1/package.json
+++ b/apps/n1/package.json
@@ -42,7 +42,6 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
-    "babel-plugin-react-compiler": "^1.0.0",
     "dotenv": "^16.4.7",
     "postcss": "^8.5.6",
     "postcss-import": "^16.1.1",

--- a/apps/n1/package.json
+++ b/apps/n1/package.json
@@ -13,9 +13,9 @@
     ]
   },
   "scripts": {
-    "dev": "next dev",
-    "start:ci-dev": "next dev --hostname 0.0.0.0 --port 3000",
-    "build": "next build",
+    "dev": "next dev --turbopack",
+    "start:ci-dev": "next dev --turbopack --hostname 0.0.0.0 --port 3000",
+    "build": "next build --turbopack",
     "start": "next start",
     "lint": "biome check",
     "format": "biome format --write",

--- a/apps/payload/next.config.mjs
+++ b/apps/payload/next.config.mjs
@@ -1,25 +1,13 @@
 import { join } from "node:path"
 import { withPayload } from "@payloadcms/next/withPayload"
 
-const isTurbopack = Boolean(process.env.TURBOPACK)
-const turbopackRustCompiler = isTurbopack
-  ? { turbopackRustReactCompiler: true }
-  : {}
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: join(import.meta.dirname, "../../"),
-  reactCompiler: isTurbopack,
-  experimental: turbopackRustCompiler,
-  webpack: (webpackConfig) => {
-    webpackConfig.resolve.extensionAlias = {
-      ".cjs": [".cts", ".cjs"],
-      ".js": [".ts", ".tsx", ".js", ".jsx"],
-      ".mjs": [".mts", ".mjs"],
-    }
-
-    return webpackConfig
+  reactCompiler: true,
+  experimental: {
+    turbopackRustReactCompiler: true,
   },
 }
 

--- a/apps/payload/next.config.mjs
+++ b/apps/payload/next.config.mjs
@@ -1,11 +1,17 @@
 import { join } from "node:path"
 import { withPayload } from "@payloadcms/next/withPayload"
 
+const isTurbopack = Boolean(process.env.TURBOPACK)
+const turbopackRustCompiler = isTurbopack
+  ? { turbopackRustReactCompiler: true }
+  : {}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   outputFileTracingRoot: join(import.meta.dirname, "../../"),
-  reactCompiler: true,
+  reactCompiler: isTurbopack,
+  experimental: turbopackRustCompiler,
   webpack: (webpackConfig) => {
     webpackConfig.resolve.extensionAlias = {
       ".cjs": [".cts", ".cjs"],

--- a/apps/payload/package.json
+++ b/apps/payload/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" next build",
-    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev",
-    "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev",
+    "build": "cross-env NODE_OPTIONS=\"--no-deprecation --max-old-space-size=8000\" next build --turbopack",
+    "dev": "cross-env NODE_OPTIONS=--no-deprecation next dev --turbopack",
+    "devsafe": "rm -rf .next && cross-env NODE_OPTIONS=--no-deprecation next dev --turbopack",
     "generate:importmap": "cross-env NODE_OPTIONS=--no-deprecation payload generate:importmap",
     "generate:types": "cross-env NODE_OPTIONS=--no-deprecation payload generate:types",
     "import:articles": "cross-env NODE_OPTIONS=--no-deprecation payload run src/scripts/import-articles.ts",

--- a/apps/payload/package.json
+++ b/apps/payload/package.json
@@ -28,7 +28,6 @@
     "@payloadcms/translations": "3.85.1",
     "@payloadcms/ui": "3.85.1",
     "@pigment/auto-translate": "^1.3.4",
-    "babel-plugin-react-compiler": "1.0.0",
     "dotenv": "16.4.7",
     "exceljs": "^4.4.0",
     "graphql": "^16.8.1",

--- a/docker/development/herbatika/Dockerfile
+++ b/docker/development/herbatika/Dockerfile
@@ -21,7 +21,7 @@ CMD ["sh", "-lc", "\
     [ -x apps/herbatika/node_modules/.bin/next ] || CI=true pnpm install --frozen-lockfile --prefer-offline --filter=herbatika...; \
     pnpm --filter=@techsio/storefront-data build; \
     pnpm --filter=@techsio/ui-kit build; \
-    pnpm --filter=herbatika exec next dev --hostname 0.0.0.0 --port 3000 \
+    pnpm --filter=herbatika exec next dev --turbopack --hostname 0.0.0.0 --port 3000 \
 "]
 
 FROM base AS build

--- a/docker/development/herbatika/Dockerfile
+++ b/docker/development/herbatika/Dockerfile
@@ -63,7 +63,7 @@ RUN pnpm --filter=@techsio/storefront-data build
 RUN pnpm --filter=@techsio/ui-kit build
 
 RUN --mount=type=cache,id=next-cache-herbatika,target=/var/www/apps/herbatika/.next/cache \
-    pnpm --filter=herbatika exec next build --webpack && \
+    pnpm --filter=herbatika exec next build --turbopack && \
     test -f apps/herbatika/.next/BUILD_ID
 
 FROM node:24-slim AS prod

--- a/docker/development/n1/Dockerfile
+++ b/docker/development/n1/Dockerfile
@@ -110,7 +110,7 @@ ENV NEXT_PUBLIC_HEUREKA_API_KEY=${NEXT_PUBLIC_HEUREKA_API_KEY}
 # after building @techsio/* dist outputs or Next build can resolve stale package state.
 RUN --mount=type=cache,id=pnpm-store-n1,target=/pnpm/store \
     pnpm install --store-dir=/pnpm/store --offline --frozen-lockfile --filter=n1... && \
-    pnpm --filter=n1 exec next typegen && \
+    TURBOPACK=1 pnpm --filter=n1 exec next typegen && \
     pnpm --filter=n1 build && \
     test -f apps/n1/.next/BUILD_ID
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.3)
-      babel-plugin-react-compiler:
-        specifier: 1.0.0
-        version: 1.0.0
       dotenv:
         specifier: ^16.6.0
         version: 16.6.1
@@ -246,9 +243,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.3)
-      babel-plugin-react-compiler:
-        specifier: 1.0.0
-        version: 1.0.0
       postcss:
         specifier: ^8.5.6
         version: 8.5.14
@@ -684,9 +678,6 @@ importers:
       '@types/react-dom':
         specifier: 19.2.3
         version: 19.2.3(@types/react@19.2.3)
-      babel-plugin-react-compiler:
-        specifier: ^1.0.0
-        version: 1.0.0
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -757,9 +748,6 @@ importers:
       '@pigment/auto-translate':
         specifier: ^1.3.4
         version: 1.3.4(@types/react@19.2.3)(monaco-editor@0.55.1)(next@16.3.0-preview.5(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.84.0))(payload@3.85.1(graphql@16.12.0)(typescript@5.7.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.7.3)(ws@8.19.0)(zod@4.2.0)
-      babel-plugin-react-compiler:
-        specifier: 1.0.0
-        version: 1.0.0
       dotenv:
         specifier: 16.4.7
         version: 16.4.7


### PR DESCRIPTION
## Summary
- enable `experimental.turbopackRustReactCompiler` for the four Next 16.3 apps
- remove direct `babel-plugin-react-compiler` dependencies from those apps after local production builds passed without direct package resolution
- keep Medusa admin compiler dependencies untouched

Closes #485

## Validation
- `mise exec -- pnpm install --frozen-lockfile`
- `mise exec -- bunx biome check --write apps/frontend-demo/next.config.js apps/frontend-demo/package.json apps/n1/next.config.ts apps/n1/package.json apps/payload/next.config.mjs apps/payload/package.json`
- `mise exec -- pnpm -C apps/frontend-demo exec next build`
- `mise exec -- pnpm -C apps/herbatika build`
- `mise exec -- pnpm -C libs/analytics build && mise exec -- pnpm -C apps/n1 build`
- `mise exec -- env PAYLOAD_SECRET=local-build-secret DATABASE_URL=postgresql://payload:payload@127.0.0.1:5432/payload S3_ENDPOINT=http://127.0.0.1:9000 S3_REGION=us-east-1 S3_BUCKET=payload-media S3_ACCESS_KEY_ID=payload S3_SECRET_ACCESS_KEY=payload-secret pnpm -C apps/payload build`
- `mise exec -- ./node_modules/.bin/nubx --node nx affected -t lint test --files="<changed files>"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled the Rust-based React compiler experimental path across multiple Next.js app configurations.
* **Chores**
  * Switched local development and build scripts to use Turbopack (`--turbopack`) across affected apps and the development container.
  * Removed the `babel-plugin-react-compiler` dependency from the relevant app package(s).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->