### PR TITLE
Fix payment reminder payable total

### DIFF
--- a/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
+++ b/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
@@ -71,6 +71,52 @@ type Notification = {
   data?: Record<string, unknown>
 }
 
+type OrderTotalFixture = {
+  summary: {
+    current_order_total?: number | string | null
+    original_order_total?: number | string | null
+  } | null
+  total: number | string | null
+}
+
+function createPaymentReminderNotificationContext(order: OrderTotalFixture) {
+  const graph = vi.fn().mockResolvedValue({
+    data: [
+      {
+        currency_code: "czk",
+        customer_id: "cus_123",
+        display_id: 1001,
+        id: "order_123",
+        ...order,
+      },
+    ],
+  })
+  const generateOrderReceiptAttachment = vi.fn().mockResolvedValue({
+    content: Buffer.from("pdf"),
+    content_type: "application/pdf",
+    filename: "receipt.pdf",
+  })
+  const container = {
+    resolve: vi.fn((key: string) => {
+      if (key === "query") {
+        return { graph }
+      }
+
+      if (key === "logger") {
+        return { warn: vi.fn() }
+      }
+
+      if (key === "order_receipt") {
+        return { generateOrderReceiptAttachment }
+      }
+
+      throw new Error(`Unexpected dependency ${key}`)
+    }),
+  }
+
+  return { container, generateOrderReceiptAttachment, graph }
+}
+
 describe("send order payment reminder workflow", () => {
   it("uses the fetched order summary total for notification data", async () => {
     await import("../send-order-payment-reminder")
@@ -81,43 +127,13 @@ describe("send order payment reminder workflow", () => {
 
     expect(step).toBeDefined()
 
-    const graph = vi.fn().mockResolvedValue({
-      data: [
-        {
-          currency_code: "czk",
-          customer_id: "cus_123",
-          display_id: 1001,
-          id: "order_123",
-          summary: {
-            current_order_total: 1234.56,
-            original_order_total: 1999,
-          },
-          total: 1999,
-        },
-      ],
+    const { container, graph } = createPaymentReminderNotificationContext({
+      summary: {
+        current_order_total: 1234.56,
+        original_order_total: 1999,
+      },
+      total: 1999,
     })
-    const generateOrderReceiptAttachment = vi.fn().mockResolvedValue({
-      content: Buffer.from("pdf"),
-      content_type: "application/pdf",
-      filename: "receipt.pdf",
-    })
-    const container = {
-      resolve: vi.fn((key: string) => {
-        if (key === "query") {
-          return { graph }
-        }
-
-        if (key === "logger") {
-          return { warn: vi.fn() }
-        }
-
-        if (key === "order_receipt") {
-          return { generateOrderReceiptAttachment }
-        }
-
-        throw new Error(`Unexpected dependency ${key}`)
-      }),
-    }
 
     const result = (await step?.(
       {
@@ -198,39 +214,7 @@ describe("send order payment reminder workflow", () => {
     )
     expect(step).toBeDefined()
 
-    const graph = vi.fn().mockResolvedValue({
-      data: [
-        {
-          currency_code: "czk",
-          customer_id: "cus_123",
-          display_id: 1001,
-          id: "order_123",
-          ...order,
-        },
-      ],
-    })
-    const generateOrderReceiptAttachment = vi.fn().mockResolvedValue({
-      content: Buffer.from("pdf"),
-      content_type: "application/pdf",
-      filename: "receipt.pdf",
-    })
-    const container = {
-      resolve: vi.fn((key: string) => {
-        if (key === "query") {
-          return { graph }
-        }
-
-        if (key === "logger") {
-          return { warn: vi.fn() }
-        }
-
-        if (key === "order_receipt") {
-          return { generateOrderReceiptAttachment }
-        }
-
-        throw new Error(`Unexpected dependency ${key}`)
-      }),
-    }
+    const { container } = createPaymentReminderNotificationContext(order)
 
     const result = (await step?.(
       {

--- a/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
+++ b/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
@@ -148,4 +148,103 @@ describe("send order payment reminder workflow", () => {
       })
     )
   })
+
+  it.each([
+    {
+      expectedTotal: new Intl.NumberFormat("cs-CZ", {
+        currency: "CZK",
+        style: "currency",
+      }).format(1500),
+      inputTotal: "stale input total",
+      order: {
+        summary: {
+          current_order_total: null,
+          original_order_total: 1500,
+        },
+        total: 1999,
+      },
+    },
+    {
+      expectedTotal: new Intl.NumberFormat("cs-CZ", {
+        currency: "CZK",
+        style: "currency",
+      }).format(1600.5),
+      inputTotal: "stale input total",
+      order: {
+        summary: {
+          current_order_total: null,
+          original_order_total: null,
+        },
+        total: "1600.5",
+      },
+    },
+    {
+      expectedTotal: "1 234,56 Kč",
+      inputTotal: "1 234,56 Kč",
+      order: {
+        summary: null,
+        total: null,
+      },
+    },
+  ])("uses fetched order total precedence before input fallback %#", async ({
+    expectedTotal,
+    inputTotal,
+    order,
+  }) => {
+    await import("../send-order-payment-reminder")
+
+    const step = workflowSdkMock.steps.get(
+      "build-order-payment-reminder-notification"
+    )
+    expect(step).toBeDefined()
+
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          currency_code: "czk",
+          customer_id: "cus_123",
+          display_id: 1001,
+          id: "order_123",
+          ...order,
+        },
+      ],
+    })
+    const generateOrderReceiptAttachment = vi.fn().mockResolvedValue({
+      content: Buffer.from("pdf"),
+      content_type: "application/pdf",
+      filename: "receipt.pdf",
+    })
+    const container = {
+      resolve: vi.fn((key: string) => {
+        if (key === "query") {
+          return { graph }
+        }
+
+        if (key === "logger") {
+          return { warn: vi.fn() }
+        }
+
+        if (key === "order_receipt") {
+          return { generateOrderReceiptAttachment }
+        }
+
+        throw new Error(`Unexpected dependency ${key}`)
+      }),
+    }
+
+    const result = (await step?.(
+      {
+        customer_id: "cus_123",
+        email: "customer@example.com",
+        order_display_id: "#1001",
+        order_id: "order_123",
+        payment_url: "https://shop.example/orders/order_123",
+        store_name: "Store",
+        total: inputTotal,
+      },
+      { container }
+    )) as { output: Notification[] }
+
+    expect(result.output[0]?.data?.total).toBe(expectedTotal)
+  })
 })

--- a/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
+++ b/apps/medusa-be/src/workflows/__tests__/send-order-payment-reminder.unit.spec.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest"
+
+const workflowSdkMock = vi.hoisted(() => {
+  class StepResponse<TOutput> {
+    output: TOutput
+
+    constructor(output: TOutput) {
+      this.output = output
+    }
+  }
+
+  class WorkflowResponse<TOutput> {
+    output: TOutput
+
+    constructor(output: TOutput) {
+      this.output = output
+    }
+  }
+
+  return {
+    StepResponse,
+    WorkflowResponse,
+    steps: new Map<string, (...args: unknown[]) => unknown>(),
+  }
+})
+
+vi.mock("@medusajs/framework/utils", () => {
+  class MedusaError extends Error {
+    static Types = {
+      NOT_FOUND: "not_found",
+    }
+
+    type: string
+
+    constructor(type: string, message: string) {
+      super(message)
+      this.type = type
+    }
+  }
+
+  return {
+    ContainerRegistrationKeys: {
+      LOGGER: "logger",
+      QUERY: "query",
+    },
+    MedusaError,
+  }
+})
+
+vi.mock("@medusajs/framework/workflows-sdk", () => ({
+  StepResponse: workflowSdkMock.StepResponse,
+  WorkflowResponse: workflowSdkMock.WorkflowResponse,
+  createStep: vi.fn(
+    (name: string, handler: (...args: unknown[]) => unknown) => {
+      workflowSdkMock.steps.set(name, handler)
+      return handler
+    }
+  ),
+  createWorkflow: vi.fn((_name: string, handler: unknown) => handler),
+}))
+
+vi.mock("../../modules/order-receipt", () => ({
+  ORDER_RECEIPT_MODULE: "order_receipt",
+}))
+
+vi.mock("../steps/send-notification", () => ({
+  sendNotificationStep: vi.fn(),
+}))
+
+type Notification = {
+  data?: Record<string, unknown>
+}
+
+describe("send order payment reminder workflow", () => {
+  it("uses the fetched order summary total for notification data", async () => {
+    await import("../send-order-payment-reminder")
+
+    const step = workflowSdkMock.steps.get(
+      "build-order-payment-reminder-notification"
+    )
+
+    expect(step).toBeDefined()
+
+    const graph = vi.fn().mockResolvedValue({
+      data: [
+        {
+          currency_code: "czk",
+          customer_id: "cus_123",
+          display_id: 1001,
+          id: "order_123",
+          summary: {
+            current_order_total: 1234.56,
+            original_order_total: 1999,
+          },
+          total: 1999,
+        },
+      ],
+    })
+    const generateOrderReceiptAttachment = vi.fn().mockResolvedValue({
+      content: Buffer.from("pdf"),
+      content_type: "application/pdf",
+      filename: "receipt.pdf",
+    })
+    const container = {
+      resolve: vi.fn((key: string) => {
+        if (key === "query") {
+          return { graph }
+        }
+
+        if (key === "logger") {
+          return { warn: vi.fn() }
+        }
+
+        if (key === "order_receipt") {
+          return { generateOrderReceiptAttachment }
+        }
+
+        throw new Error(`Unexpected dependency ${key}`)
+      }),
+    }
+
+    const result = (await step?.(
+      {
+        customer_id: "cus_123",
+        email: "customer@example.com",
+        order_display_id: "#1001",
+        order_id: "order_123",
+        payment_url: "https://shop.example/orders/order_123",
+        store_name: "Store",
+        total: "stale input total",
+      },
+      { container }
+    )) as { output: Notification[] }
+
+    expect(result.output[0]?.data?.total).toBe(
+      new Intl.NumberFormat("cs-CZ", {
+        currency: "CZK",
+        style: "currency",
+      }).format(1234.56)
+    )
+    expect(result.output[0]?.data?.total).not.toBe("stale input total")
+    expect(result.output[0]?.data?.total).not.toBe(1999)
+    expect(graph).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entity: "order",
+        fields: expect.arrayContaining(["summary.*", "total", "currency_code"]),
+        filters: { id: "order_123" },
+      })
+    )
+  })
+})

--- a/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
+++ b/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
@@ -153,7 +153,7 @@ const buildOrderPaymentReminderNotificationStep = createStep(
           order_id: input.order_id,
           payment_url: input.payment_url,
           store_name: input.store_name,
-          total: formatTotal(order),
+          total: formatTotal(order) ?? input.total,
         },
         receiver_id: input.customer_id,
         resource_id: input.order_id,

--- a/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
+++ b/apps/medusa-be/src/workflows/send-order-payment-reminder.ts
@@ -16,6 +16,10 @@ import {
 import { ORDER_RECEIPT_MODULE } from "../modules/order-receipt"
 import type OrderReceiptModuleService from "../modules/order-receipt/service"
 import type { OrderReceiptOrder } from "../modules/order-receipt/service"
+import {
+  formatTotal,
+  type PaymentReminderOrder,
+} from "../utils/order-payment-reminders"
 import { sendNotificationStep } from "./steps/send-notification"
 
 type WorkflowInput = {
@@ -28,9 +32,7 @@ type WorkflowInput = {
   total?: string
 }
 
-type QueryOrder = OrderReceiptOrder & {
-  customer_id?: string | null
-}
+type QueryOrder = OrderReceiptOrder & PaymentReminderOrder
 
 function isQueryOrder(value: unknown): value is QueryOrder {
   if (typeof value !== "object" || value === null) {
@@ -151,7 +153,7 @@ const buildOrderPaymentReminderNotificationStep = createStep(
           order_id: input.order_id,
           payment_url: input.payment_url,
           store_name: input.store_name,
-          total: order.total,
+          total: formatTotal(order),
         },
         receiver_id: input.customer_id,
         resource_id: input.order_id,


### PR DESCRIPTION
### Problem
Payment reminder emails could show a different total than the attached receipt. The workflow reloaded the order for the PDF, but the email payload still used raw `order.total` instead of the current payable summary total.

### What changed
The reminder notification total is formatted from the freshly fetched order using the same summary-aware total logic.

### Evidence
Added workflow coverage where raw `order.total` is stale and `summary.current_order_total` is current; notification data uses the current formatted total.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order payment reminder notifications now show the total in a consistent localised currency format, with a fallback to the original input value when needed.

* **Tests**
  * Added coverage for reminder total calculation, including different order data shapes and fallback scenarios.
  * Verified the notification payload uses the expected order details when building the reminder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->