### PR TITLE
Prefer stored receipt tax totals

### DIFF
--- a/apps/medusa-be/src/modules/order-receipt/helpers.ts
+++ b/apps/medusa-be/src/modules/order-receipt/helpers.ts
@@ -495,28 +495,27 @@ function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
     return roundMoney(taxTotal)
   }
 
+  const items = order.items ?? []
+  const shippingMethods = order.shipping_methods ?? []
   const itemTaxTotal = getExplicitMoneyTotal(order.item_tax_total)
   const shippingTaxTotal = getExplicitMoneyTotal(order.shipping_tax_total)
-  const itemsHaveTaxTotals = (order.items ?? []).some((item) =>
+  const allItemsHaveTaxTotals = items.every((item) =>
     hasExplicitMoney(item.tax_total)
   )
-  const shippingMethodsHaveTaxTotals = (order.shipping_methods ?? []).some(
+  const allShippingMethodsHaveTaxTotals = shippingMethods.every(
     (shippingMethod) => hasExplicitMoney(shippingMethod.tax_total)
   )
+  const hasItemTaxSignal = itemTaxTotal !== null || allItemsHaveTaxTotals
+  const hasShippingTaxSignal =
+    shippingTaxTotal !== null || allShippingMethodsHaveTaxTotals
 
-  if (
-    itemTaxTotal === null &&
-    shippingTaxTotal === null &&
-    !itemsHaveTaxTotals &&
-    !shippingMethodsHaveTaxTotals
-  ) {
+  if (!(hasItemTaxSignal && hasShippingTaxSignal)) {
     return null
   }
 
   return roundMoney(
-    (itemTaxTotal ?? getLineItemsTaxTotal(order.items ?? [])) +
-      (shippingTaxTotal ??
-        getShippingMethodsTaxTotal(order.shipping_methods ?? []))
+    (itemTaxTotal ?? getLineItemsTaxTotal(items)) +
+      (shippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
   )
 }
 

--- a/apps/medusa-be/src/modules/order-receipt/helpers.ts
+++ b/apps/medusa-be/src/modules/order-receipt/helpers.ts
@@ -507,6 +507,30 @@ function hasCompleteRelationTaxSignal(
   )
 }
 
+function getCurrentOrderTaxBalance(order: OrderReceiptOrder) {
+  if (
+    order.summary?.current_order_total === null ||
+    order.summary?.current_order_total === undefined
+  ) {
+    return null
+  }
+
+  return roundMoney(
+    toNumber(order.summary.current_order_total) +
+      toNumber(order.discount_total) -
+      getSubtotal(order) -
+      getShippingSubtotalTotal(order)
+  )
+}
+
+function getCurrentOrderTaxTotal(order: OrderReceiptOrder) {
+  const currentOrderTaxBalance = getCurrentOrderTaxBalance(order)
+
+  return currentOrderTaxBalance === null
+    ? null
+    : Math.max(0, currentOrderTaxBalance)
+}
+
 function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
   const hasItemsRelation = Array.isArray(order.items)
   const hasShippingMethodsRelation = Array.isArray(order.shipping_methods)
@@ -528,10 +552,23 @@ function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
   )
 
   if (hasItemTaxSignal && hasShippingTaxSignal) {
-    return roundMoney(
+    const explicitTaxTotal = roundMoney(
       (itemTaxTotal ?? getLineItemsTaxTotal(items)) +
         (clampedShippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
     )
+    const currentOrderTaxBalance = getCurrentOrderTaxBalance(order)
+    const currentOrderTaxTotal = getCurrentOrderTaxTotal(order)
+
+    if (
+      toNumber(order.discount_total) > 0 &&
+      currentOrderTaxBalance !== null &&
+      currentOrderTaxBalance >= 0 &&
+      currentOrderTaxTotal !== null
+    ) {
+      return Math.min(explicitTaxTotal, currentOrderTaxTotal)
+    }
+
+    return explicitTaxTotal
   }
 
   const taxTotal = getExplicitMoneyTotal(order.tax_total)
@@ -548,19 +585,9 @@ export function getTaxTotal(order: OrderReceiptOrder) {
     return explicitTaxTotal
   }
 
-  if (
-    order.summary?.current_order_total !== null &&
-    order.summary?.current_order_total !== undefined
-  ) {
-    return Math.max(
-      0,
-      roundMoney(
-        toNumber(order.summary.current_order_total) +
-          toNumber(order.discount_total) -
-          getSubtotal(order) -
-          getShippingSubtotalTotal(order)
-      )
-    )
+  const currentOrderTaxTotal = getCurrentOrderTaxTotal(order)
+  if (currentOrderTaxTotal !== null) {
+    return currentOrderTaxTotal
   }
 
   const itemTaxTotal = getLineItemsTaxTotal(order.items ?? [])

--- a/apps/medusa-be/src/modules/order-receipt/helpers.ts
+++ b/apps/medusa-be/src/modules/order-receipt/helpers.ts
@@ -489,34 +489,55 @@ function getShippingMethodsTaxTotal(
   )
 }
 
-function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
-  const taxTotal = getExplicitMoneyTotal(order.tax_total)
+function hasCompleteRelationTaxSignal(
+  relation: Array<{ tax_total?: OrderReceiptMoney }> | null | undefined,
+  taxTotal: number | null
+) {
+  if (!Array.isArray(relation)) {
+    return false
+  }
+
   if (taxTotal !== null) {
+    return true
+  }
+
+  return (
+    relation.length > 0 &&
+    relation.every((entry) => hasExplicitMoney(entry.tax_total))
+  )
+}
+
+function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
+  const hasItemsRelation = Array.isArray(order.items)
+  const hasShippingMethodsRelation = Array.isArray(order.shipping_methods)
+  const items = hasItemsRelation ? (order.items ?? []) : []
+  const shippingMethods = hasShippingMethodsRelation
+    ? (order.shipping_methods ?? [])
+    : []
+  const itemTaxTotal = getExplicitMoneyTotal(order.item_tax_total)
+  const shippingTaxTotal = getExplicitMoneyTotal(order.shipping_tax_total)
+  const hasItemTaxSignal = hasCompleteRelationTaxSignal(
+    order.items,
+    itemTaxTotal
+  )
+  const hasShippingTaxSignal = hasCompleteRelationTaxSignal(
+    order.shipping_methods,
+    shippingTaxTotal
+  )
+
+  if (hasItemTaxSignal && hasShippingTaxSignal) {
+    return roundMoney(
+      (itemTaxTotal ?? getLineItemsTaxTotal(items)) +
+        (shippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
+    )
+  }
+
+  const taxTotal = getExplicitMoneyTotal(order.tax_total)
+  if (taxTotal !== null && toNumber(order.discount_total) <= 0) {
     return roundMoney(taxTotal)
   }
 
-  const items = order.items ?? []
-  const shippingMethods = order.shipping_methods ?? []
-  const itemTaxTotal = getExplicitMoneyTotal(order.item_tax_total)
-  const shippingTaxTotal = getExplicitMoneyTotal(order.shipping_tax_total)
-  const allItemsHaveTaxTotals = items.every((item) =>
-    hasExplicitMoney(item.tax_total)
-  )
-  const allShippingMethodsHaveTaxTotals = shippingMethods.every(
-    (shippingMethod) => hasExplicitMoney(shippingMethod.tax_total)
-  )
-  const hasItemTaxSignal = itemTaxTotal !== null || allItemsHaveTaxTotals
-  const hasShippingTaxSignal =
-    shippingTaxTotal !== null || allShippingMethodsHaveTaxTotals
-
-  if (!(hasItemTaxSignal && hasShippingTaxSignal)) {
-    return null
-  }
-
-  return roundMoney(
-    (itemTaxTotal ?? getLineItemsTaxTotal(items)) +
-      (shippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
-  )
+  return null
 }
 
 export function getTaxTotal(order: OrderReceiptOrder) {

--- a/apps/medusa-be/src/modules/order-receipt/helpers.ts
+++ b/apps/medusa-be/src/modules/order-receipt/helpers.ts
@@ -450,7 +450,7 @@ export function getShippingTaxTotal(
 
   const taxTotal = getExplicitMoneyTotal(shippingMethod.tax_total)
   if (taxTotal !== null) {
-    return taxTotal
+    return Math.max(0, taxTotal)
   }
 
   const grossSubtotal = toNumber(
@@ -516,19 +516,21 @@ function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
     : []
   const itemTaxTotal = getExplicitMoneyTotal(order.item_tax_total)
   const shippingTaxTotal = getExplicitMoneyTotal(order.shipping_tax_total)
+  const clampedShippingTaxTotal =
+    shippingTaxTotal === null ? null : Math.max(0, shippingTaxTotal)
   const hasItemTaxSignal = hasCompleteRelationTaxSignal(
     order.items,
     itemTaxTotal
   )
   const hasShippingTaxSignal = hasCompleteRelationTaxSignal(
     order.shipping_methods,
-    shippingTaxTotal
+    clampedShippingTaxTotal
   )
 
   if (hasItemTaxSignal && hasShippingTaxSignal) {
     return roundMoney(
       (itemTaxTotal ?? getLineItemsTaxTotal(items)) +
-        (shippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
+        (clampedShippingTaxTotal ?? getShippingMethodsTaxTotal(shippingMethods))
     )
   }
 

--- a/apps/medusa-be/src/modules/order-receipt/helpers.ts
+++ b/apps/medusa-be/src/modules/order-receipt/helpers.ts
@@ -84,6 +84,7 @@ export type OrderReceiptOrder = {
   payment_collections?: OrderReceiptPaymentCollection[] | null
   shipping_methods?: OrderReceiptShippingMethod[] | null
   shipping_total?: OrderReceiptMoney
+  shipping_tax_total?: OrderReceiptMoney
   shipping_address?: OrderReceiptAddress | null
   subtotal?: OrderReceiptMoney
   summary?: OrderReceiptSummary | null
@@ -131,6 +132,14 @@ export function toNumber(value: OrderReceiptMoney | undefined): number {
   const number = typeof value === "string" ? Number(value) : value
 
   return Number.isFinite(number) ? number : 0
+}
+
+function hasExplicitMoney(value: OrderReceiptMoney | undefined) {
+  return value !== null && value !== undefined
+}
+
+function getExplicitMoneyTotal(value: OrderReceiptMoney | undefined) {
+  return hasExplicitMoney(value) ? toNumber(value) : null
 }
 
 export function ascii(value: unknown) {
@@ -391,19 +400,23 @@ function getItemsSubtotal(items: OrderReceiptLineItem[]) {
 }
 
 function getItemTaxTotal(item: OrderReceiptLineItem) {
+  const taxTotal = getExplicitMoneyTotal(item.tax_total)
+  if (taxTotal !== null) {
+    return taxTotal
+  }
+
   const subtotal = getItemSubtotalAmount(item)
   const rate = getTaxRate(item)
 
   if (rate <= 0) {
-    return toNumber(item.tax_total)
+    return 0
   }
 
   if (item.is_tax_inclusive === true) {
     return roundMoney(subtotal - getNetFromGross(subtotal, rate))
   }
 
-  const taxTotal = toNumber(item.tax_total)
-  return taxTotal > 0 ? taxTotal : roundMoney((subtotal * rate) / 100)
+  return roundMoney((subtotal * rate) / 100)
 }
 
 export function getShippingSubtotal(
@@ -435,6 +448,11 @@ export function getShippingTaxTotal(
     return 0
   }
 
+  const taxTotal = getExplicitMoneyTotal(shippingMethod.tax_total)
+  if (taxTotal !== null) {
+    return taxTotal
+  }
+
   const grossSubtotal = toNumber(
     shippingMethod.subtotal ??
       shippingMethod.total ??
@@ -444,22 +462,70 @@ export function getShippingTaxTotal(
   const rate = getTaxRate(shippingMethod)
 
   if (rate <= 0) {
-    return toNumber(shippingMethod.tax_total)
+    return 0
   }
 
   if (shippingMethod.is_tax_inclusive === true) {
     return roundMoney(grossSubtotal - getNetFromGross(grossSubtotal, rate))
   }
 
-  const taxTotal = toNumber(shippingMethod.tax_total)
-  return taxTotal > 0 ? taxTotal : roundMoney((grossSubtotal * rate) / 100)
+  return roundMoney((grossSubtotal * rate) / 100)
 }
 
 export function getSubtotal(order: OrderReceiptOrder) {
   return getItemsSubtotal(order.items ?? [])
 }
 
+function getLineItemsTaxTotal(items: OrderReceiptLineItem[]) {
+  return items.reduce((sum, item) => sum + getItemTaxTotal(item), 0)
+}
+
+function getShippingMethodsTaxTotal(
+  shippingMethods: OrderReceiptShippingMethod[]
+) {
+  return shippingMethods.reduce(
+    (sum, shippingMethod) => sum + getShippingTaxTotal(shippingMethod),
+    0
+  )
+}
+
+function getExplicitOrderTaxTotal(order: OrderReceiptOrder) {
+  const taxTotal = getExplicitMoneyTotal(order.tax_total)
+  if (taxTotal !== null) {
+    return roundMoney(taxTotal)
+  }
+
+  const itemTaxTotal = getExplicitMoneyTotal(order.item_tax_total)
+  const shippingTaxTotal = getExplicitMoneyTotal(order.shipping_tax_total)
+  const itemsHaveTaxTotals = (order.items ?? []).some((item) =>
+    hasExplicitMoney(item.tax_total)
+  )
+  const shippingMethodsHaveTaxTotals = (order.shipping_methods ?? []).some(
+    (shippingMethod) => hasExplicitMoney(shippingMethod.tax_total)
+  )
+
+  if (
+    itemTaxTotal === null &&
+    shippingTaxTotal === null &&
+    !itemsHaveTaxTotals &&
+    !shippingMethodsHaveTaxTotals
+  ) {
+    return null
+  }
+
+  return roundMoney(
+    (itemTaxTotal ?? getLineItemsTaxTotal(order.items ?? [])) +
+      (shippingTaxTotal ??
+        getShippingMethodsTaxTotal(order.shipping_methods ?? []))
+  )
+}
+
 export function getTaxTotal(order: OrderReceiptOrder) {
+  const explicitTaxTotal = getExplicitOrderTaxTotal(order)
+  if (explicitTaxTotal !== null) {
+    return explicitTaxTotal
+  }
+
   if (
     order.summary?.current_order_total !== null &&
     order.summary?.current_order_total !== undefined
@@ -475,13 +541,9 @@ export function getTaxTotal(order: OrderReceiptOrder) {
     )
   }
 
-  const itemTaxTotal = (order.items ?? []).reduce(
-    (sum, item) => sum + getItemTaxTotal(item),
-    0
-  )
-  const shippingTaxTotal = (order.shipping_methods ?? []).reduce(
-    (sum, shippingMethod) => sum + getShippingTaxTotal(shippingMethod),
-    0
+  const itemTaxTotal = getLineItemsTaxTotal(order.items ?? [])
+  const shippingTaxTotal = getShippingMethodsTaxTotal(
+    order.shipping_methods ?? []
   )
 
   return roundMoney(itemTaxTotal + shippingTaxTotal)

--- a/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
+++ b/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
@@ -61,6 +61,7 @@ const ORDER_PAYMENT_REMINDER_RECEIPT_FIELDS = [
   "payment_collections.payments.data",
   "payment_collections.payments.provider_id",
   "shipping_total",
+  "shipping_tax_total",
   "shipping_methods.amount",
   "shipping_methods.is_tax_inclusive",
   "shipping_methods.name",

--- a/apps/medusa-be/src/workflows/send-order-receipt.ts
+++ b/apps/medusa-be/src/workflows/send-order-receipt.ts
@@ -55,6 +55,7 @@ const ORDER_RECEIPT_FIELDS = [
   "payment_collections.payments.data",
   "payment_collections.payments.provider_id",
   "shipping_total",
+  "shipping_tax_total",
   "shipping_methods.amount",
   "shipping_methods.is_tax_inclusive",
   "shipping_methods.name",

--- a/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
@@ -187,6 +187,125 @@ describe("order receipt service", () => {
     ).toBe(7.5)
   })
 
+  it("uses order-level item tax total with stored shipping tax total", () => {
+    expect(
+      getTaxTotal({
+        id: "order_level_item_tax",
+        item_tax_total: 15,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 3,
+          },
+        ],
+        summary: {
+          current_order_total: 999,
+        },
+      })
+    ).toBe(18)
+  })
+
+  it("uses order-level shipping tax total with stored item tax total", () => {
+    expect(
+      getTaxTotal({
+        id: "order_level_shipping_tax",
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 15,
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_tax_total: 3,
+        summary: {
+          current_order_total: 999,
+        },
+      })
+    ).toBe(18)
+  })
+
+  it("keeps discount-aware fallback when explicit tax totals are partial", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_partial_stored_tax",
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 1,
+          },
+        ],
+        summary: {
+          current_order_total: 61,
+        },
+      })
+    ).toBe(1)
+  })
+
+  it("keeps discount-aware fallback when stored item tax totals are partial", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_partial_line_tax",
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 4,
+          },
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 40,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 1,
+          },
+        ],
+        summary: {
+          current_order_total: 101,
+        },
+      })
+    ).toBe(1)
+  })
+
   it("clamps derived tax totals at zero", () => {
     expect(
       getTaxTotal({

--- a/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
@@ -187,6 +187,48 @@ describe("order receipt service", () => {
     ).toBe(7.5)
   })
 
+  it("clamps negative stored shipping tax totals", () => {
+    expect(
+      getTaxTotal({
+        id: "order_negative_shipping_method_tax",
+        item_tax_total: 21,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+            tax_total: -5,
+          },
+        ],
+      })
+    ).toBe(21)
+
+    expect(
+      getTaxTotal({
+        id: "order_negative_shipping_tax",
+        item_tax_total: 0,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [],
+        shipping_tax_total: -5,
+      })
+    ).toBe(0)
+  })
+
   it("uses order-level item tax total with stored shipping tax total", () => {
     expect(
       getTaxTotal({

--- a/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
@@ -309,6 +309,30 @@ describe("order receipt service", () => {
     ).toBe(12.32)
   })
 
+  it("nets discounts from stored tax totals on discounted receipts", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_discounted_pre_discount_tax",
+        item_tax_total: 21,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [],
+        shipping_tax_total: 0,
+        summary: {
+          current_order_total: 62.32,
+        },
+        tax_total: 21,
+      })
+    ).toBe(12.32)
+  })
+
   it("treats explicit zero tax totals as present when relations are loaded", () => {
     expect(
       getTaxTotal({

--- a/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
@@ -123,10 +123,10 @@ describe("order receipt service", () => {
     ).toBe(21)
   })
 
-  it("prefers stored order tax totals over discounted balance arithmetic", () => {
+  it("uses stored order tax totals when receipt is not discounted", () => {
     expect(
       getTaxTotal({
-        discount_total: 50,
+        discount_total: 0,
         id: "order_stored_tax",
         items: [
           {
@@ -243,6 +243,54 @@ describe("order receipt service", () => {
     ).toBe(18)
   })
 
+  it("uses side stored tax totals before order tax total on discounted receipts", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_discounted_side_tax",
+        item_tax_total: 12.32,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [],
+        shipping_tax_total: 0,
+        summary: {
+          current_order_total: 62.32,
+        },
+        tax_total: 21,
+      })
+    ).toBe(12.32)
+  })
+
+  it("treats explicit zero tax totals as present when relations are loaded", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 1,
+        id: "order_zero_side_tax",
+        item_tax_total: 0,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [],
+        shipping_tax_total: 0,
+        summary: {
+          current_order_total: 999,
+        },
+        tax_total: 99,
+      })
+    ).toBe(0)
+  })
+
   it("keeps discount-aware fallback when explicit tax totals are partial", () => {
     expect(
       getTaxTotal({
@@ -266,6 +314,47 @@ describe("order receipt service", () => {
         ],
         summary: {
           current_order_total: 61,
+        },
+      })
+    ).toBe(1)
+  })
+
+  it("keeps discount-aware fallback when shipping methods relation is missing", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_missing_shipping_relation",
+        item_tax_total: 21,
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        summary: {
+          current_order_total: 51,
+        },
+      })
+    ).toBe(1)
+  })
+
+  it("keeps discount-aware fallback when items relation is missing", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 5,
+        id: "order_missing_items_relation",
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_tax_total: 2,
+        summary: {
+          current_order_total: 6,
         },
       })
     ).toBe(1)

--- a/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
+++ b/apps/medusa-be/tests/unit/src/modules/order-receipt/service.unit.spec.ts
@@ -123,6 +123,70 @@ describe("order receipt service", () => {
     ).toBe(21)
   })
 
+  it("prefers stored order tax totals over discounted balance arithmetic", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 50,
+        id: "order_stored_tax",
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+          },
+        ],
+        summary: {
+          current_order_total: 150,
+        },
+        tax_total: 11,
+      })
+    ).toBe(11)
+  })
+
+  it("sums mixed stored item and shipping tax totals before discounted balance arithmetic", () => {
+    expect(
+      getTaxTotal({
+        discount_total: 20,
+        id: "order_stored_line_tax",
+        items: [
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 100,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 0,
+          },
+          {
+            is_tax_inclusive: false,
+            quantity: 1,
+            subtotal: 30,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 6.3,
+          },
+        ],
+        shipping_methods: [
+          {
+            amount: 10,
+            is_tax_inclusive: false,
+            tax_lines: [{ rate: 21 }],
+            tax_total: 1.2,
+          },
+        ],
+        summary: {
+          current_order_total: 100,
+        },
+      })
+    ).toBe(7.5)
+  })
+
   it("clamps derived tax totals at zero", () => {
     expect(
       getTaxTotal({


### PR DESCRIPTION
### Problem
Receipt DPH could be calculated by balancing totals (`current total + discount - subtotal - shipping`) even when Medusa had stored tax totals. That can make invoice DPH differ from the order tax data.

### What changed
Receipt tax now uses stored order tax totals first, then stored item/shipping tax totals, and only falls back to arithmetic when explicit tax data is absent.

### Evidence
Added coverage for stored order tax and mixed item/shipping stored tax totals, including explicit zero tax totals.
