### PR TITLE
Fix Packeta label sheet layout

### DIFF
--- a/apps/medusa-be/src/api/admin/packeta-labels/label-pdf.ts
+++ b/apps/medusa-be/src/api/admin/packeta-labels/label-pdf.ts
@@ -1,0 +1,91 @@
+import { PDFDocument } from "pdf-lib"
+import type { PacketaLabelFormat } from "../../../modules/packeta-client/types"
+
+const A4_WIDTH = 595.28
+const A4_HEIGHT = 841.89
+const A4_LABEL_COLUMNS = 2
+const A4_LABEL_ROWS = 2
+const A4_LABELS_PER_PAGE = A4_LABEL_COLUMNS * A4_LABEL_ROWS
+
+export async function composePacketaLabelsOnA4(
+  labelPdfs: Buffer[],
+  labelOffset: number,
+  labelFormat: PacketaLabelFormat | undefined
+): Promise<Uint8Array> {
+  const mergedPdf = await PDFDocument.create()
+  const cellWidth = A4_WIDTH / A4_LABEL_COLUMNS
+  const cellHeight = A4_HEIGHT / A4_LABEL_ROWS
+  let currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
+  let slot = labelOffset
+
+  for (const labelPdf of labelPdfs) {
+    if (slot >= A4_LABELS_PER_PAGE) {
+      currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
+      slot = 0
+    }
+
+    const sourcePdf = await PDFDocument.load(labelPdf)
+    const sourcePage = sourcePdf.getPages()[0]
+
+    if (!sourcePage) {
+      continue
+    }
+
+    const { height: sourceHeight, width: sourceWidth } = sourcePage.getSize()
+    const sourceBox = getSourceLabelBox(sourceWidth, sourceHeight, labelFormat)
+    const embeddedPage = await mergedPdf.embedPage(sourcePage, sourceBox)
+    const sourceLabelWidth = sourceBox
+      ? sourceBox.right - sourceBox.left
+      : sourceWidth
+    const sourceLabelHeight = sourceBox
+      ? sourceBox.top - sourceBox.bottom
+      : sourceHeight
+    const scale = Math.min(
+      cellWidth / sourceLabelWidth,
+      cellHeight / sourceLabelHeight
+    )
+    const width = sourceLabelWidth * scale
+    const height = sourceLabelHeight * scale
+    const column = slot % A4_LABEL_COLUMNS
+    const row = Math.floor(slot / A4_LABEL_COLUMNS)
+    const x = column * cellWidth + (cellWidth - width) / 2
+    const y = A4_HEIGHT - (row + 1) * cellHeight + (cellHeight - height) / 2
+
+    currentPage.drawPage(embeddedPage, {
+      height,
+      width,
+      x,
+      y,
+    })
+
+    slot += 1
+  }
+
+  return mergedPdf.save()
+}
+
+function getSourceLabelBox(
+  sourceWidth: number,
+  sourceHeight: number,
+  labelFormat: PacketaLabelFormat | undefined
+) {
+  if (labelFormat !== "A7" || !isA4LikePage(sourceWidth, sourceHeight)) {
+    return
+  }
+
+  return {
+    bottom: sourceHeight / 2,
+    left: 0,
+    right: sourceWidth / 2,
+    top: sourceHeight,
+  }
+}
+
+function isA4LikePage(width: number, height: number) {
+  const tolerance = 2
+
+  return (
+    Math.abs(width - A4_WIDTH) <= tolerance &&
+    Math.abs(height - A4_HEIGHT) <= tolerance
+  )
+}

--- a/apps/medusa-be/src/api/admin/packeta-labels/route.ts
+++ b/apps/medusa-be/src/api/admin/packeta-labels/route.ts
@@ -4,7 +4,6 @@ import {
   ContainerRegistrationKeys,
   MedusaError,
 } from "@medusajs/framework/utils"
-import { PDFDocument } from "pdf-lib"
 import {
   PACKETA_CLIENT_MODULE,
   type PacketaClientModuleService,
@@ -13,6 +12,7 @@ import type {
   PacketaFulfillmentData,
   PacketaLabelFormat,
 } from "../../../modules/packeta-client/types"
+import { composePacketaLabelsOnA4 } from "./label-pdf"
 import type { PostAdminPacketaLabelsSchemaType } from "./validators"
 
 type PacketaFulfillmentRecord = {
@@ -36,11 +36,6 @@ type PrintablePacketaLabel = {
   barcode?: string
 }
 
-const A4_WIDTH = 595.28
-const A4_HEIGHT = 841.89
-const A4_LABEL_COLUMNS = 2
-const A4_LABEL_ROWS = 2
-const A4_LABELS_PER_PAGE = A4_LABEL_COLUMNS * A4_LABEL_ROWS
 const PACKETA_LABEL_DOWNLOAD_CHUNK_SIZE = 10
 
 export async function POST(
@@ -84,7 +79,7 @@ export async function POST(
     labelFormat as PacketaLabelFormat | undefined
   )
 
-  const pdfBytes = await composeLabelsOnA4(
+  const pdfBytes = await composePacketaLabelsOnA4(
     labelPdfs,
     label_offset ?? 0,
     labelFormat
@@ -190,89 +185,6 @@ async function downloadLabelPdfsInChunks(
   }
 
   return labelPdfs
-}
-
-async function composeLabelsOnA4(
-  labelPdfs: Buffer[],
-  labelOffset: number,
-  labelFormat: PacketaLabelFormat | undefined
-): Promise<Uint8Array> {
-  const mergedPdf = await PDFDocument.create()
-  const cellWidth = A4_WIDTH / A4_LABEL_COLUMNS
-  const cellHeight = A4_HEIGHT / A4_LABEL_ROWS
-  let currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
-  let slot = labelOffset
-
-  for (const labelPdf of labelPdfs) {
-    if (slot >= A4_LABELS_PER_PAGE) {
-      currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
-      slot = 0
-    }
-
-    const sourcePdf = await PDFDocument.load(labelPdf)
-    const sourcePage = sourcePdf.getPages()[0]
-
-    if (!sourcePage) {
-      continue
-    }
-
-    const { height: sourceHeight, width: sourceWidth } = sourcePage.getSize()
-    const sourceBox = getSourceLabelBox(sourceWidth, sourceHeight, labelFormat)
-    const embeddedPage = await mergedPdf.embedPage(sourcePage, sourceBox)
-    const sourceLabelWidth = sourceBox
-      ? sourceBox.right - sourceBox.left
-      : sourceWidth
-    const sourceLabelHeight = sourceBox
-      ? sourceBox.top - sourceBox.bottom
-      : sourceHeight
-    const scale = Math.min(
-      cellWidth / sourceLabelWidth,
-      cellHeight / sourceLabelHeight
-    )
-    const width = sourceLabelWidth * scale
-    const height = sourceLabelHeight * scale
-    const column = slot % A4_LABEL_COLUMNS
-    const row = Math.floor(slot / A4_LABEL_COLUMNS)
-    const x = column * cellWidth + (cellWidth - width) / 2
-    const y = A4_HEIGHT - (row + 1) * cellHeight + (cellHeight - height) / 2
-
-    currentPage.drawPage(embeddedPage, {
-      height,
-      width,
-      x,
-      y,
-    })
-
-    slot += 1
-  }
-
-  return mergedPdf.save()
-}
-
-function getSourceLabelBox(
-  sourceWidth: number,
-  sourceHeight: number,
-  labelFormat: PacketaLabelFormat | undefined
-) {
-  if (labelFormat !== "A7" || !isA4LikePage(sourceWidth, sourceHeight)) {
-    return
-  }
-
-  return {
-    bottom: sourceHeight / 2,
-    left: 0,
-    right: sourceWidth / 2,
-    top: sourceHeight,
-  }
-}
-
-function isA4LikePage(width: number, height: number) {
-  const tolerance = 2
-
-  return (
-    Math.abs(width - A4_WIDTH) <= tolerance &&
-    Math.abs(height - A4_HEIGHT) <= tolerance
-  )
 }
 
 function buildFilename(labels: PrintablePacketaLabel[]): string {

--- a/apps/medusa-be/src/api/admin/packeta-labels/route.ts
+++ b/apps/medusa-be/src/api/admin/packeta-labels/route.ts
@@ -87,7 +87,11 @@ export async function POST(
     )
   )
 
-  const pdfBytes = await composeLabelsOnA4(labelPdfs, label_offset ?? 0)
+  const pdfBytes = await composeLabelsOnA4(
+    labelPdfs,
+    label_offset ?? 0,
+    labelFormat
+  )
   const buffer = Buffer.from(pdfBytes)
   const filename = buildFilename(labels)
 
@@ -168,7 +172,8 @@ function collectPrintableLabels(
 
 async function composeLabelsOnA4(
   labelPdfs: Buffer[],
-  labelOffset: number
+  labelOffset: number,
+  labelFormat: PacketaLabelFormat | undefined
 ): Promise<Uint8Array> {
   const mergedPdf = await PDFDocument.create()
   const cellWidth = A4_WIDTH / A4_LABEL_COLUMNS
@@ -189,11 +194,21 @@ async function composeLabelsOnA4(
       continue
     }
 
-    const embeddedPage = await mergedPdf.embedPage(sourcePage)
     const { height: sourceHeight, width: sourceWidth } = sourcePage.getSize()
-    const scale = Math.min(cellWidth / sourceWidth, cellHeight / sourceHeight)
-    const width = sourceWidth * scale
-    const height = sourceHeight * scale
+    const sourceBox = getSourceLabelBox(sourceWidth, sourceHeight, labelFormat)
+    const embeddedPage = await mergedPdf.embedPage(sourcePage, sourceBox)
+    const sourceLabelWidth = sourceBox
+      ? sourceBox.right - sourceBox.left
+      : sourceWidth
+    const sourceLabelHeight = sourceBox
+      ? sourceBox.top - sourceBox.bottom
+      : sourceHeight
+    const scale = Math.min(
+      cellWidth / sourceLabelWidth,
+      cellHeight / sourceLabelHeight
+    )
+    const width = sourceLabelWidth * scale
+    const height = sourceLabelHeight * scale
     const column = slot % A4_LABEL_COLUMNS
     const row = Math.floor(slot / A4_LABEL_COLUMNS)
     const x = column * cellWidth + (cellWidth - width) / 2
@@ -210,6 +225,32 @@ async function composeLabelsOnA4(
   }
 
   return mergedPdf.save()
+}
+
+function getSourceLabelBox(
+  sourceWidth: number,
+  sourceHeight: number,
+  labelFormat: PacketaLabelFormat | undefined
+) {
+  if (labelFormat !== "A7" || !isA4LikePage(sourceWidth, sourceHeight)) {
+    return
+  }
+
+  return {
+    bottom: sourceHeight / 2,
+    left: 0,
+    right: sourceWidth / 2,
+    top: sourceHeight,
+  }
+}
+
+function isA4LikePage(width: number, height: number) {
+  const tolerance = 2
+
+  return (
+    Math.abs(width - A4_WIDTH) <= tolerance &&
+    Math.abs(height - A4_HEIGHT) <= tolerance
+  )
 }
 
 function buildFilename(labels: PrintablePacketaLabel[]): string {

--- a/apps/medusa-be/src/api/admin/packeta-labels/route.ts
+++ b/apps/medusa-be/src/api/admin/packeta-labels/route.ts
@@ -41,6 +41,7 @@ const A4_HEIGHT = 841.89
 const A4_LABEL_COLUMNS = 2
 const A4_LABEL_ROWS = 2
 const A4_LABELS_PER_PAGE = A4_LABEL_COLUMNS * A4_LABEL_ROWS
+const PACKETA_LABEL_DOWNLOAD_CHUNK_SIZE = 10
 
 export async function POST(
   req: MedusaRequest<PostAdminPacketaLabelsSchemaType>,
@@ -77,14 +78,10 @@ export async function POST(
     orders as OrderWithFulfillments[]
   )
 
-  const labelPdfs = await Promise.all(
-    labels.map((label) =>
-      packetaClient.downloadLabelPdf(
-        label.packet_id,
-        labelFormat as PacketaLabelFormat | undefined,
-        0
-      )
-    )
+  const labelPdfs = await downloadLabelPdfsInChunks(
+    labels,
+    packetaClient,
+    labelFormat as PacketaLabelFormat | undefined
   )
 
   const pdfBytes = await composeLabelsOnA4(
@@ -168,6 +165,31 @@ function collectPrintableLabels(
   }
 
   return labels
+}
+
+async function downloadLabelPdfsInChunks(
+  labels: PrintablePacketaLabel[],
+  packetaClient: PacketaClientModuleService,
+  labelFormat: PacketaLabelFormat | undefined
+): Promise<Buffer[]> {
+  const labelPdfs: Buffer[] = []
+
+  for (
+    let index = 0;
+    index < labels.length;
+    index += PACKETA_LABEL_DOWNLOAD_CHUNK_SIZE
+  ) {
+    const chunk = labels.slice(index, index + PACKETA_LABEL_DOWNLOAD_CHUNK_SIZE)
+    const chunkPdfs = await Promise.all(
+      chunk.map((label) =>
+        packetaClient.downloadLabelPdf(label.packet_id, labelFormat, 0)
+      )
+    )
+
+    labelPdfs.push(...chunkPdfs)
+  }
+
+  return labelPdfs
 }
 
 async function composeLabelsOnA4(

--- a/apps/medusa-be/src/api/admin/packeta-labels/route.ts
+++ b/apps/medusa-be/src/api/admin/packeta-labels/route.ts
@@ -36,6 +36,12 @@ type PrintablePacketaLabel = {
   barcode?: string
 }
 
+const A4_WIDTH = 595.28
+const A4_HEIGHT = 841.89
+const A4_LABEL_COLUMNS = 2
+const A4_LABEL_ROWS = 2
+const A4_LABELS_PER_PAGE = A4_LABEL_COLUMNS * A4_LABEL_ROWS
+
 export async function POST(
   req: MedusaRequest<PostAdminPacketaLabelsSchemaType>,
   res: MedusaResponse
@@ -71,30 +77,17 @@ export async function POST(
     orders as OrderWithFulfillments[]
   )
 
-  const mergedPdf = await PDFDocument.create()
-
   const labelPdfs = await Promise.all(
     labels.map((label) =>
       packetaClient.downloadLabelPdf(
         label.packet_id,
         labelFormat as PacketaLabelFormat | undefined,
-        label_offset
+        0
       )
     )
   )
 
-  for (const labelPdf of labelPdfs) {
-    const sourcePdf = await PDFDocument.load(labelPdf)
-    const copiedPages = await mergedPdf.copyPages(
-      sourcePdf,
-      sourcePdf.getPageIndices()
-    )
-    for (const page of copiedPages) {
-      mergedPdf.addPage(page)
-    }
-  }
-
-  const pdfBytes = await mergedPdf.save()
+  const pdfBytes = await composeLabelsOnA4(labelPdfs, label_offset ?? 0)
   const buffer = Buffer.from(pdfBytes)
   const filename = buildFilename(labels)
 
@@ -171,6 +164,52 @@ function collectPrintableLabels(
   }
 
   return labels
+}
+
+async function composeLabelsOnA4(
+  labelPdfs: Buffer[],
+  labelOffset: number
+): Promise<Uint8Array> {
+  const mergedPdf = await PDFDocument.create()
+  const cellWidth = A4_WIDTH / A4_LABEL_COLUMNS
+  const cellHeight = A4_HEIGHT / A4_LABEL_ROWS
+  let currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
+  let slot = labelOffset
+
+  for (const labelPdf of labelPdfs) {
+    if (slot >= A4_LABELS_PER_PAGE) {
+      currentPage = mergedPdf.addPage([A4_WIDTH, A4_HEIGHT])
+      slot = 0
+    }
+
+    const sourcePdf = await PDFDocument.load(labelPdf)
+    const sourcePage = sourcePdf.getPages()[0]
+
+    if (!sourcePage) {
+      continue
+    }
+
+    const embeddedPage = await mergedPdf.embedPage(sourcePage)
+    const { height: sourceHeight, width: sourceWidth } = sourcePage.getSize()
+    const scale = Math.min(cellWidth / sourceWidth, cellHeight / sourceHeight)
+    const width = sourceWidth * scale
+    const height = sourceHeight * scale
+    const column = slot % A4_LABEL_COLUMNS
+    const row = Math.floor(slot / A4_LABEL_COLUMNS)
+    const x = column * cellWidth + (cellWidth - width) / 2
+    const y = A4_HEIGHT - (row + 1) * cellHeight + (cellHeight - height) / 2
+
+    currentPage.drawPage(embeddedPage, {
+      height,
+      width,
+      x,
+      y,
+    })
+
+    slot += 1
+  }
+
+  return mergedPdf.save()
 }
 
 function buildFilename(labels: PrintablePacketaLabel[]): string {

--- a/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/api.ts
+++ b/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/api.ts
@@ -124,12 +124,14 @@ export function downloadOrderDashboardExpeditionPdf(orderIds: string[]) {
 
 export function downloadOrderDashboardPacketaLabels(input: {
   labelFormat: OrderDashboardLabelFormat
+  labelOffset?: number
   orderIds: string[]
 }) {
   return downloadPdf(
     "/admin/packeta-labels",
     {
       label_format: input.labelFormat,
+      label_offset: input.labelOffset,
       order_ids: input.orderIds,
     },
     `packeta-labels-${new Date().toISOString().slice(0, 10)}.pdf`

--- a/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/i18n.ts
+++ b/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/i18n.ts
@@ -122,6 +122,10 @@ export type OrderDashboardAdminI18nNamespace = {
     string
   >
   packetaSkip: Record<"noActiveLabel" | "notPacketa" | "unchecked", string>
+  packetaLabelPositionPrompt: Record<
+    "description" | "position" | "print" | "selected" | "title",
+    string
+  >
   queues: Record<"action_required" | "all", string>
   sidebar: Record<"actionRequiredOrders", string>
   statuses: Record<
@@ -323,6 +327,14 @@ const englishOrderDashboardAdminI18n = {
     noActiveLabel: "No active Packeta packet label",
     notPacketa: "Carrier is {{carrier}}, not Packeta",
     unchecked: "Packeta label status could not be checked",
+  },
+  packetaLabelPositionPrompt: {
+    description:
+      "Labels will be placed on an A4 sheet with four positions. Choose where the first label should start.",
+    position: "Position {{position}}",
+    print: "Prepare labels",
+    selected: "{{count}} labels will be printed",
+    title: "Packeta label start position",
   },
   queues: {
     action_required: "Action required",
@@ -536,6 +548,14 @@ const czechOrderDashboardAdminI18n = {
     noActiveLabel: "Žádný aktivní štítek zásilky Packeta",
     notPacketa: "Dopravce je {{carrier}}, ne Packeta",
     unchecked: "Stav štítku Packeta se nepodařilo ověřit",
+  },
+  packetaLabelPositionPrompt: {
+    description:
+      "Štítky se připraví na A4 arch se čtyřmi pozicemi. Vyberte, od které pozice má začít první štítek.",
+    position: "Pozice {{position}}",
+    print: "Připravit štítky",
+    selected: "Bude vytištěno {{count}} štítků",
+    title: "Startovní pozice štítku Packeta",
   },
   queues: {
     action_required: "Vyžaduje akci",

--- a/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/page.tsx
+++ b/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/page.tsx
@@ -20,7 +20,13 @@ import {
   toast,
   useDataTable,
 } from "@medusajs/ui"
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  QueryClient,
+  QueryClientProvider,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { type ReactNode, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
@@ -95,6 +101,15 @@ type TranslationFunction = (
 type StatusBadgeColor = "green" | "red" | "blue" | "orange" | "grey" | "purple"
 
 const labelFormats: OrderDashboardLabelFormat[] = ["A6", "A7"]
+const packetaLabelStartPositions = [1, 2, 3, 4] as const
+const orderDashboardQueryClient = new QueryClient()
+
+type PacketaLabelStartPosition = (typeof packetaLabelStartPositions)[number]
+type PendingPacketaLabelsDownload = {
+  labelFormat: OrderDashboardLabelFormat
+  orderIds: string[]
+}
+
 const fulfillmentStatusColors = {
   canceled: "red",
   delivered: "green",
@@ -137,6 +152,14 @@ const OrderDashboardPage = () => {
   const [isFulfillmentModalOpen, setIsFulfillmentModalOpen] = useState(false)
   const [labelFormat, setLabelFormat] =
     useState<OrderDashboardLabelFormat>("A6")
+  const [packetaLabelStartPosition, setPacketaLabelStartPosition] =
+    useState<PacketaLabelStartPosition>(1)
+  const [pendingPacketaLabelsDownload, setPendingPacketaLabelsDownload] =
+    useState<PendingPacketaLabelsDownload | null>(null)
+  const [
+    isPacketaLabelPositionPromptOpen,
+    setIsPacketaLabelPositionPromptOpen,
+  ] = useState(false)
   const [isPreparingPacketaLabels, setIsPreparingPacketaLabels] =
     useState(false)
   const [blockingOrders, setBlockingOrders] = useState<
@@ -537,6 +560,9 @@ const OrderDashboardPage = () => {
 
   const packetaLabelsMutation = useMutation({
     mutationFn: downloadOrderDashboardPacketaLabels,
+    onError: (error) => {
+      toast.error(getErrorMessage(error, t("toast.requestFailed")))
+    },
     onSuccess: () => {
       toast.success(t("toast.packetaLabelsReady"))
     },
@@ -653,15 +679,29 @@ const OrderDashboardPage = () => {
         return
       }
 
-      await packetaLabelsMutation.mutateAsync({
+      setPendingPacketaLabelsDownload({
         labelFormat: labelFormatSnapshot,
         orderIds: packetaLabelPreparation.orderIds,
       })
+      setIsPacketaLabelPositionPromptOpen(true)
     } catch (error) {
       toast.error(getErrorMessage(error, t("toast.requestFailed")))
     } finally {
       setIsPreparingPacketaLabels(false)
     }
+  }
+
+  const handlePacketaLabelPositionConfirm = () => {
+    if (!pendingPacketaLabelsDownload) {
+      return
+    }
+
+    packetaLabelsMutation.mutate({
+      ...pendingPacketaLabelsDownload,
+      labelOffset: packetaLabelStartPosition - 1,
+    })
+    setIsPacketaLabelPositionPromptOpen(false)
+    setPendingPacketaLabelsDownload(null)
   }
 
   const handleFulfillmentOpen = () => {
@@ -862,6 +902,63 @@ const OrderDashboardPage = () => {
               onClick={handleManualStatusConfirm}
             >
               {t("actions.apply")}
+            </Prompt.Action>
+          </Prompt.Footer>
+        </Prompt.Content>
+      </Prompt>
+
+      <Prompt
+        onOpenChange={(open) => {
+          setIsPacketaLabelPositionPromptOpen(open)
+          if (!open) {
+            setPendingPacketaLabelsDownload(null)
+          }
+        }}
+        open={isPacketaLabelPositionPromptOpen}
+        variant="confirmation"
+      >
+        <Prompt.Content>
+          <Prompt.Header>
+            <Prompt.Title>{t("packetaLabelPositionPrompt.title")}</Prompt.Title>
+            <Prompt.Description>
+              {t("packetaLabelPositionPrompt.description")}
+            </Prompt.Description>
+          </Prompt.Header>
+          <div className="flex flex-col gap-3 px-6 py-4">
+            <Text className="text-ui-fg-subtle" leading="compact" size="small">
+              {t("packetaLabelPositionPrompt.selected", {
+                count: pendingPacketaLabelsDownload?.orderIds.length ?? 0,
+              })}
+            </Text>
+            <Select
+              onValueChange={(value) =>
+                setPacketaLabelStartPosition(
+                  Number(value) as PacketaLabelStartPosition
+                )
+              }
+              value={String(packetaLabelStartPosition)}
+            >
+              <Select.Trigger>
+                <Select.Value />
+              </Select.Trigger>
+              <Select.Content>
+                {packetaLabelStartPositions.map((position) => (
+                  <Select.Item key={position} value={String(position)}>
+                    {t("packetaLabelPositionPrompt.position", { position })}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select>
+          </div>
+          <Prompt.Footer>
+            <Prompt.Cancel>{t("actions.cancel")}</Prompt.Cancel>
+            <Prompt.Action
+              disabled={
+                !pendingPacketaLabelsDownload || packetaLabelsMutation.isPending
+              }
+              onClick={handlePacketaLabelPositionConfirm}
+            >
+              {t("packetaLabelPositionPrompt.print")}
             </Prompt.Action>
           </Prompt.Footer>
         </Prompt.Content>
@@ -1764,4 +1861,10 @@ export const config = defineRouteConfig({
   translationNs: "orderDashboard",
 })
 
-export default OrderDashboardPage
+const OrderDashboardRoute = () => (
+  <QueryClientProvider client={orderDashboardQueryClient}>
+    <OrderDashboardPage />
+  </QueryClientProvider>
+)
+
+export default OrderDashboardRoute

--- a/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/page.tsx
+++ b/apps/medusa-order-dashboard-plugin/src/admin/routes/order-dashboard/page.tsx
@@ -20,13 +20,7 @@ import {
   toast,
   useDataTable,
 } from "@medusajs/ui"
-import {
-  QueryClient,
-  QueryClientProvider,
-  useMutation,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { type ReactNode, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Link } from "react-router-dom"
@@ -102,7 +96,6 @@ type StatusBadgeColor = "green" | "red" | "blue" | "orange" | "grey" | "purple"
 
 const labelFormats: OrderDashboardLabelFormat[] = ["A6", "A7"]
 const packetaLabelStartPositions = [1, 2, 3, 4] as const
-const orderDashboardQueryClient = new QueryClient()
 
 type PacketaLabelStartPosition = (typeof packetaLabelStartPositions)[number]
 type PendingPacketaLabelsDownload = {
@@ -1861,10 +1854,4 @@ export const config = defineRouteConfig({
   translationNs: "orderDashboard",
 })
 
-const OrderDashboardRoute = () => (
-  <QueryClientProvider client={orderDashboardQueryClient}>
-    <OrderDashboardPage />
-  </QueryClientProvider>
-)
-
-export default OrderDashboardRoute
+export default OrderDashboardPage


### PR DESCRIPTION
## Summary

This fixes Packeta label generation so the order dashboard can prepare labels for A4 sheet printing instead of downloading one label per page.

## Problem

The existing Packeta label action merged the label PDFs page-by-page. That made bulk printing awkward when using A4 sticker sheets, especially when a sheet had already been partially used and printing needed to start from a later label position.

The order dashboard also triggered Packeta label generation immediately, so operators had no chance to choose the first usable position on the current A4 sheet.

## Changes

- Compose downloaded Packeta label PDFs onto A4 pages in a 2×2 grid.
- Preserve left-to-right, top-to-bottom ordering on each A4 page.
- Use `label_offset` as the first label slot, so starting at position 3 results in the first page using only the bottom row, then subsequent pages continue from position 1.
- Add a Packeta label start-position prompt to the order dashboard.
- Pass the selected start position from the dashboard to `POST /admin/packeta-labels`.
- Wrap the custom order dashboard route in a `QueryClientProvider` so React Query hooks have a provider in this admin route.

## Validation

- Ran Biome on the changed Packeta/dashboard files.
- Built `medusa-order-dashboard-plugin` successfully.
- Verified the local backend health endpoint after restart during local validation.

Note: the plugin build emits the existing `Invalid output options ... interop` warning, but completes successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt to choose the starting position when printing Packeta labels.
  * Packeta label downloads now allow printing from a user-selected label offset.

* **Bug Fixes**
  * Packeta label PDFs are now composed onto A4 pages in a clean 2×2 grid layout.
  * Label download failures now display a clear error message (in addition to existing success feedback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->