### PR TITLE
Fix QR amount current order total priority

### DIFF
--- a/apps/medusa-be/src/utils/order-payment-qr.ts
+++ b/apps/medusa-be/src/utils/order-payment-qr.ts
@@ -185,8 +185,8 @@ function formatSpaydAmount(value: OrderPaymentQrOrder["total"]) {
 
 function getOrderPaymentAmount(order: OrderPaymentQrOrder) {
   return (
-    order.total ??
     order.summary?.current_order_total ??
+    order.total ??
     order.summary?.original_order_total
   )
 }

--- a/apps/medusa-be/tests/unit/src/utils/order-payment-qr.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/utils/order-payment-qr.unit.spec.ts
@@ -21,6 +21,36 @@ describe("order payment QR", () => {
     )
   })
 
+  it("prefers current order summary total over stale order total", () => {
+    expect(
+      orderPaymentQr.buildSpayd(
+        {
+          currency_code: "CZK",
+          display_id: 123,
+          id: "order_123",
+          summary: {
+            current_order_total: 123.45,
+            original_order_total: 999,
+          },
+          total: 999,
+        },
+        "CZ9608000000005444195083"
+      )
+    ).toContain("*AM:123.45*")
+  })
+
+  it("builds payment-session SPAYD from payment amount", () => {
+    expect(
+      orderPaymentQr.buildPaymentSpayd({
+        amount: 250,
+        currency_code: "CZK",
+        iban: "CZ9608000000005444195083",
+        message: "OBJEDNAVKA 123456",
+        reference: "123456",
+      })
+    ).toContain("*AM:250.00*")
+  })
+
   it("uses numeric custom display id as variable symbol", () => {
     expect(
       orderPaymentQr.buildSpayd(


### PR DESCRIPTION
### Problem
Order QR/SPAYD generation read `order.total` before the current payable summary total. If Medusa kept an old `order.total`, the QR code could ask the customer to pay the wrong amount.

### What changed
The order QR amount now prefers `summary.current_order_total`. Manual payment-session QR generation still uses the explicit payment amount.

### Evidence
Added regression coverage for `order.total = 999` and `summary.current_order_total = 123.45`; the generated SPAYD contains `AM:123.45`.
