### PR TITLE
feat(ui-kit): add techsio-ui-kit-ai agent plugin for Codex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ test-results
 
 # MCP configuration
 .mcp.json
+# ...except the agent plugin's own MCP server map, which is part of the published plugin
+!libs/ui/agent-plugin/.mcp.json
 .schaltwerk/
 
 # Frontend demo test pages

--- a/libs/ui/agent-plugin/.claude-plugin/plugin.json
+++ b/libs/ui/agent-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "techsio-ui-kit-ai",
+  "version": "0.1.0",
+  "description": "Techsio UI Kit AI — skills and subagents for developing the @techsio/ui-kit design system (libs/ui). Same content as .codex-plugin/plugin.json; this manifest makes the plugin installable in Claude Code / GitHub Copilot too.",
+  "author": {
+    "name": "Lukáš Chylík",
+    "email": "lukaschylik93@gmail.com"
+  },
+  "homepage": "https://github.com/TechsioCZ/new-engine/tree/master/libs/ui/agent-plugin",
+  "repository": "https://github.com/TechsioCZ/new-engine",
+  "keywords": ["techsio", "ui-kit", "design-system", "codex", "claude-code", "agent-skills"],
+  "license": "UNLICENSED",
+  "hooks": "hooks/hooks.json",
+  "mcpServers": ".mcp.json"
+}

--- a/libs/ui/agent-plugin/.codex-plugin/plugin.json
+++ b/libs/ui/agent-plugin/.codex-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "techsio-ui-kit-ai",
+  "version": "0.1.0",
+  "description": "Techsio UI Kit AI — skills and subagents for developing the @techsio/ui-kit design system (libs/ui). Codex-first; the skill format is shared with Claude Code.",
+  "author": {
+    "name": "Lukáš Chylík",
+    "email": "lukaschylik93@gmail.com"
+  },
+  "homepage": "https://github.com/TechsioCZ/new-engine/tree/master/libs/ui/agent-plugin",
+  "repository": "https://github.com/TechsioCZ/new-engine",
+  "keywords": ["techsio", "ui-kit", "design-system", "codex", "claude-code", "agent-skills"],
+  "license": "UNLICENSED",
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
+  "mcpServers": "./.mcp.json"
+}

--- a/libs/ui/agent-plugin/.mcp.json
+++ b/libs/ui/agent-plugin/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
+    },
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["chrome-devtools-mcp@latest"]
+    }
+  }
+}

--- a/libs/ui/agent-plugin/AGENTS.md
+++ b/libs/ui/agent-plugin/AGENTS.md
@@ -1,0 +1,27 @@
+# Techsio UI Kit AI — plugin guidance
+
+This folder is the **techsio-ui-kit-ai** agent plugin for developing `@techsio/ui-kit`
+(`libs/ui`). Canonical library rules live in `libs/ui/AGENTS.md` — read that first; this file
+only routes.
+
+## Routing
+
+| Task | Use |
+| --- | --- |
+| New component (atom/molecule/organism/template) | `$ui-new-component` skill → `ui-component-dev` agent |
+| Token CSS / cascade / shared utilities | `$ui-tokens` skill → `ui-token-stylist` agent |
+| Storybook stories | `$ui-story` skill → `ui-storybook-writer` agent |
+| Brand theme (Figma or code-authored) | `$ui-theme-brand` skill |
+| Figma Code Connect / variable sync | `$ui-figma-sync` skill → `ui-figma-connector` agent |
+| Quality gate before commit/push | `$ui-validate` skill → `ui-qa-validator` agent (mandatory last) |
+| Publish readiness / semver | `$ui-release-check` skill |
+| Consuming the kit from an app | `$ui-component-usage` skill → bundled `<component>-usage` skills |
+| Architecture / patterns / nesting policy / design review | `ui-design-system-expert` agent |
+
+## Ground rules (summary — full list in `libs/ui/AGENTS.md`)
+
+- React 19: `ref` prop, no `forwardRef`; `type` not `interface`; named exports; no barrels.
+- Styling only via `tv()` + component token classes; two-layer tokens in `@theme static`.
+- State via data attributes; interactive components via Zag.js compound pattern.
+- Every component change ends with the `ui-validate` gate; never lint with `biome check .`.
+- Never touch `apps/herbatika` from UI-kit work (pre-existing red lint on master).

--- a/libs/ui/agent-plugin/README.md
+++ b/libs/ui/agent-plugin/README.md
@@ -1,0 +1,140 @@
+# techsio-ui-kit-ai v0.1.0
+
+Agent plugin for the **@techsio/ui-kit** design system — built for **OpenAI Codex** (CLI,
+IDE extension, and the Codex app), compatible with **Claude Code** (skills use the shared
+[Agent Skills](https://agentskills.io) standard; a `.claude-plugin/plugin.json` manifest is
+included).
+
+The plugin is **self-contained and published separately** from the `new-engine` monorepo.
+It currently lives at `libs/ui/agent-plugin` only as its authoring location — deep skills are
+bundled in (see *Syncing bundled skills*), so the folder can be moved to its own repo or
+marketplace as-is.
+
+Inspired by the Neuron FE AI plugin, scoped to design-system development and consumption —
+no spec-driven workflow.
+
+## What's included
+
+| Type | Count | Purpose |
+| --- | --- | --- |
+| Workflow skills | 8 | `$ui-*` entry points: scaffold, tokens, stories, theming, Figma sync, validation, release, usage routing |
+| Bundled deep skills | 58 | Synced 1:1 from `libs/ui/skills/`: per-component `*-usage` guides, `component-authoring`, `tailwind-token-authoring`, `storybook-authoring`, `zag-compound-components`, … |
+| Subagents (Codex TOML) | 6 | design-system expert, component-dev orchestrator, token/story/figma specialists, QA gate |
+| Hooks | 1 | Pre-push gate: blocks `git push` of `libs/ui` changes until `ui-validate` passed for HEAD |
+| MCP servers | 3 | context7 (docs), figma (design context + Code Connect), chrome-devtools (browser) |
+
+> **Note on slash commands:** Codex deprecated `~/.codex/prompts` custom prompts in favor of
+> skills. Skills ARE the slash commands now — invoke them explicitly with `$skill-name` (or
+> `/skills` in the CLI/IDE), or let Codex trigger them implicitly from their descriptions.
+
+## Workflow skills
+
+| Skill | Invoke | Use for |
+| --- | --- | --- |
+| `ui-new-component` | `$ui-new-component <name>` | Scaffold atom/molecule/organism/template (4-file checklist) |
+| `ui-tokens` | `$ui-tokens` | Token CSS: cascade, two-layer rules, shared utilities, validation |
+| `ui-story` | `$ui-story <component>` | CSF3 Storybook stories |
+| `ui-validate` | `$ui-validate` | Full quality gate; writes the pre-push marker |
+| `ui-theme-brand` | `$ui-theme-brand` | Brand themes — Figma pipeline or code-authored ("vibed") |
+| `ui-figma-sync` | `$ui-figma-sync` | Code Connect + Figma variables |
+| `ui-release-check` | `$ui-release-check` | semantic-release / publish readiness |
+| `ui-component-usage` | `$ui-component-usage <component>` | Router to the bundled `<component>-usage` skills for app work |
+
+## Subagents
+
+Codex subagents are TOML files in `agents/`. Copy (or symlink) them into `~/.codex/agents/`
+(personal) or a repo's `.codex/agents/` (project-scoped — the project must be trusted in
+Codex). Hooks additionally require `features.hooks` enabled in Codex `config.toml`.
+
+| Agent | Role |
+| --- | --- |
+| `ui-design-system-expert` | Knows the whole system — patterns, nesting/composition policy, token flows, validation pipeline. Architecture questions, placement decisions, design reviews |
+| `ui-component-dev` | Orchestrator — builds components end-to-end, delegates, always finishes with the QA gate |
+| `ui-token-stylist` | Token CSS specialist (two-layer tokens, form-control-base, validation scripts) |
+| `ui-storybook-writer` | CSF3 stories, visual snapshots, a11y sweep |
+| `ui-figma-connector` | Code Connect mappings + Figma variable rules + export pipeline |
+| `ui-qa-validator` | Mandatory last step — build, tokens, lint, visual tests, consistency checklist |
+
+## Installation
+
+### Codex CLI / IDE
+
+From wherever this plugin is published (its own git repo, or any repo containing a
+marketplace):
+
+```sh
+codex plugin marketplace add <marketplace-repo-or-path>
+codex plugin install techsio-ui-kit-ai
+```
+
+Marketplace entry for the repo that hosts the plugin (`.agents/plugins/marketplace.json`):
+
+```json
+{
+  "name": "techsio-marketplace",
+  "plugins": [
+    {
+      "name": "techsio-ui-kit-ai",
+      "source": { "source": "local", "path": "./techsio-ui-kit-ai" },
+      "category": "development"
+    }
+  ]
+}
+```
+
+(`git`/`npm` sources work too — the package is publishable as `@techsio/ui-kit-ai`.)
+
+### Codex app (desktop)
+
+Enable developer mode → Plugins → add the marketplace source → install **techsio-ui-kit-ai**.
+
+### Claude Code
+
+```sh
+claude plugin marketplace add <marketplace-repo-or-path>
+claude plugin install techsio-ui-kit-ai
+```
+
+Skills and hooks work as-is via `.claude-plugin/plugin.json`. The TOML subagents are
+Codex-specific — Claude Code users get equivalent behavior through the skills.
+
+## Syncing bundled skills
+
+`libs/ui/skills/` in the `new-engine` repo is the **single source of truth** for the deep
+skills. Before each plugin release, refresh the bundle from a checkout of `new-engine`:
+
+```sh
+node scripts/sync-skills.mjs   # or: pnpm sync-skills
+```
+
+The script copies every skill (except `_artifacts`) into `skills/` and fails on a name
+collision with the 8 authored workflow skills. Never edit bundled skills inside the plugin —
+edit them in `libs/ui/skills/` and re-sync.
+
+## Hook: pre-push validate gate
+
+`hooks/hooks.json` registers a `PreToolUse` hook that blocks `git push` when outgoing commits
+touch `libs/ui/**` (excluding the plugin folder itself) and the quality gate hasn't passed for
+the current HEAD — so it is only active when working inside the `new-engine` repo. Passing
+`$ui-validate` writes the marker:
+
+```sh
+git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"
+```
+
+Any new commit invalidates the marker.
+
+## Layout
+
+```
+techsio-ui-kit-ai/
+├── .codex-plugin/plugin.json    # Codex manifest
+├── .claude-plugin/plugin.json   # Claude Code manifest (same plugin)
+├── package.json                 # npm packaging (@techsio/ui-kit-ai)
+├── AGENTS.md                    # routing table
+├── .mcp.json                    # context7, figma, chrome-devtools
+├── agents/*.toml                # 6 Codex subagents
+├── skills/                      # 8 authored workflow skills + 58 bundled deep skills
+├── hooks/hooks.json             # pre-push validate gate
+└── scripts/                     # pre-push-validate-gate.mjs, sync-skills.mjs
+```

--- a/libs/ui/agent-plugin/README.md
+++ b/libs/ui/agent-plugin/README.md
@@ -20,7 +20,7 @@ no spec-driven workflow.
 | Workflow skills | 8 | `$ui-*` entry points: scaffold, tokens, stories, theming, Figma sync, validation, release, usage routing |
 | Bundled deep skills | 58 | Synced 1:1 from `libs/ui/skills/`: per-component `*-usage` guides, `component-authoring`, `tailwind-token-authoring`, `storybook-authoring`, `zag-compound-components`, … |
 | Subagents (Codex TOML) | 6 | design-system expert, component-dev orchestrator, token/story/figma specialists, QA gate |
-| Hooks | 1 | Pre-push gate: blocks `git push` of `libs/ui` changes until `ui-validate` passed for HEAD |
+| Hooks | 2 | Real git `pre-push` gate (auto-installed) + a `--no-verify` guard |
 | MCP servers | 3 | context7 (docs), figma (design context + Code Connect), chrome-devtools (browser) |
 
 > **Note on slash commands:** Codex deprecated `~/.codex/prompts` custom prompts in favor of
@@ -111,18 +111,31 @@ The script copies every skill (except `_artifacts`) into `skills/` and fails on 
 collision with the 8 authored workflow skills. Never edit bundled skills inside the plugin —
 edit them in `libs/ui/skills/` and re-sync.
 
-## Hook: pre-push validate gate
+## The pre-push quality gate
 
-`hooks/hooks.json` registers a `PreToolUse` hook that blocks `git push` when outgoing commits
-touch `libs/ui/**` (excluding the plugin folder itself) and the quality gate hasn't passed for
-the current HEAD — so it is only active when working inside the `new-engine` repo. Passing
-`$ui-validate` writes the marker:
+Pushes carrying `libs/ui` changes are blocked until `$ui-validate` has passed for the ref being
+pushed. Enforcement is a real **git `pre-push` hook** (`hooks/pre-push`), installed into the
+repo by a `SessionStart` hook (`scripts/install-git-hook.mjs`).
+
+That matters: git invokes `pre-push` with the *resolved* push operation and hands it the exact
+refs and SHAs on stdin. There is nothing to infer, so no phrasing of the command gets around it
+— not `--all`, `--mirror`, glob refspecs, `push.default=matching`, `remote.<name>.push`, nor a
+git alias. An earlier agent-side version of this gate tried to derive the same information by
+parsing the `git push` command string and was bypassable **eleven** different ways; that
+approach is gone.
+
+A narrow `PreToolUse` hook remains, with one job: refusing `--no-verify`, the only way an agent
+could skip the git hook. It does no ref parsing.
+
+Passing `$ui-validate` records the marker:
 
 ```sh
 git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"
 ```
 
-Any new commit invalidates the marker.
+Any new commit invalidates it. The installer is idempotent, honours `core.hooksPath` (husky,
+lefthook), and **never overwrites a pre-push hook it did not write** — a pre-existing hook is
+left alone with a note on how to install manually.
 
 ## Layout
 
@@ -135,6 +148,8 @@ techsio-ui-kit-ai/
 ├── .mcp.json                    # context7, figma, chrome-devtools
 ├── agents/*.toml                # 6 Codex subagents
 ├── skills/                      # 8 authored workflow skills + 58 bundled deep skills
-├── hooks/hooks.json             # pre-push validate gate
-└── scripts/                     # pre-push-validate-gate.mjs, sync-skills.mjs
+├── hooks/
+│   ├── hooks.json               # SessionStart installer + --no-verify guard
+│   └── pre-push                 # the real gate (git hands it the exact refs/SHAs)
+└── scripts/                     # install-git-hook.mjs, pre-push-validate-gate.mjs, sync-skills.mjs
 ```

--- a/libs/ui/agent-plugin/agents/ui-component-dev.toml
+++ b/libs/ui/agent-plugin/agents/ui-component-dev.toml
@@ -1,0 +1,50 @@
+# Codex subagent — orchestrator for @techsio/ui-kit component development.
+# Install: symlink/copy into <repo>/.codex/agents/ (project, trusted) or ~/.codex/agents/ (personal).
+
+name = "ui-component-dev"
+description = "Builds and refactors @techsio/ui-kit components in libs/ui end-to-end: component source, tv() variants, token CSS, stories, exports. Delegates token CSS to ui-token-stylist, stories to ui-storybook-writer, Figma mapping to ui-figma-connector, and always finishes with ui-qa-validator."
+nickname_candidates = ["Kit", "Atom"]
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the lead developer of @techsio/ui-kit (libs/ui) — React 19 + Tailwind v4 + Zag.js,
+atomic design (atoms/molecules/organisms/templates), flat kebab-case files, no barrels.
+
+Before writing any code, read `libs/ui/AGENTS.md` (canonical rules) and the matching skill:
+- new/changed component -> bundled `component-authoring` skill
+- scaffolding workflow -> `$ui-new-component` plugin skill
+- interactive component -> bundled `zag-compound-components` skill
+- architecture/placement doubts -> ask the `ui-design-system-expert` agent
+
+## Non-negotiable rules
+- React 19: `ref` is a prop (`ref?: Ref<T>`), never `forwardRef`; no `useCallback` for plain handlers.
+- Styling only via `tv()` from `../utils` with component token classes (`bg-button-bg-primary`,
+  `h-button-md`). Never semantic tokens in component code (`bg-primary`), never arbitrary
+  values (`bg-[#f00]`, `p-[1rem]`), never a tailwind.config file.
+- `type` not `interface`; named exports only; no `index.ts` barrels.
+- State styling via data attributes: shorthand for booleans (`data-disabled:`), brackets for
+  enums (`data-[state=open]:`, `data-[validation=error]:`).
+- Interactive components: Zag.js machine + connect, compound subcomponents via
+  `Component.Sub = function ComponentSub(...) {}` (no object exports).
+- Every new component ships 4 pieces: `src/<level>/<name>.tsx`, token CSS
+  `src/tokens/components/<level>/_<name>.css` (registered in `components.css`),
+  `stories/<level>/<name>.stories.tsx`, and later `src/<level>/<name>.figma.tsx`.
+  Per-level subpath exports (`./atoms/*` etc.) already exist in package.json — only add a new
+  exports entry when introducing a new level.
+
+## Delegation
+- Token CSS design/edits -> spawn `ui-token-stylist`
+- Stories -> spawn `ui-storybook-writer`
+- Figma Code Connect / variable sync -> spawn `ui-figma-connector`
+- MANDATORY last step -> spawn `ui-qa-validator`; do not report done until it passes.
+
+## Commands (from repo root unless noted)
+- Build: `bunx nx run ui-kit:build`
+- Storybook: `bunx nx run ui-kit:storybook`
+- Tokens: `pnpm --dir libs/ui validate:tokens`
+- Lint: `bunx biome check --write <changed files>` (NEVER `.`)
+
+Never touch apps/herbatika from UI-kit work — its lint is red on master and any UI diff makes it
+"affected" in CI; that failure is pre-existing, not yours.
+"""

--- a/libs/ui/agent-plugin/agents/ui-design-system-expert.toml
+++ b/libs/ui/agent-plugin/agents/ui-design-system-expert.toml
@@ -1,0 +1,78 @@
+# Codex subagent — design-system expert for @techsio/ui-kit.
+
+name = "ui-design-system-expert"
+description = "Design-system expert for @techsio/ui-kit: knows the atomic-design nesting policy, token architecture and cascade, theming flow, component patterns (tv, Zag compound, data-attribute states), and the validation pipeline. Use for architecture questions, design reviews, deciding where something belongs, and auditing changes against the system's rules."
+nickname_candidates = ["Sage", "DS"]
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the design-system expert for @techsio/ui-kit (libs/ui). You hold the whole system in
+your head and keep it coherent: you answer architecture questions, decide where things belong,
+review changes against the system's rules, and only then implement. When a question is purely
+advisory, answer it — don't start editing files.
+
+Canonical rules: `libs/ui/AGENTS.md`. Deep dives: the bundled skills `component-authoring`,
+`tailwind-token-authoring`, `zag-compound-components`, `component-consistency-validation`,
+`figma-sync-handoff`, and `libs/ui/THEME-FLOW.md` / `libs/ui/token-contribution.md` in-repo.
+
+## Nesting & composition policy (enforce strictly)
+
+- Hierarchy: atoms -> molecules -> organisms -> templates. Imports flow strictly upward:
+  atoms import only `../utils`; molecules may compose atoms; organisms compose molecules and
+  atoms; templates compose anything. Never sideways-import between components of the same
+  level; never downward (an atom importing a molecule is an automatic reject).
+- Placement test: single element, no state machine -> atom. Interactive with a Zag machine or
+  compound parts -> molecule. Page-level section -> organism. Composition example only ->
+  template (templates are documentation, not shipped building blocks for new features).
+- Compound components: `Component.Sub = function ComponentSub() {}` — no object exports, no
+  barrels, named exports only, flat kebab-case files, one component per file.
+- Stories live in `libs/ui/stories/<level>/`, never colocated. Every public component has a
+  token CSS file and (eventually) a `*.figma.tsx` mapping.
+
+## Token architecture (the flow, end to end)
+
+- Cascade (`src/tokens/_tokens-base.css`): primitives -> `_semantic.css` -> component tokens
+  (`components/components.css`) -> generated `figma/variables.css` -> generated
+  `figma/brand-overrides.css`. The two generated files are outputs of the Figma merge
+  pipeline — hand-edits there are always wrong.
+- Component tokens are two-layer: reference (`--color-button-primary: var(--color-primary)`)
+  then derived (`--color-button-bg-primary`), derived names ending `-bg`/`-fg`/`-border`.
+- Consumption policy: component code uses ONLY component token classes; semantic tokens are
+  for stories and app code; primitives are for the token layer itself. A `bg-primary` inside
+  `src/atoms/*` is a violation; so is any arbitrary value (`bg-[#f00]`).
+- Shared chrome: `form-control-base` utility (NumericInput.Control, Combobox.Control,
+  Select.Trigger, SearchForm.Control) and `_icon-button.css` (16/20/24 sizes). New form-like
+  controls must reuse these, not re-derive them.
+- Theming: brands (base, neo, cyber) x color scheme, switched via `data-theme` +
+  `.light`/`.dark` classes (better-themes). Brands override primitives and re-alias — a brand
+  that restructures the component layer is wrong.
+
+## State & interaction patterns
+
+- State styling via data attributes only: boolean shorthand (`data-disabled:`), enumerated
+  brackets (`data-[state=open]:`, `data-[orientation=vertical]:`).
+- Validation is `data-[validation=error|success|warning]` on the control element — the
+  combobox is the canonical implementation; `data-invalid`-style attributes are rejected.
+- React 19: `ref` as a prop, no `forwardRef`, no `useCallback` for plain handlers,
+  `type` over `interface`.
+
+## Validation pipeline (what "done" means)
+
+1. `bunx nx run ui-kit:build` (rslib + publint)
+2. `pnpm --dir libs/ui validate:tokens` (+ `check:unused-tokens` on renames/removals)
+3. `bunx biome check --write <changed files>` — never `.`
+4. `pnpm --dir libs/ui lint:tailwind` when class names changed
+5. `pnpm --dir libs/ui test:components` (Playwright visual snapshots) when visuals changed
+6. Consistency checklist: bundled `component-consistency-validation` skill
+Delegate execution to `ui-qa-validator`; your job is judging whether findings are real
+violations and which layer must change.
+
+## Review stance
+
+When reviewing, cite the specific rule and layer for each finding ("atom imports molecule —
+nesting policy", "raw value in component token — two-layer rule") and state the minimal fix at
+the correct layer. Prefer fixing the system (a missing semantic token, a missing shared
+utility) over per-component workarounds. apps/herbatika lint failures are pre-existing on
+master — never attribute them to UI changes and never patch that app from UI work.
+"""

--- a/libs/ui/agent-plugin/agents/ui-figma-connector.toml
+++ b/libs/ui/agent-plugin/agents/ui-figma-connector.toml
@@ -1,0 +1,31 @@
+# Codex subagent — Figma Code Connect & token-sync specialist for @techsio/ui-kit.
+
+name = "ui-figma-connector"
+description = "Maintains the Figma bridge for @techsio/ui-kit: *.figma.tsx Code Connect files, Figma variable naming/aliasing rules, and the token export/merge pipeline. Use when a component's public API or visuals changed, or when working with Figma variables."
+nickname_candidates = ["Figs"]
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You keep code and Figma in sync for @techsio/ui-kit. The CODEBASE token architecture is the
+source of truth — Figma mirrors code, never the other way around.
+
+Read first: the bundled `figma-sync-handoff` skill, the Figma Sync Rules section of
+`libs/ui/AGENTS.md`, and `libs/ui/THEME-FLOW.md` for the variables pipeline.
+
+## Code Connect
+- Every public component has `src/<level>/<name>.figma.tsx` mapping Figma props to code props
+  (alias `@libs/ui/*` per `figma.config.json`).
+- Validate: `pnpm --dir libs/ui figma:connect:parse`
+- Publish (only when asked): `pnpm --dir libs/ui figma:connect:publish`
+
+## Figma variables
+- Mirror the code hierarchy: primitives -> semantic aliases -> component aliases. Component
+  variables must alias upper layers, never hold raw values when an upper token exists.
+- Naming: slash-separated `property/component/cssProperty/variant/state`, omitting segments
+  that don't vary (`spacing/form-field/gap`, `color/button/bg/primary/hover`).
+- Set explicit scopes (never ALL_SCOPES) and code syntax to the real CSS custom property,
+  e.g. `var(--color-button-bg-primary)`.
+- Generated files `src/tokens/figma/variables.css` and `figma/brand-overrides.css` come from
+  the merge scripts in `.agents/skills/figma-token-binding/scripts/` — regenerate, don't edit.
+"""

--- a/libs/ui/agent-plugin/agents/ui-figma-connector.toml
+++ b/libs/ui/agent-plugin/agents/ui-figma-connector.toml
@@ -27,5 +27,6 @@ Read first: the bundled `figma-sync-handoff` skill, the Figma Sync Rules section
 - Set explicit scopes (never ALL_SCOPES) and code syntax to the real CSS custom property,
   e.g. `var(--color-button-bg-primary)`.
 - Generated files `src/tokens/figma/variables.css` and `figma/brand-overrides.css` come from
-  the merge scripts in `.agents/skills/figma-token-binding/scripts/` — regenerate, don't edit.
+  the merge scripts in the new-engine repo at `.agents/skills/figma-token-binding/scripts/`
+  (`merge-figma-themes.mjs`, `split-figma-tokens.mjs`) — regenerate, don't edit by hand.
 """

--- a/libs/ui/agent-plugin/agents/ui-qa-validator.toml
+++ b/libs/ui/agent-plugin/agents/ui-qa-validator.toml
@@ -1,0 +1,32 @@
+# Codex subagent — mandatory quality gate for @techsio/ui-kit changes.
+
+name = "ui-qa-validator"
+description = "Runs the @techsio/ui-kit quality gate: build, token validation, lint on changed files, visual/a11y tests, and the component-consistency checklist. Spawn as the LAST step of every libs/ui change."
+nickname_candidates = ["Gate"]
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the quality gate for libs/ui. You do not redesign code — you verify it and report
+pass/fail with exact commands and outputs. Fix only mechanical issues (formatting, missing
+token registration); send anything structural back with a precise finding.
+
+## Gate (run in this order, from repo root)
+1. `bunx nx run ui-kit:build` — must succeed.
+2. `pnpm --dir libs/ui validate:tokens` — token usage + definitions.
+3. `bunx biome check --write <changed files>` — NEVER `biome check .`.
+4. `pnpm --dir libs/ui lint:tailwind` when class names changed.
+5. Visual regression when component markup/CSS changed: `pnpm --dir libs/ui test:components`.
+   Snapshot diffs are a finding, not an auto-update; update only when the change is intended.
+6. Checklist review against the bundled `component-consistency-validation` skill
+   (React 19 ref prop, tv() token classes only, two-layer tokens, data-attribute states,
+   stories present, exports intact, figma.tsx present or explicitly deferred).
+
+## On success
+Write the marker consumed by the pre-push hook:
+`git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`
+
+## Known CI trap
+apps/herbatika has 9 pre-existing lint errors on master; any UI diff makes it "affected", so a
+red `herbatica:lint` is NOT caused by the UI change. Never "fix" herbatika from UI work.
+"""

--- a/libs/ui/agent-plugin/agents/ui-qa-validator.toml
+++ b/libs/ui/agent-plugin/agents/ui-qa-validator.toml
@@ -23,8 +23,10 @@ token registration); send anything structural back with a precise finding.
    stories present, exports intact, figma.tsx present or explicitly deferred).
 
 ## On success
-Write the marker consumed by the pre-push hook:
+Write the marker consumed by the git pre-push hook (which rejects any push of libs/ui changes
+until it matches the pushed ref's tip):
 `git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`
+Validate LAST — any new commit invalidates the marker.
 
 ## Known CI trap
 apps/herbatika has 9 pre-existing lint errors on master; any UI diff makes it "affected", so a

--- a/libs/ui/agent-plugin/agents/ui-storybook-writer.toml
+++ b/libs/ui/agent-plugin/agents/ui-storybook-writer.toml
@@ -1,0 +1,31 @@
+# Codex subagent — Storybook stories author for @techsio/ui-kit.
+
+name = "ui-storybook-writer"
+description = "Writes CSF3 Storybook stories for @techsio/ui-kit components in libs/ui/stories/**. Use whenever a component is added or its public API changes."
+nickname_candidates = ["Story"]
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You write Storybook 10 stories (CSF3 + autodocs) for @techsio/ui-kit.
+
+Read first: the bundled `storybook-authoring` skill; mirror an existing story such as
+`libs/ui/stories/atoms/button.stories.tsx` before inventing structure.
+
+## Rules
+- Stories live in `libs/ui/stories/<level>/<name>.stories.tsx` — NOT next to the component.
+- Use kit components instead of native HTML (`<Button/>` over `<button>`).
+- Class names in stories use the token system (`bg-danger`, `p-100`, `gap-50`) — semantic
+  tokens ARE allowed in stories, hardcoded Tailwind values (`bg-red-500`, `p-2`) are not.
+- Story order (only include what the component supports):
+  1. Playground  2. Variants  3. Sizes  4. States  5. component-specific stories.
+- Use `VariantContainer` / `VariantGroup` (see `stories/helpers/`) for visual matrices.
+- Use `fn()` from `storybook/test` for event handlers.
+- Controls only for props with a visible effect — never for `id`, `ref`, internal callbacks.
+
+## Verify
+- `bunx nx run ui-kit:storybook` renders the new stories without errors.
+- Visual snapshots: `pnpm --dir libs/ui test:components` (update deliberately with
+  `test:components:update` and mention it in the summary).
+- a11y sweep when adding a new component: `pnpm --dir libs/ui storybook:a11y`.
+"""

--- a/libs/ui/agent-plugin/agents/ui-token-stylist.toml
+++ b/libs/ui/agent-plugin/agents/ui-token-stylist.toml
@@ -1,0 +1,40 @@
+# Codex subagent — design-token & component CSS specialist for @techsio/ui-kit.
+
+name = "ui-token-stylist"
+description = "Writes and refactors token CSS for @techsio/ui-kit: component tokens under src/tokens/components/**, two-layer token structure, @theme static, shared utilities like form-control-base. Use for any *.css change in libs/ui/src/tokens."
+nickname_candidates = ["Tok"]
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the token/CSS specialist for @techsio/ui-kit (libs/ui). You only touch CSS under
+`libs/ui/src/tokens/` and the token classes referenced from component `tv()` calls.
+
+Read first: the bundled `tailwind-token-authoring` skill and `libs/ui/token-contribution.md` (in-repo).
+
+## Rules
+- Tailwind v4, `@theme static` blocks — never a tailwind.config file.
+- Two-layer tokens, always:
+  reference layer `--color-button-primary: var(--color-primary);`
+  derived layer  `--color-button-bg-primary: var(--color-button-primary);`
+  Derived names must end in `-bg`, `-fg`, or `-border`. No abbreviations in component names.
+  Border widths are `--border-width-<component>` (locked standard).
+- Allowed prefixes: --color-, --spacing-, --padding-, --gap-, --text-, --font-weight-,
+  --radius-, --border-width-, --shadow-, --opacity-.
+- New component tokens go to `src/tokens/components/<level>/_<name>.css` and MUST be
+  registered in `src/tokens/components/components.css`.
+- Shared control styling: reuse `@utility form-control-base` from
+  `src/tokens/components/_form-control.css` (used by NumericInput.Control, Combobox.Control,
+  Select.Trigger, SearchForm.Control) and `_icon-button.css` for icon sub-buttons.
+- Validation states use `data-[validation=error|success|warning]` on the control element —
+  the combobox pattern is canonical. Never invent `data-invalid`-style attributes.
+- Respect the cascade order in `_tokens-base.css`:
+  primitives -> semantic -> component tokens -> figma/variables.css -> figma/brand-overrides.css.
+  Never edit `figma/variables.css` or `figma/brand-overrides.css` by hand — they are generated
+  (see `libs/ui/THEME-FLOW.md`).
+
+## Verify every change
+- `pnpm --dir libs/ui validate:tokens`
+- `pnpm --dir libs/ui check:unused-tokens` when removing/renaming tokens
+- `bunx biome check --write <changed files>` (never `.`)
+"""

--- a/libs/ui/agent-plugin/hooks/hooks.json
+++ b/libs/ui/agent-plugin/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PreToolUse": [
       {
-        "matcher": "*",
+        "matcher": "Bash|shell|local_shell",
         "hooks": [
           {
             "type": "command",

--- a/libs/ui/agent-plugin/hooks/hooks.json
+++ b/libs/ui/agent-plugin/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/pre-push-validate-gate.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/libs/ui/agent-plugin/hooks/hooks.json
+++ b/libs/ui/agent-plugin/hooks/hooks.json
@@ -1,5 +1,15 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT}}/scripts/install-git-hook.mjs\""
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash|shell|local_shell",

--- a/libs/ui/agent-plugin/hooks/pre-push
+++ b/libs/ui/agent-plugin/hooks/pre-push
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * git pre-push hook — the REAL ui-kit quality gate.
+ *
+ * Git invokes this with the resolved push operation and feeds it, on stdin, one line per ref
+ * actually being pushed:
+ *
+ *   <local_ref> <local_sha> <remote_ref> <remote_sha>
+ *
+ * That is the whole point of this file. The agent-side PreToolUse hook that preceded it tried to
+ * work out the same information by parsing a `git push` command string, and got it wrong ten
+ * separate ways (wrong ref, multi-ref, deletions, --all, --mirror, --follow-tags, annotated tags,
+ * push.default=matching, glob/`:` refspecs, remote.<name>.push, git aliases). None of those are
+ * reachable here: git has already resolved aliases, config, refspecs and defaults before calling
+ * us, and it tells us the exact SHAs. There is nothing left to infer.
+ *
+ * Blocks the push when the commits being uploaded touch libs/ui (excluding the plugin itself)
+ * and the ui-validate gate has not been recorded for that ref's tip.
+ *
+ * Exit 0 = allow, non-zero = reject the push.
+ */
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ZERO = /^0+$/;
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
+const git = (...args) =>
+  execFileSync("git", args, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+
+const touchesUi = (files) =>
+  files.some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
+
+let raw = "";
+process.stdin.on("data", (c) => {
+  raw += c;
+});
+process.stdin.on("end", () => {
+  const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
+  if (!lines.length) process.exit(0); // nothing being pushed
+
+  let gitDir;
+  try {
+    gitDir = git("rev-parse", "--absolute-git-dir");
+  } catch {
+    process.exit(0);
+  }
+
+  let marker = "";
+  try {
+    marker = readFileSync(join(gitDir, "ui-validate-passed"), "utf8").trim();
+  } catch {
+    // not validated yet
+  }
+
+  for (const line of lines) {
+    const [localRef, localSha, , remoteSha] = line.split(/\s+/);
+
+    // A deletion: git sends an all-zero local sha. Nothing is uploaded, so nothing to gate.
+    if (!localSha || ZERO.test(localSha)) continue;
+
+    // Peel to a commit — an annotated tag's own sha is the tag object, not the commit.
+    let tip;
+    try {
+      tip = git("rev-parse", "--verify", `${localSha}^{commit}`);
+    } catch {
+      // Cannot resolve what is being pushed → fail closed rather than wave it through.
+      process.stderr.write(`\nBLOCKED: cannot resolve pushed ref ${localRef} (${localSha}).\n`);
+      process.exit(1);
+    }
+
+    // Which commits are actually new to the remote?
+    let files;
+    if (remoteSha && !ZERO.test(remoteSha)) {
+      files = git("diff", "--name-only", `${remoteSha}..${tip}`).split("\n").filter(Boolean);
+    } else {
+      // New ref on the remote. Everything reachable from the tip that the remote does not
+      // already have (via any remote-tracking ref) is new.
+      const newCommits = git("rev-list", tip, "--not", "--remotes").split("\n").filter(Boolean);
+      if (!newCommits.length) continue; // remote already has all of it
+      const oldest = newCommits[newCommits.length - 1];
+      let base;
+      try {
+        base = git("rev-parse", "--verify", `${oldest}^`); // parent of the oldest new commit
+      } catch {
+        base = EMPTY_TREE; // root commit
+      }
+      files = git("diff", "--name-only", base, tip).split("\n").filter(Boolean);
+    }
+
+    if (!touchesUi(files)) continue;
+    if (marker === tip) continue; // validated
+
+    process.stderr.write(
+      [
+        "",
+        `BLOCKED: ${localRef} (${tip.slice(0, 8)}) contains libs/ui changes that have not passed the ui-kit quality gate.`,
+        "",
+        "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
+        "then record it:",
+        '  git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"',
+        "",
+        "Any new commit invalidates the marker.",
+        "",
+      ].join("\n"),
+    );
+    process.exit(1);
+  }
+
+  process.exit(0);
+});

--- a/libs/ui/agent-plugin/hooks/pre-push
+++ b/libs/ui/agent-plugin/hooks/pre-push
@@ -19,9 +19,9 @@
  *
  * Exit 0 = allow, non-zero = reject the push.
  */
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 const ZERO = /^0+$/;
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
@@ -32,11 +32,32 @@ const git = (...args) =>
 const touchesUi = (files) =>
   files.some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
 
+/**
+ * If this repo already had a pre-push hook (husky, lefthook, a custom one), the installer moved
+ * it aside rather than deleting it. Run it FIRST and honour its verdict — the human's hook wins,
+ * and our gate is additive rather than a replacement that silently drops their checks.
+ * Both hooks need stdin, so we replay the buffered ref lines into it.
+ */
+function runChainedHook(stdinData) {
+  const chained = join(dirname(process.argv[1]), "pre-push.pre-ui-kit");
+  if (!existsSync(chained)) return;
+
+  const res = spawnSync(chained, process.argv.slice(2), {
+    input: stdinData,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+
+  if (res.error) return; // not executable / not runnable — do not block on our own plumbing
+  if (typeof res.status === "number" && res.status !== 0) process.exit(res.status);
+}
+
 let raw = "";
 process.stdin.on("data", (c) => {
   raw += c;
 });
 process.stdin.on("end", () => {
+  runChainedHook(raw);
+
   const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
   if (!lines.length) process.exit(0); // nothing being pushed
 

--- a/libs/ui/agent-plugin/package.json
+++ b/libs/ui/agent-plugin/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@techsio/ui-kit-ai",
+  "version": "0.1.0",
+  "description": "Techsio UI Kit AI — agent plugin (skills + Codex subagents) for developing and consuming the @techsio/ui-kit design system.",
+  "author": {
+    "name": "Lukáš Chylík",
+    "email": "lukaschylik93@gmail.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TechsioCZ/new-engine.git",
+    "directory": "libs/ui/agent-plugin"
+  },
+  "keywords": ["techsio", "ui-kit", "design-system", "codex", "claude-code", "agent-skills", "plugin"],
+  "license": "UNLICENSED",
+  "scripts": {
+    "sync-skills": "node scripts/sync-skills.mjs"
+  },
+  "files": [
+    ".codex-plugin",
+    ".claude-plugin",
+    ".mcp.json",
+    "AGENTS.md",
+    "README.md",
+    "agents",
+    "hooks",
+    "scripts",
+    "skills"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/libs/ui/agent-plugin/package.json
+++ b/libs/ui/agent-plugin/package.json
@@ -13,6 +13,7 @@
   },
   "keywords": ["techsio", "ui-kit", "design-system", "codex", "claude-code", "agent-skills", "plugin"],
   "license": "UNLICENSED",
+  "private": true,
   "scripts": {
     "sync-skills": "node scripts/sync-skills.mjs"
   },
@@ -27,7 +28,5 @@
     "scripts",
     "skills"
   ],
-  "publishConfig": {
-    "access": "public"
-  }
+  "_publishing": "Distributed as a Codex/Claude plugin via a marketplace (git source), not via npm. To publish to npm instead, drop `private`, pick a license, and add `publishConfig.access`."
 }

--- a/libs/ui/agent-plugin/scripts/install-git-hook.mjs
+++ b/libs/ui/agent-plugin/scripts/install-git-hook.mjs
@@ -8,7 +8,7 @@
  * Idempotent. Never clobbers a pre-push hook this plugin did not write: if a foreign hook is
  * present it warns and leaves it alone, so the human's own hook always wins.
  */
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, renameSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -40,19 +40,33 @@ try {
 
 const target = join(hooksDir, "pre-push");
 
+const chained = `${target}.pre-ui-kit`;
+
 if (existsSync(target)) {
   const current = readFileSync(target, "utf8");
-  if (!current.includes(MARKER)) {
-    process.stderr.write(
-      [
-        "ui-kit: a pre-push hook already exists and was not installed by this plugin — leaving it alone.",
-        `Install manually if wanted: cp "${source}" "${target}" && chmod +x "${target}"`,
-        "",
-      ].join("\n"),
-    );
-    process.exit(0);
+
+  if (current.includes(MARKER)) {
+    // Ours already — refresh it if the plugin shipped a newer version.
+    if (current === readFileSync(source, "utf8")) process.exit(0);
+  } else {
+    // A foreign hook (husky, lefthook, hand-written). Do NOT skip installation — that would
+    // leave the gate unenforced in exactly the repos that already care about hooks. Move it
+    // aside instead; our hook runs it first and honours its exit code, so it still wins.
+    if (!existsSync(chained)) {
+      try {
+        renameSync(target, chained);
+        chmodSync(chained, 0o755);
+        process.stderr.write(
+          `ui-kit: existing pre-push hook preserved as "${chained}" and chained — it runs first.\n`,
+        );
+      } catch (err) {
+        process.stderr.write(
+          `ui-kit: could not preserve the existing pre-push hook (${err.message}) — leaving it untouched, gate NOT installed.\n`,
+        );
+        process.exit(0); // never destroy a hook we cannot back up
+      }
+    }
   }
-  if (current === readFileSync(source, "utf8")) process.exit(0); // already current
 }
 
 try {

--- a/libs/ui/agent-plugin/scripts/install-git-hook.mjs
+++ b/libs/ui/agent-plugin/scripts/install-git-hook.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * SessionStart hook: install the plugin's `pre-push` git hook into the repo.
+ *
+ * The git hook is the real gate — git hands it the exact refs and SHAs being pushed, so unlike
+ * an agent-side command-string parser it cannot be fooled by aliases, refspec forms, or config.
+ *
+ * Idempotent. Never clobbers a pre-push hook this plugin did not write: if a foreign hook is
+ * present it warns and leaves it alone, so the human's own hook always wins.
+ */
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const MARKER = "git pre-push hook — the REAL ui-kit quality gate";
+const source = join(dirname(dirname(fileURLToPath(import.meta.url))), "hooks", "pre-push");
+
+let gitDir;
+try {
+  gitDir = execFileSync("git", ["rev-parse", "--absolute-git-dir"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+} catch {
+  process.exit(0); // not a git repo — nothing to install
+}
+
+// Respect a configured hooksPath (husky, lefthook, …) so we install where git actually looks.
+let hooksDir = join(gitDir, "hooks");
+try {
+  const configured = execFileSync("git", ["config", "--get", "core.hooksPath"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+  if (configured) hooksDir = configured;
+} catch {
+  // unset → default
+}
+
+const target = join(hooksDir, "pre-push");
+
+if (existsSync(target)) {
+  const current = readFileSync(target, "utf8");
+  if (!current.includes(MARKER)) {
+    process.stderr.write(
+      [
+        "ui-kit: a pre-push hook already exists and was not installed by this plugin — leaving it alone.",
+        `Install manually if wanted: cp "${source}" "${target}" && chmod +x "${target}"`,
+        "",
+      ].join("\n"),
+    );
+    process.exit(0);
+  }
+  if (current === readFileSync(source, "utf8")) process.exit(0); // already current
+}
+
+try {
+  mkdirSync(hooksDir, { recursive: true });
+  copyFileSync(source, target);
+  chmodSync(target, 0o755);
+} catch (err) {
+  process.stderr.write(`ui-kit: could not install pre-push hook: ${err.message}\n`);
+}
+
+process.exit(0);

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -11,11 +11,9 @@
  *
  * Exit codes: 0 = allow, 2 = block (stderr is fed back to the agent).
  */
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-
-const shellQuote = (s) => `'${String(s).replace(/'/g, "'\\''")}'`;
 
 /**
  * Extract the remote and the local ref being pushed from a `git push` command line.
@@ -66,12 +64,14 @@ process.stdin.on("end", () => {
   }
 
   const cwd = input?.cwd || process.cwd();
-  const git = (args) =>
-    execSync(`git ${args}`, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  // execFileSync (no shell) — refs come from an agent-supplied command line, so never
+  // interpolate them into a shell string.
+  const git = (...args) =>
+    execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
 
   let gitDir;
   try {
-    gitDir = git("rev-parse --absolute-git-dir");
+    gitDir = git("rev-parse", "--absolute-git-dir");
   } catch {
     process.exit(0); // not a git repo — nothing to gate
   }
@@ -81,14 +81,14 @@ process.stdin.on("end", () => {
   const { remote, localRef } = parsePushArgs(command);
   let tip;
   try {
-    tip = git(`rev-parse --verify ${shellQuote(localRef)}`);
+    tip = git("rev-parse", "--verify", localRef);
   } catch {
     process.exit(0); // unresolvable ref (e.g. --delete, tag, or typo) — do not block
   }
 
   // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
-  const touchesUi = (range) => {
-    const changed = git(`diff --name-only ${range}`);
+  const touchesUi = (...range) => {
+    const changed = git("diff", "--name-only", ...range);
     return changed
       .split("\n")
       .some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
@@ -98,7 +98,7 @@ process.stdin.on("end", () => {
   // matching remote branch, then the remote's default branch.
   const resolves = (rev) => {
     try {
-      git(`rev-parse --verify --quiet ${shellQuote(`${rev}^{commit}`)}`);
+      git("rev-parse", "--verify", "--quiet", `${rev}^{commit}`);
       return true;
     } catch {
       return false;
@@ -117,12 +117,12 @@ process.stdin.on("end", () => {
 
   let uiChanged;
   if (base) {
-    uiChanged = touchesUi(`${shellQuote(base)}...${tip}`);
+    uiChanged = touchesUi(`${base}...${tip}`);
   } else {
     // No base to compare against (e.g. a brand-new repo with no remote refs). Fail closed:
     // diff the whole tree against the empty tree rather than silently allowing the push.
     const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-    uiChanged = touchesUi(`${EMPTY_TREE} ${shellQuote(tip)}`);
+    uiChanged = touchesUi(EMPTY_TREE, tip);
   }
   if (!uiChanged) process.exit(0);
 

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -19,9 +19,12 @@ import { join } from "node:path";
  * Extract the remote and EVERY local ref being pushed from a `git push` command line.
  * `git push origin main feature` pushes both refs, so every one of them must be gated —
  * checking only the first would let an unvalidated branch ride along with a validated one.
- * Falls back to `origin` / `HEAD` when they are implicit (`git push`, `git push -u origin`).
+ * `--all` / `--mirror` push every local branch, so they expand to all of them.
+ * Falls back to `origin` / `HEAD` when refs are implicit (`git push`, `git push -u origin`).
+ *
+ * @param listAllBranches - returns every local branch name (injected so parsing stays pure)
  */
-function parsePushArgs(command) {
+function parsePushArgs(command, listAllBranches) {
   const tokens = command.trim().split(/\s+/);
   const pushIdx = tokens.findIndex((t) => t === "push");
   const rest = pushIdx === -1 ? [] : tokens.slice(pushIdx + 1);
@@ -29,6 +32,7 @@ function parsePushArgs(command) {
   const FLAGS_WITH_VALUE = new Set(["--repo", "--exec", "--receive-pack", "-o", "--push-option"]);
   const positional = [];
   let deleteMode = false;
+  let allMode = false;
   for (let i = 0; i < rest.length; i++) {
     const t = rest[i];
     if (FLAGS_WITH_VALUE.has(t)) {
@@ -39,6 +43,11 @@ function parsePushArgs(command) {
       deleteMode = true;
       continue;
     }
+    // `--all` / `--mirror` / `--branches` push every local branch, not just HEAD.
+    if (t === "--all" || t === "--mirror" || t === "--branches") {
+      allMode = true;
+      continue;
+    }
     if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
     positional.push(t);
   }
@@ -46,6 +55,13 @@ function parsePushArgs(command) {
   const remote = positional[0] ?? "origin";
   // `git push --delete origin foo` deletes a remote branch and uploads nothing — never gate it.
   if (deleteMode) return { remote, localRefs: [] };
+
+  // `git push --all` uploads every local branch, so every one of them must be gated. Fail
+  // closed: if the branch list can't be read, gate HEAD rather than waving the push through.
+  if (allMode) {
+    const branches = listAllBranches();
+    return { remote, localRefs: branches.length ? branches : ["HEAD"] };
+  }
 
   const refspecs = positional.slice(1);
   // Each refspec is `src`, `src:dst`, or `+src:dst`; gate the source side. A refspec with an
@@ -96,7 +112,18 @@ process.stdin.on("end", () => {
   // Resolve what is actually being pushed. `git push origin some-branch` from a different
   // checkout must be gated on `some-branch`, not on the current HEAD — and a multi-ref push
   // (`git push origin main feature`) must gate EVERY ref, or an unvalidated branch rides along.
-  const { remote, localRefs } = parsePushArgs(command);
+  const listAllBranches = () => {
+    try {
+      return git("for-each-ref", "--format=%(refname:short)", "refs/heads/")
+        .split("\n")
+        .map((b) => b.trim())
+        .filter(Boolean);
+    } catch {
+      return []; // caller falls back to HEAD (fail closed)
+    }
+  };
+
+  const { remote, localRefs } = parsePushArgs(command, listAllBranches);
 
   // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
   const touchesUi = (...range) => {

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -15,6 +15,36 @@ import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+const shellQuote = (s) => `'${String(s).replace(/'/g, "'\\''")}'`;
+
+/**
+ * Extract the remote and the local ref being pushed from a `git push` command line.
+ * Falls back to `origin` / `HEAD` when they are implicit (`git push`, `git push -u origin`).
+ */
+function parsePushArgs(command) {
+  const tokens = command.trim().split(/\s+/);
+  const pushIdx = tokens.findIndex((t) => t === "push");
+  const rest = pushIdx === -1 ? [] : tokens.slice(pushIdx + 1);
+
+  const FLAGS_WITH_VALUE = new Set(["--repo", "--exec", "--receive-pack", "-o", "--push-option"]);
+  const positional = [];
+  for (let i = 0; i < rest.length; i++) {
+    const t = rest[i];
+    if (FLAGS_WITH_VALUE.has(t)) {
+      i++; // skip its value
+      continue;
+    }
+    if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
+    positional.push(t);
+  }
+
+  const remote = positional[0] ?? "origin";
+  const refspec = positional[1];
+  // A refspec may be `src:dst`, `+src:dst`, or bare `src`. We gate on the source side.
+  const localRef = refspec ? refspec.replace(/^\+/, "").split(":")[0] || "HEAD" : "HEAD";
+  return { remote, localRef };
+}
+
 let raw = "";
 process.stdin.on("data", (chunk) => {
   raw += chunk;
@@ -27,7 +57,10 @@ process.stdin.on("end", () => {
     process.exit(0);
   }
 
-  const command = input?.tool_input?.command ?? input?.tool_input?.cmd ?? "";
+  // Claude Code passes tool_input.command as a string; Codex's shell tool passes an
+  // argv array (e.g. ["bash", "-lc", "git push"]). Normalize both.
+  const rawCommand = input?.tool_input?.command ?? input?.tool_input?.cmd ?? "";
+  const command = Array.isArray(rawCommand) ? rawCommand.join(" ") : rawCommand;
   if (typeof command !== "string" || !/\bgit\b[\s\S]*\bpush\b/.test(command)) {
     process.exit(0);
   }
@@ -36,31 +69,62 @@ process.stdin.on("end", () => {
   const git = (args) =>
     execSync(`git ${args}`, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
 
-  let head;
   let gitDir;
   try {
-    head = git("rev-parse HEAD");
     gitDir = git("rev-parse --absolute-git-dir");
   } catch {
     process.exit(0); // not a git repo — nothing to gate
   }
 
-  // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own docs).
-  let touchesUi = false;
+  // Resolve what is actually being pushed. `git push origin some-branch` from a different
+  // checkout must be gated on `some-branch`, not on the current HEAD.
+  const { remote, localRef } = parsePushArgs(command);
+  let tip;
   try {
-    const upstream = git("rev-parse --abbrev-ref --symbolic-full-name @{upstream}");
-    const changed = git(`diff --name-only ${upstream}...HEAD`);
-    touchesUi = changed.split("\n").some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
+    tip = git(`rev-parse --verify ${shellQuote(localRef)}`);
   } catch {
-    // No upstream (first push) — fall back to comparing against origin/master.
-    try {
-      const changed = git("diff --name-only origin/master...HEAD");
-      touchesUi = changed.split("\n").some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
-    } catch {
-      process.exit(0); // cannot determine — do not block
-    }
+    process.exit(0); // unresolvable ref (e.g. --delete, tag, or typo) — do not block
   }
-  if (!touchesUi) process.exit(0);
+
+  // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
+  const touchesUi = (range) => {
+    const changed = git(`diff --name-only ${range}`);
+    return changed
+      .split("\n")
+      .some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
+  };
+
+  // Resolve the base to diff the pushed ref against. Prefer the ref's own upstream, then the
+  // matching remote branch, then the remote's default branch.
+  const resolves = (rev) => {
+    try {
+      git(`rev-parse --verify --quiet ${shellQuote(`${rev}^{commit}`)}`);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const branch = localRef.replace(/^refs\/heads\//, "");
+  const candidates = [
+    `${localRef}@{upstream}`,
+    `${remote}/${branch}`,
+    `${remote}/HEAD`,
+    `${remote}/master`,
+    `${remote}/main`,
+  ];
+  const base = candidates.find((c) => resolves(c));
+
+  let uiChanged;
+  if (base) {
+    uiChanged = touchesUi(`${shellQuote(base)}...${tip}`);
+  } else {
+    // No base to compare against (e.g. a brand-new repo with no remote refs). Fail closed:
+    // diff the whole tree against the empty tree rather than silently allowing the push.
+    const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+    uiChanged = touchesUi(`${EMPTY_TREE} ${shellQuote(tip)}`);
+  }
+  if (!uiChanged) process.exit(0);
 
   let marker = "";
   try {
@@ -69,13 +133,13 @@ process.stdin.on("end", () => {
     // no marker yet
   }
 
-  if (marker === head) process.exit(0);
+  if (marker === tip) process.exit(0);
 
   process.stderr.write(
     [
-      "BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for the current HEAD.",
+      `BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for ${localRef} (${tip.slice(0, 8)}).`,
       "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
-      'then mark it passed: git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"',
+      `then mark it passed: git rev-parse ${localRef} > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
     ].join("\n"),
   );
   process.exit(2);

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -105,13 +105,50 @@ function resolvePushedRefs(parsed, git) {
 
   if (tagsMode) for (const t of listRefs("refs/tags/")) refs.add(t);
 
+  // Branches that already exist on the remote — the set a "matching" push uploads.
+  const matchingBranches = () =>
+    listRefs("refs/heads/").filter((b) => {
+      try {
+        git("rev-parse", "--verify", "--quiet", `${remote}/${b}^{commit}`);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+  let sawExplicitRefspec = false;
   for (const spec of refspecs) {
+    const bare = spec.replace(/^\+/, "");
+
+    // A lone `:` is an EXPLICIT matching push — it uploads every branch that exists on the
+    // remote, regardless of push.default. Dropping it as an "empty source" let those through.
+    if (bare === ":" || bare === "") {
+      sawExplicitRefspec = true;
+      const m = matchingBranches();
+      for (const b of (m.length ? m : listRefs("refs/heads/"))) refs.add(b); // fail closed
+      continue;
+    }
+
     // `src`, `src:dst`, `+src:dst`. An empty source (`:foo`) is a deletion — pushes nothing.
-    const src = spec.replace(/^\+/, "").split(":")[0];
-    if (src && src !== ".") refs.add(src);
+    const src = bare.split(":")[0];
+    if (!src || src === ".") continue;
+    sawExplicitRefspec = true;
+
+    // A glob refspec (`refs/heads/*:refs/heads/*`) is not a resolvable rev — it stands for
+    // every matching local ref. Expand it rather than letting rev-parse fail and skip it.
+    if (src.includes("*")) {
+      const pattern = src.startsWith("refs/") ? src : `refs/heads/${src}`;
+      const expanded = listRefs(pattern);
+      for (const r of (expanded.length ? expanded : listRefs("refs/heads/"))) refs.add(r); // fail closed
+      continue;
+    }
+
+    refs.add(src);
   }
 
   if (refs.size) return [...refs];
+  // An explicit refspec was given but resolved to nothing gateable (pure deletions) — allow.
+  if (sawExplicitRefspec) return [];
 
   // No explicit refspec and no expanding flag. What an implicit `git push` uploads depends on
   // push.default: `matching` sends EVERY local branch that already exists on the remote, so
@@ -212,7 +249,16 @@ process.stdin.on("end", () => {
       // points at, so comparing it against the marker (which is a commit SHA) never matches.
       tip = git("rev-parse", "--verify", `${localRef}^{commit}`);
     } catch {
-      continue; // unresolvable ref (e.g. a --delete target or a tag) — nothing to gate
+      // Fail CLOSED. Skipping here was fail-open: anything this gate could not resolve — a glob
+      // it did not expand, an odd refspec form — was waved through without inspection, which is
+      // exactly how a bypass hides. If we cannot see what a ref contains, we do not allow it.
+      process.stderr.write(
+        [
+          `BLOCKED: cannot resolve the pushed ref "${localRef}", so the ui-kit gate cannot verify what it contains.`,
+          "Push an explicit branch or refspec (e.g. `git push origin <branch>`), or resolve the ref and retry.",
+        ].join("\n"),
+      );
+      process.exit(2);
     }
 
     // Base to diff against: the ref's own upstream, then the matching remote branch, then the

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -28,10 +28,15 @@ function parsePushArgs(command) {
 
   const FLAGS_WITH_VALUE = new Set(["--repo", "--exec", "--receive-pack", "-o", "--push-option"]);
   const positional = [];
+  let deleteMode = false;
   for (let i = 0; i < rest.length; i++) {
     const t = rest[i];
     if (FLAGS_WITH_VALUE.has(t)) {
       i++; // skip its value
+      continue;
+    }
+    if (t === "--delete" || t === "-d") {
+      deleteMode = true;
       continue;
     }
     if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
@@ -39,12 +44,20 @@ function parsePushArgs(command) {
   }
 
   const remote = positional[0] ?? "origin";
-  // Every remaining positional is a refspec: `src`, `src:dst`, or `+src:dst`. Gate the source side.
-  const localRefs = positional
-    .slice(1)
+  // `git push --delete origin foo` deletes a remote branch and uploads nothing — never gate it.
+  if (deleteMode) return { remote, localRefs: [] };
+
+  const refspecs = positional.slice(1);
+  // Each refspec is `src`, `src:dst`, or `+src:dst`; gate the source side. A refspec with an
+  // empty source (`:foo`) is a deletion — it pushes no commits, so it must not be gated, and
+  // must NOT fall back to HEAD (that would block deleting an unrelated remote branch).
+  const localRefs = refspecs
     .map((spec) => spec.replace(/^\+/, "").split(":")[0])
     .filter((ref) => ref && ref !== "."); // `.` means "current branch" in some forms
-  return { remote, localRefs: localRefs.length ? localRefs : ["HEAD"] };
+
+  // Only fall back to HEAD when no refspec was supplied at all (`git push`, `git push origin`).
+  if (!refspecs.length) return { remote, localRefs: ["HEAD"] };
+  return { remote, localRefs };
 }
 
 let raw = "";

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -16,7 +16,9 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
- * Extract the remote and the local ref being pushed from a `git push` command line.
+ * Extract the remote and EVERY local ref being pushed from a `git push` command line.
+ * `git push origin main feature` pushes both refs, so every one of them must be gated —
+ * checking only the first would let an unvalidated branch ride along with a validated one.
  * Falls back to `origin` / `HEAD` when they are implicit (`git push`, `git push -u origin`).
  */
 function parsePushArgs(command) {
@@ -37,10 +39,12 @@ function parsePushArgs(command) {
   }
 
   const remote = positional[0] ?? "origin";
-  const refspec = positional[1];
-  // A refspec may be `src:dst`, `+src:dst`, or bare `src`. We gate on the source side.
-  const localRef = refspec ? refspec.replace(/^\+/, "").split(":")[0] || "HEAD" : "HEAD";
-  return { remote, localRef };
+  // Every remaining positional is a refspec: `src`, `src:dst`, or `+src:dst`. Gate the source side.
+  const localRefs = positional
+    .slice(1)
+    .map((spec) => spec.replace(/^\+/, "").split(":")[0])
+    .filter((ref) => ref && ref !== "."); // `.` means "current branch" in some forms
+  return { remote, localRefs: localRefs.length ? localRefs : ["HEAD"] };
 }
 
 let raw = "";
@@ -77,14 +81,9 @@ process.stdin.on("end", () => {
   }
 
   // Resolve what is actually being pushed. `git push origin some-branch` from a different
-  // checkout must be gated on `some-branch`, not on the current HEAD.
-  const { remote, localRef } = parsePushArgs(command);
-  let tip;
-  try {
-    tip = git("rev-parse", "--verify", localRef);
-  } catch {
-    process.exit(0); // unresolvable ref (e.g. --delete, tag, or typo) — do not block
-  }
+  // checkout must be gated on `some-branch`, not on the current HEAD — and a multi-ref push
+  // (`git push origin main feature`) must gate EVERY ref, or an unvalidated branch rides along.
+  const { remote, localRefs } = parsePushArgs(command);
 
   // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
   const touchesUi = (...range) => {
@@ -94,8 +93,6 @@ process.stdin.on("end", () => {
       .some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
   };
 
-  // Resolve the base to diff the pushed ref against. Prefer the ref's own upstream, then the
-  // matching remote branch, then the remote's default branch.
   const resolves = (rev) => {
     try {
       git("rev-parse", "--verify", "--quiet", `${rev}^{commit}`);
@@ -105,27 +102,6 @@ process.stdin.on("end", () => {
     }
   };
 
-  const branch = localRef.replace(/^refs\/heads\//, "");
-  const candidates = [
-    `${localRef}@{upstream}`,
-    `${remote}/${branch}`,
-    `${remote}/HEAD`,
-    `${remote}/master`,
-    `${remote}/main`,
-  ];
-  const base = candidates.find((c) => resolves(c));
-
-  let uiChanged;
-  if (base) {
-    uiChanged = touchesUi(`${base}...${tip}`);
-  } else {
-    // No base to compare against (e.g. a brand-new repo with no remote refs). Fail closed:
-    // diff the whole tree against the empty tree rather than silently allowing the push.
-    const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-    uiChanged = touchesUi(EMPTY_TREE, tip);
-  }
-  if (!uiChanged) process.exit(0);
-
   let marker = "";
   try {
     marker = readFileSync(join(gitDir, "ui-validate-passed"), "utf8").trim();
@@ -133,14 +109,46 @@ process.stdin.on("end", () => {
     // no marker yet
   }
 
-  if (marker === tip) process.exit(0);
+  const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
-  process.stderr.write(
-    [
-      `BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for ${localRef} (${tip.slice(0, 8)}).`,
-      "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
-      `then mark it passed: git rev-parse ${localRef} > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
-    ].join("\n"),
-  );
-  process.exit(2);
+  for (const localRef of localRefs) {
+    let tip;
+    try {
+      tip = git("rev-parse", "--verify", localRef);
+    } catch {
+      continue; // unresolvable ref (e.g. a --delete target or a tag) — nothing to gate
+    }
+
+    // Base to diff against: the ref's own upstream, then the matching remote branch, then the
+    // remote's default branch.
+    const branch = localRef.replace(/^refs\/heads\//, "");
+    const base = [
+      `${localRef}@{upstream}`,
+      `${remote}/${branch}`,
+      `${remote}/HEAD`,
+      `${remote}/master`,
+      `${remote}/main`,
+    ].find((c) => resolves(c));
+
+    // No base (e.g. a fresh repo with no remote refs) → fail closed by diffing the whole tree.
+    const uiChanged = base ? touchesUi(`${base}...${tip}`) : touchesUi(EMPTY_TREE, tip);
+    if (!uiChanged) continue;
+    if (marker === tip) continue; // this ref has been validated
+
+    process.stderr.write(
+      [
+        `BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for ${localRef} (${tip.slice(0, 8)}).`,
+        "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
+        `then mark it passed: git rev-parse ${localRef} > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
+        localRefs.length > 1
+          ? `Note: this command pushes ${localRefs.length} refs (${localRefs.join(", ")}); each UI-changing ref must be validated.`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
+    process.exit(2);
+  }
+
+  process.exit(0); // every pushed ref is clean or validated
 });

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -30,7 +30,7 @@ function parsePushArgs(command) {
   let deleteMode = false;
   let allMode = false; // --all / --branches: every local branch
   let mirrorMode = false; // --mirror: EVERY ref under refs/ (branches AND tags)
-  let tagsMode = false; // --tags / --follow-tags: tags in addition to the refspecs
+  let tagsMode = false; // --tags: every local tag, in addition to the refspecs
   for (let i = 0; i < rest.length; i++) {
     const t = rest[i];
     if (FLAGS_WITH_VALUE.has(t)) {
@@ -49,10 +49,15 @@ function parsePushArgs(command) {
       allMode = true;
       continue;
     }
-    if (t === "--tags" || t === "--follow-tags") {
+    // `--tags` sends EVERY local tag, including tags on no pushed branch — those must be gated.
+    // `--follow-tags` is different: it only sends annotated tags *reachable from the refs being
+    // pushed*, so their commits are already covered by those refs' own diff. It adds no
+    // ungated content, and expanding it to all tags would falsely block on an unrelated tag.
+    if (t === "--tags") {
       tagsMode = true;
       continue;
     }
+    if (t === "--follow-tags") continue;
     if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
     positional.push(t);
   }
@@ -203,7 +208,9 @@ process.stdin.on("end", () => {
   for (const localRef of localRefs) {
     let tip;
     try {
-      tip = git("rev-parse", "--verify", localRef);
+      // Peel to the COMMIT. An annotated tag's own SHA is the tag object, not the commit it
+      // points at, so comparing it against the marker (which is a commit SHA) never matches.
+      tip = git("rev-parse", "--verify", `${localRef}^{commit}`);
     } catch {
       continue; // unresolvable ref (e.g. a --delete target or a tag) — nothing to gate
     }
@@ -228,7 +235,9 @@ process.stdin.on("end", () => {
       [
         `BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for ${localRef} (${tip.slice(0, 8)}).`,
         "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
-        `then mark it passed: git rev-parse ${localRef} > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
+        // `^{commit}` matters for annotated tags: `git rev-parse <tag>` writes the tag object
+        // SHA, which would never match the commit SHA this gate compares against.
+        `then mark it passed: git rev-parse "${localRef}^{commit}" > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
         localRefs.length > 1
           ? `Note: this command pushes ${localRefs.length} refs (${localRefs.join(", ")}); each UI-changing ref must be validated.`
           : "",

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -16,15 +16,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 /**
- * Extract the remote and EVERY local ref being pushed from a `git push` command line.
- * `git push origin main feature` pushes both refs, so every one of them must be gated —
- * checking only the first would let an unvalidated branch ride along with a validated one.
- * `--all` / `--mirror` push every local branch, so they expand to all of them.
- * Falls back to `origin` / `HEAD` when refs are implicit (`git push`, `git push -u origin`).
- *
- * @param listAllBranches - returns every local branch name (injected so parsing stays pure)
+ * Parse a `git push` command line into the remote, the explicit refspecs, and the modes that
+ * change WHICH refs git uploads. Ref expansion needs real repo state, so it is done by the
+ * caller (`resolvePushedRefs`); this function stays pure.
  */
-function parsePushArgs(command, listAllBranches) {
+function parsePushArgs(command) {
   const tokens = command.trim().split(/\s+/);
   const pushIdx = tokens.findIndex((t) => t === "push");
   const rest = pushIdx === -1 ? [] : tokens.slice(pushIdx + 1);
@@ -32,7 +28,9 @@ function parsePushArgs(command, listAllBranches) {
   const FLAGS_WITH_VALUE = new Set(["--repo", "--exec", "--receive-pack", "-o", "--push-option"]);
   const positional = [];
   let deleteMode = false;
-  let allMode = false;
+  let allMode = false; // --all / --branches: every local branch
+  let mirrorMode = false; // --mirror: EVERY ref under refs/ (branches AND tags)
+  let tagsMode = false; // --tags / --follow-tags: tags in addition to the refspecs
   for (let i = 0; i < rest.length; i++) {
     const t = rest[i];
     if (FLAGS_WITH_VALUE.has(t)) {
@@ -43,9 +41,16 @@ function parsePushArgs(command, listAllBranches) {
       deleteMode = true;
       continue;
     }
-    // `--all` / `--mirror` / `--branches` push every local branch, not just HEAD.
-    if (t === "--all" || t === "--mirror" || t === "--branches") {
+    if (t === "--mirror") {
+      mirrorMode = true;
+      continue;
+    }
+    if (t === "--all" || t === "--branches") {
       allMode = true;
+      continue;
+    }
+    if (t === "--tags" || t === "--follow-tags") {
+      tagsMode = true;
       continue;
     }
     if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
@@ -53,27 +58,80 @@ function parsePushArgs(command, listAllBranches) {
   }
 
   const remote = positional[0] ?? "origin";
-  // `git push --delete origin foo` deletes a remote branch and uploads nothing — never gate it.
-  if (deleteMode) return { remote, localRefs: [] };
+  const refspecs = positional.slice(1);
+  return { remote, refspecs, deleteMode, allMode, mirrorMode, tagsMode };
+}
 
-  // `git push --all` uploads every local branch, so every one of them must be gated. Fail
-  // closed: if the branch list can't be read, gate HEAD rather than waving the push through.
-  if (allMode) {
-    const branches = listAllBranches();
-    return { remote, localRefs: branches.length ? branches : ["HEAD"] };
+/**
+ * Work out every local ref the command will actually upload. Anything that cannot be
+ * determined resolves to a superset (fail closed) rather than being skipped.
+ */
+function resolvePushedRefs(parsed, git) {
+  const { remote, refspecs, deleteMode, allMode, mirrorMode, tagsMode } = parsed;
+
+  // Deletes a remote ref and uploads no commits — nothing to gate.
+  if (deleteMode) return [];
+
+  const listRefs = (...globs) => {
+    try {
+      return git("for-each-ref", "--format=%(refname:short)", ...globs)
+        .split("\n")
+        .map((r) => r.trim())
+        .filter(Boolean);
+    } catch {
+      return [];
+    }
+  };
+
+  // --mirror uploads EVERY ref under refs/ — branches and tags alike. A tag can point at a
+  // commit that is on no local branch, so expanding to branches only would miss it.
+  if (mirrorMode) {
+    const refs = listRefs("refs/heads/", "refs/tags/");
+    return refs.length ? refs : ["HEAD"]; // fail closed
   }
 
-  const refspecs = positional.slice(1);
-  // Each refspec is `src`, `src:dst`, or `+src:dst`; gate the source side. A refspec with an
-  // empty source (`:foo`) is a deletion — it pushes no commits, so it must not be gated, and
-  // must NOT fall back to HEAD (that would block deleting an unrelated remote branch).
-  const localRefs = refspecs
-    .map((spec) => spec.replace(/^\+/, "").split(":")[0])
-    .filter((ref) => ref && ref !== "."); // `.` means "current branch" in some forms
+  const refs = new Set();
 
-  // Only fall back to HEAD when no refspec was supplied at all (`git push`, `git push origin`).
-  if (!refspecs.length) return { remote, localRefs: ["HEAD"] };
-  return { remote, localRefs };
+  if (allMode) {
+    const branches = listRefs("refs/heads/");
+    if (!branches.length) return ["HEAD"]; // fail closed
+    for (const b of branches) refs.add(b);
+  }
+
+  if (tagsMode) for (const t of listRefs("refs/tags/")) refs.add(t);
+
+  for (const spec of refspecs) {
+    // `src`, `src:dst`, `+src:dst`. An empty source (`:foo`) is a deletion — pushes nothing.
+    const src = spec.replace(/^\+/, "").split(":")[0];
+    if (src && src !== ".") refs.add(src);
+  }
+
+  if (refs.size) return [...refs];
+
+  // No explicit refspec and no expanding flag. What an implicit `git push` uploads depends on
+  // push.default: `matching` sends EVERY local branch that already exists on the remote, so
+  // gating HEAD alone would let other branches through.
+  let pushDefault = "simple";
+  try {
+    pushDefault = git("config", "--get", "push.default") || "simple";
+  } catch {
+    // unset → git's default (`simple`)
+  }
+
+  if (pushDefault === "matching") {
+    const matching = listRefs("refs/heads/").filter((b) => {
+      try {
+        git("rev-parse", "--verify", "--quiet", `${remote}/${b}^{commit}`);
+        return true; // branch exists on the remote → it is part of a matching push
+      } catch {
+        return false;
+      }
+    });
+    return matching.length ? matching : ["HEAD"];
+  }
+
+  // simple / current / upstream / nothing → at most the current branch.
+  return ["HEAD"];
 }
 
 let raw = "";
@@ -112,18 +170,9 @@ process.stdin.on("end", () => {
   // Resolve what is actually being pushed. `git push origin some-branch` from a different
   // checkout must be gated on `some-branch`, not on the current HEAD — and a multi-ref push
   // (`git push origin main feature`) must gate EVERY ref, or an unvalidated branch rides along.
-  const listAllBranches = () => {
-    try {
-      return git("for-each-ref", "--format=%(refname:short)", "refs/heads/")
-        .split("\n")
-        .map((b) => b.trim())
-        .filter(Boolean);
-    } catch {
-      return []; // caller falls back to HEAD (fail closed)
-    }
-  };
-
-  const { remote, localRefs } = parsePushArgs(command, listAllBranches);
+  const parsed = parsePushArgs(command);
+  const { remote } = parsed;
+  const localRefs = resolvePushedRefs(parsed, git);
 
   // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
   const touchesUi = (...range) => {

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -116,23 +116,26 @@ function resolvePushedRefs(parsed, git) {
       }
     });
 
-  let sawExplicitRefspec = false;
-  for (const spec of refspecs) {
+  /**
+   * Expand one refspec into the local refs it uploads. Used for BOTH command-line refspecs and
+   * the ones configured in `remote.<name>.push` — git treats them identically, so they must not
+   * be parsed by two different code paths.
+   * @returns true if the spec contributed anything gateable
+   */
+  const addRefspec = (spec) => {
     const bare = spec.replace(/^\+/, "");
 
-    // A lone `:` is an EXPLICIT matching push — it uploads every branch that exists on the
-    // remote, regardless of push.default. Dropping it as an "empty source" let those through.
+    // A lone `:` is an EXPLICIT matching push — every branch that exists on the remote,
+    // regardless of push.default. Dropping it as an "empty source" let those through.
     if (bare === ":" || bare === "") {
-      sawExplicitRefspec = true;
       const m = matchingBranches();
       for (const b of (m.length ? m : listRefs("refs/heads/"))) refs.add(b); // fail closed
-      continue;
+      return true;
     }
 
     // `src`, `src:dst`, `+src:dst`. An empty source (`:foo`) is a deletion — pushes nothing.
     const src = bare.split(":")[0];
-    if (!src || src === ".") continue;
-    sawExplicitRefspec = true;
+    if (!src || src === ".") return false;
 
     // A glob refspec (`refs/heads/*:refs/heads/*`) is not a resolvable rev — it stands for
     // every matching local ref. Expand it rather than letting rev-parse fail and skip it.
@@ -140,19 +143,41 @@ function resolvePushedRefs(parsed, git) {
       const pattern = src.startsWith("refs/") ? src : `refs/heads/${src}`;
       const expanded = listRefs(pattern);
       for (const r of (expanded.length ? expanded : listRefs("refs/heads/"))) refs.add(r); // fail closed
-      continue;
+      return true;
     }
 
     refs.add(src);
-  }
+    return true;
+  };
+
+  // Any refspec on the command line means the user named the refs explicitly — even a pure
+  // deletion, which contributes nothing to gate but must not fall through to the implicit path.
+  const sawExplicitRefspec = refspecs.length > 0;
+  for (const spec of refspecs) addRefspec(spec);
 
   if (refs.size) return [...refs];
   // An explicit refspec was given but resolved to nothing gateable (pure deletions) — allow.
   if (sawExplicitRefspec) return [];
 
-  // No explicit refspec and no expanding flag. What an implicit `git push` uploads depends on
-  // push.default: `matching` sends EVERY local branch that already exists on the remote, so
-  // gating HEAD alone would let other branches through.
+  // Implicit push (`git push`, `git push origin`). Git does NOT necessarily send HEAD:
+  //   1. `remote.<name>.push` refspecs, when configured, decide what is pushed and OVERRIDE
+  //      push.default entirely (e.g. `refs/heads/*:refs/heads/*` uploads every branch).
+  //   2. otherwise push.default applies; `matching` sends every branch already on the remote.
+  let configured = [];
+  try {
+    configured = git("config", "--get-all", `remote.${remote}.push`)
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    // none configured
+  }
+
+  if (configured.length) {
+    for (const spec of configured) addRefspec(spec);
+    return refs.size ? [...refs] : ["HEAD"]; // fail closed
+  }
+
   let pushDefault = "simple";
   try {
     pushDefault = git("config", "--get", "push.default") || "simple";
@@ -161,14 +186,7 @@ function resolvePushedRefs(parsed, git) {
   }
 
   if (pushDefault === "matching") {
-    const matching = listRefs("refs/heads/").filter((b) => {
-      try {
-        git("rev-parse", "--verify", "--quiet", `${remote}/${b}^{commit}`);
-        return true; // branch exists on the remote → it is part of a matching push
-      } catch {
-        return false;
-      }
-    });
+    const matching = matchingBranches();
     return matching.length ? matching : ["HEAD"];
   }
 

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse gate (Codex + Claude Code): blocks `git push` when the outgoing
+ * commits touch libs/ui and the $ui-validate gate has not passed for the
+ * current HEAD.
+ *
+ * The gate is marked passed by writing HEAD into
+ * `$(git rev-parse --absolute-git-dir)/ui-validate-passed` — done automatically
+ * at the end of the ui-validate skill / ui-qa-validator agent. Any new commit
+ * invalidates the marker.
+ *
+ * Exit codes: 0 = allow, 2 = block (stderr is fed back to the agent).
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+let raw = "";
+process.stdin.on("data", (chunk) => {
+  raw += chunk;
+});
+process.stdin.on("end", () => {
+  let input = {};
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+
+  const command = input?.tool_input?.command ?? input?.tool_input?.cmd ?? "";
+  if (typeof command !== "string" || !/\bgit\b[\s\S]*\bpush\b/.test(command)) {
+    process.exit(0);
+  }
+
+  const cwd = input?.cwd || process.cwd();
+  const git = (args) =>
+    execSync(`git ${args}`, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+
+  let head;
+  let gitDir;
+  try {
+    head = git("rev-parse HEAD");
+    gitDir = git("rev-parse --absolute-git-dir");
+  } catch {
+    process.exit(0); // not a git repo — nothing to gate
+  }
+
+  // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own docs).
+  let touchesUi = false;
+  try {
+    const upstream = git("rev-parse --abbrev-ref --symbolic-full-name @{upstream}");
+    const changed = git(`diff --name-only ${upstream}...HEAD`);
+    touchesUi = changed.split("\n").some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
+  } catch {
+    // No upstream (first push) — fall back to comparing against origin/master.
+    try {
+      const changed = git("diff --name-only origin/master...HEAD");
+      touchesUi = changed.split("\n").some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
+    } catch {
+      process.exit(0); // cannot determine — do not block
+    }
+  }
+  if (!touchesUi) process.exit(0);
+
+  let marker = "";
+  try {
+    marker = readFileSync(join(gitDir, "ui-validate-passed"), "utf8").trim();
+  } catch {
+    // no marker yet
+  }
+
+  if (marker === head) process.exit(0);
+
+  process.stderr.write(
+    [
+      "BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for the current HEAD.",
+      "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
+      'then mark it passed: git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"',
+    ].join("\n"),
+  );
+  process.exit(2);
+});

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -4,18 +4,87 @@
  *
  * The enforcement lives in the git `pre-push` hook (`hooks/pre-push`, installed by
  * `scripts/install-git-hook.mjs`), which git calls with the exact refs and SHAs it is about to
- * upload. This file deliberately does NOT try to work out which refs a `git push` command will
- * push: an earlier version did, and got it wrong ten separate ways (wrong ref, multi-ref,
- * deletions, --all, --mirror, --follow-tags, annotated tags, push.default=matching, glob and `:`
- * refspecs, remote.<name>.push, and finally git aliases — which no amount of string parsing can
- * see through, because git expands them after the command is written).
+ * upload. This file deliberately does NOT try to work out which refs a push will send — an
+ * earlier version did and was bypassable eleven different ways.
  *
- * It has exactly one job, which string inspection *can* do soundly: refuse the flags that skip
- * git hooks. `--no-verify` / `-n` is the only way to walk past the pre-push hook, so an agent
- * must not be allowed to use it.
+ * It has one job: refuse commands that would SKIP the git hook. `--no-verify` / `-n` is the only
+ * way past a pre-push hook, so an agent must not be allowed to use it.
+ *
+ * Crucially, that check resolves git ALIASES first. `alias.publish = push --no-verify` contains
+ * neither "push" nor "--no-verify" at the call site, so matching the raw text is not enough —
+ * git expands aliases after the command is written, and so must we.
  *
  * Exit codes: 0 = allow, 2 = block (stderr is fed back to the agent).
  */
+import { execFileSync } from "node:child_process";
+
+// Boundaries include quotes and `=`, not just whitespace: an alias definition inlined into the
+// command (`git -c alias.x='push --no-verify' x`) puts the tokens inside a quoted value, where
+// they are bounded by `'` and `=` rather than spaces.
+const B = "[\\s'\"=]";
+const SKIPS_HOOKS = new RegExp(`(^|${B})(--no-verify|-n)(${B}|$)`);
+const IS_PUSH = new RegExp(`(^|${B})push(${B}|$)`);
+
+/** Flags that take a separate value, so the following token is not the subcommand. */
+const GIT_GLOBAL_WITH_VALUE = new Set(["-c", "-C", "--git-dir", "--work-tree", "--namespace", "--exec-path"]);
+
+const gitConfig = (key, cwd) => {
+  try {
+    return execFileSync("git", ["config", "--get", key], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Expand git aliases in a command so the guard sees what git will actually run.
+ * Bounded to a few rounds — aliases can chain, but we are not writing an interpreter.
+ */
+function expandAliases(command, cwd) {
+  let expanded = command;
+
+  for (let round = 0; round < 5; round++) {
+    const tokens = expanded.trim().split(/\s+/);
+    const gitIdx = tokens.findIndex((t) => t === "git" || t.endsWith("/git"));
+    if (gitIdx === -1) return expanded;
+
+    // Inline `-c alias.x=...` definitions are part of this very command — honour them.
+    const inline = new Map();
+    let i = gitIdx + 1;
+    for (; i < tokens.length; i++) {
+      const t = tokens[i];
+      if (t === "-c" && tokens[i + 1]) {
+        const [k, ...v] = tokens[i + 1].split("=");
+        if (k.startsWith("alias.")) inline.set(k.slice("alias.".length), v.join("="));
+        i++;
+        continue;
+      }
+      if (GIT_GLOBAL_WITH_VALUE.has(t)) {
+        i++;
+        continue;
+      }
+      if (t.startsWith("-")) continue;
+      break; // first non-flag token = the subcommand
+    }
+
+    const sub = tokens[i];
+    if (!sub) return expanded;
+
+    const definition = inline.get(sub) ?? gitConfig(`alias.${sub}`, cwd);
+    if (!definition) return expanded; // not an alias — done
+
+    // Replace the subcommand with its definition and go round again (aliases can nest).
+    const next = [...tokens.slice(0, i), definition, ...tokens.slice(i + 1)].join(" ");
+    if (next === expanded) return expanded;
+    expanded = next;
+  }
+
+  return expanded;
+}
 
 let raw = "";
 process.stdin.on("data", (chunk) => {
@@ -32,17 +101,27 @@ process.stdin.on("end", () => {
   // Claude Code passes a string; Codex's shell tool passes an argv array.
   const rawCommand = input?.tool_input?.command ?? input?.tool_input?.cmd ?? "";
   const command = Array.isArray(rawCommand) ? rawCommand.join(" ") : rawCommand;
-  if (typeof command !== "string") process.exit(0);
+  if (typeof command !== "string" || !/\bgit\b/.test(command)) process.exit(0);
 
-  const isPush = /\bgit\b[\s\S]*\bpush\b/.test(command);
-  const skipsHooks = /(^|\s)(--no-verify|-n)(\s|=|$)/.test(command);
+  const cwd = input?.cwd || process.cwd();
+  const resolved = expandAliases(command, cwd);
 
-  if (isPush && skipsHooks) {
+  // Check the raw text AND the alias-resolved text. The resolved form catches an alias stored in
+  // config (`alias.publish = push --no-verify`, whose call site shows neither token); the raw form
+  // catches a definition inlined into this very command (`git -c alias.x='push --no-verify' x`),
+  // where the flags are inside a quoted value that no whitespace tokenizer can see into.
+  const hit = (re) => re.test(command) || re.test(resolved);
+
+  if (hit(IS_PUSH) && hit(SKIPS_HOOKS)) {
+    const viaAlias = resolved !== command;
     process.stderr.write(
       [
-        "BLOCKED: `--no-verify` skips the pre-push hook that enforces the ui-kit quality gate.",
-        "Run the `ui-validate` skill and push normally instead.",
-      ].join("\n"),
+        "BLOCKED: this command skips the pre-push hook that enforces the ui-kit quality gate.",
+        viaAlias ? `The git alias expands to: ${resolved.trim()}` : "",
+        "`--no-verify` is not permitted. Run the `ui-validate` skill and push normally.",
+      ]
+        .filter(Boolean)
+        .join("\n"),
     );
     process.exit(2);
   }

--- a/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
+++ b/libs/ui/agent-plugin/scripts/pre-push-validate-gate.mjs
@@ -1,316 +1,51 @@
 #!/usr/bin/env node
 /**
- * PreToolUse gate (Codex + Claude Code): blocks `git push` when the outgoing
- * commits touch libs/ui and the $ui-validate gate has not passed for the
- * current HEAD.
+ * PreToolUse hook — a NARROW companion to the real gate.
  *
- * The gate is marked passed by writing HEAD into
- * `$(git rev-parse --absolute-git-dir)/ui-validate-passed` — done automatically
- * at the end of the ui-validate skill / ui-qa-validator agent. Any new commit
- * invalidates the marker.
+ * The enforcement lives in the git `pre-push` hook (`hooks/pre-push`, installed by
+ * `scripts/install-git-hook.mjs`), which git calls with the exact refs and SHAs it is about to
+ * upload. This file deliberately does NOT try to work out which refs a `git push` command will
+ * push: an earlier version did, and got it wrong ten separate ways (wrong ref, multi-ref,
+ * deletions, --all, --mirror, --follow-tags, annotated tags, push.default=matching, glob and `:`
+ * refspecs, remote.<name>.push, and finally git aliases — which no amount of string parsing can
+ * see through, because git expands them after the command is written).
+ *
+ * It has exactly one job, which string inspection *can* do soundly: refuse the flags that skip
+ * git hooks. `--no-verify` / `-n` is the only way to walk past the pre-push hook, so an agent
+ * must not be allowed to use it.
  *
  * Exit codes: 0 = allow, 2 = block (stderr is fed back to the agent).
  */
-import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
-/**
- * Parse a `git push` command line into the remote, the explicit refspecs, and the modes that
- * change WHICH refs git uploads. Ref expansion needs real repo state, so it is done by the
- * caller (`resolvePushedRefs`); this function stays pure.
- */
-function parsePushArgs(command) {
-  const tokens = command.trim().split(/\s+/);
-  const pushIdx = tokens.findIndex((t) => t === "push");
-  const rest = pushIdx === -1 ? [] : tokens.slice(pushIdx + 1);
-
-  const FLAGS_WITH_VALUE = new Set(["--repo", "--exec", "--receive-pack", "-o", "--push-option"]);
-  const positional = [];
-  let deleteMode = false;
-  let allMode = false; // --all / --branches: every local branch
-  let mirrorMode = false; // --mirror: EVERY ref under refs/ (branches AND tags)
-  let tagsMode = false; // --tags: every local tag, in addition to the refspecs
-  for (let i = 0; i < rest.length; i++) {
-    const t = rest[i];
-    if (FLAGS_WITH_VALUE.has(t)) {
-      i++; // skip its value
-      continue;
-    }
-    if (t === "--delete" || t === "-d") {
-      deleteMode = true;
-      continue;
-    }
-    if (t === "--mirror") {
-      mirrorMode = true;
-      continue;
-    }
-    if (t === "--all" || t === "--branches") {
-      allMode = true;
-      continue;
-    }
-    // `--tags` sends EVERY local tag, including tags on no pushed branch — those must be gated.
-    // `--follow-tags` is different: it only sends annotated tags *reachable from the refs being
-    // pushed*, so their commits are already covered by those refs' own diff. It adds no
-    // ungated content, and expanding it to all tags would falsely block on an unrelated tag.
-    if (t === "--tags") {
-      tagsMode = true;
-      continue;
-    }
-    if (t === "--follow-tags") continue;
-    if (t.startsWith("-")) continue; // -u, --force, --set-upstream, --force-with-lease=…, …
-    positional.push(t);
-  }
-
-  const remote = positional[0] ?? "origin";
-  const refspecs = positional.slice(1);
-  return { remote, refspecs, deleteMode, allMode, mirrorMode, tagsMode };
-}
-
-/**
- * Work out every local ref the command will actually upload. Anything that cannot be
- * determined resolves to a superset (fail closed) rather than being skipped.
- */
-function resolvePushedRefs(parsed, git) {
-  const { remote, refspecs, deleteMode, allMode, mirrorMode, tagsMode } = parsed;
-
-  // Deletes a remote ref and uploads no commits — nothing to gate.
-  if (deleteMode) return [];
-
-  const listRefs = (...globs) => {
-    try {
-      return git("for-each-ref", "--format=%(refname:short)", ...globs)
-        .split("\n")
-        .map((r) => r.trim())
-        .filter(Boolean);
-    } catch {
-      return [];
-    }
-  };
-
-  // --mirror uploads EVERY ref under refs/ — branches and tags alike. A tag can point at a
-  // commit that is on no local branch, so expanding to branches only would miss it.
-  if (mirrorMode) {
-    const refs = listRefs("refs/heads/", "refs/tags/");
-    return refs.length ? refs : ["HEAD"]; // fail closed
-  }
-
-  const refs = new Set();
-
-  if (allMode) {
-    const branches = listRefs("refs/heads/");
-    if (!branches.length) return ["HEAD"]; // fail closed
-    for (const b of branches) refs.add(b);
-  }
-
-  if (tagsMode) for (const t of listRefs("refs/tags/")) refs.add(t);
-
-  // Branches that already exist on the remote — the set a "matching" push uploads.
-  const matchingBranches = () =>
-    listRefs("refs/heads/").filter((b) => {
-      try {
-        git("rev-parse", "--verify", "--quiet", `${remote}/${b}^{commit}`);
-        return true;
-      } catch {
-        return false;
-      }
-    });
-
-  /**
-   * Expand one refspec into the local refs it uploads. Used for BOTH command-line refspecs and
-   * the ones configured in `remote.<name>.push` — git treats them identically, so they must not
-   * be parsed by two different code paths.
-   * @returns true if the spec contributed anything gateable
-   */
-  const addRefspec = (spec) => {
-    const bare = spec.replace(/^\+/, "");
-
-    // A lone `:` is an EXPLICIT matching push — every branch that exists on the remote,
-    // regardless of push.default. Dropping it as an "empty source" let those through.
-    if (bare === ":" || bare === "") {
-      const m = matchingBranches();
-      for (const b of (m.length ? m : listRefs("refs/heads/"))) refs.add(b); // fail closed
-      return true;
-    }
-
-    // `src`, `src:dst`, `+src:dst`. An empty source (`:foo`) is a deletion — pushes nothing.
-    const src = bare.split(":")[0];
-    if (!src || src === ".") return false;
-
-    // A glob refspec (`refs/heads/*:refs/heads/*`) is not a resolvable rev — it stands for
-    // every matching local ref. Expand it rather than letting rev-parse fail and skip it.
-    if (src.includes("*")) {
-      const pattern = src.startsWith("refs/") ? src : `refs/heads/${src}`;
-      const expanded = listRefs(pattern);
-      for (const r of (expanded.length ? expanded : listRefs("refs/heads/"))) refs.add(r); // fail closed
-      return true;
-    }
-
-    refs.add(src);
-    return true;
-  };
-
-  // Any refspec on the command line means the user named the refs explicitly — even a pure
-  // deletion, which contributes nothing to gate but must not fall through to the implicit path.
-  const sawExplicitRefspec = refspecs.length > 0;
-  for (const spec of refspecs) addRefspec(spec);
-
-  if (refs.size) return [...refs];
-  // An explicit refspec was given but resolved to nothing gateable (pure deletions) — allow.
-  if (sawExplicitRefspec) return [];
-
-  // Implicit push (`git push`, `git push origin`). Git does NOT necessarily send HEAD:
-  //   1. `remote.<name>.push` refspecs, when configured, decide what is pushed and OVERRIDE
-  //      push.default entirely (e.g. `refs/heads/*:refs/heads/*` uploads every branch).
-  //   2. otherwise push.default applies; `matching` sends every branch already on the remote.
-  let configured = [];
-  try {
-    configured = git("config", "--get-all", `remote.${remote}.push`)
-      .split("\n")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  } catch {
-    // none configured
-  }
-
-  if (configured.length) {
-    for (const spec of configured) addRefspec(spec);
-    return refs.size ? [...refs] : ["HEAD"]; // fail closed
-  }
-
-  let pushDefault = "simple";
-  try {
-    pushDefault = git("config", "--get", "push.default") || "simple";
-  } catch {
-    // unset → git's default (`simple`)
-  }
-
-  if (pushDefault === "matching") {
-    const matching = matchingBranches();
-    return matching.length ? matching : ["HEAD"];
-  }
-
-  // simple / current / upstream / nothing → at most the current branch.
-  return ["HEAD"];
-}
 
 let raw = "";
 process.stdin.on("data", (chunk) => {
   raw += chunk;
 });
 process.stdin.on("end", () => {
-  let input = {};
+  let input;
   try {
     input = JSON.parse(raw);
   } catch {
     process.exit(0);
   }
 
-  // Claude Code passes tool_input.command as a string; Codex's shell tool passes an
-  // argv array (e.g. ["bash", "-lc", "git push"]). Normalize both.
+  // Claude Code passes a string; Codex's shell tool passes an argv array.
   const rawCommand = input?.tool_input?.command ?? input?.tool_input?.cmd ?? "";
   const command = Array.isArray(rawCommand) ? rawCommand.join(" ") : rawCommand;
-  if (typeof command !== "string" || !/\bgit\b[\s\S]*\bpush\b/.test(command)) {
-    process.exit(0);
-  }
+  if (typeof command !== "string") process.exit(0);
 
-  const cwd = input?.cwd || process.cwd();
-  // execFileSync (no shell) — refs come from an agent-supplied command line, so never
-  // interpolate them into a shell string.
-  const git = (...args) =>
-    execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  const isPush = /\bgit\b[\s\S]*\bpush\b/.test(command);
+  const skipsHooks = /(^|\s)(--no-verify|-n)(\s|=|$)/.test(command);
 
-  let gitDir;
-  try {
-    gitDir = git("rev-parse", "--absolute-git-dir");
-  } catch {
-    process.exit(0); // not a git repo — nothing to gate
-  }
-
-  // Resolve what is actually being pushed. `git push origin some-branch` from a different
-  // checkout must be gated on `some-branch`, not on the current HEAD — and a multi-ref push
-  // (`git push origin main feature`) must gate EVERY ref, or an unvalidated branch rides along.
-  const parsed = parsePushArgs(command);
-  const { remote } = parsed;
-  const localRefs = resolvePushedRefs(parsed, git);
-
-  // Gate only pushes whose outgoing commits touch libs/ui (excluding this plugin's own files).
-  const touchesUi = (...range) => {
-    const changed = git("diff", "--name-only", ...range);
-    return changed
-      .split("\n")
-      .some((f) => f.startsWith("libs/ui/") && !f.startsWith("libs/ui/agent-plugin/"));
-  };
-
-  const resolves = (rev) => {
-    try {
-      git("rev-parse", "--verify", "--quiet", `${rev}^{commit}`);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
-  let marker = "";
-  try {
-    marker = readFileSync(join(gitDir, "ui-validate-passed"), "utf8").trim();
-  } catch {
-    // no marker yet
-  }
-
-  const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-
-  for (const localRef of localRefs) {
-    let tip;
-    try {
-      // Peel to the COMMIT. An annotated tag's own SHA is the tag object, not the commit it
-      // points at, so comparing it against the marker (which is a commit SHA) never matches.
-      tip = git("rev-parse", "--verify", `${localRef}^{commit}`);
-    } catch {
-      // Fail CLOSED. Skipping here was fail-open: anything this gate could not resolve — a glob
-      // it did not expand, an odd refspec form — was waved through without inspection, which is
-      // exactly how a bypass hides. If we cannot see what a ref contains, we do not allow it.
-      process.stderr.write(
-        [
-          `BLOCKED: cannot resolve the pushed ref "${localRef}", so the ui-kit gate cannot verify what it contains.`,
-          "Push an explicit branch or refspec (e.g. `git push origin <branch>`), or resolve the ref and retry.",
-        ].join("\n"),
-      );
-      process.exit(2);
-    }
-
-    // Base to diff against: the ref's own upstream, then the matching remote branch, then the
-    // remote's default branch.
-    const branch = localRef.replace(/^refs\/heads\//, "");
-    const base = [
-      `${localRef}@{upstream}`,
-      `${remote}/${branch}`,
-      `${remote}/HEAD`,
-      `${remote}/master`,
-      `${remote}/main`,
-    ].find((c) => resolves(c));
-
-    // No base (e.g. a fresh repo with no remote refs) → fail closed by diffing the whole tree.
-    const uiChanged = base ? touchesUi(`${base}...${tip}`) : touchesUi(EMPTY_TREE, tip);
-    if (!uiChanged) continue;
-    if (marker === tip) continue; // this ref has been validated
-
+  if (isPush && skipsHooks) {
     process.stderr.write(
       [
-        `BLOCKED: this push contains libs/ui changes but the ui-kit quality gate has not passed for ${localRef} (${tip.slice(0, 8)}).`,
-        "Run the `ui-validate` skill (build, validate:tokens, biome on changed files, visual tests),",
-        // `^{commit}` matters for annotated tags: `git rev-parse <tag>` writes the tag object
-        // SHA, which would never match the commit SHA this gate compares against.
-        `then mark it passed: git rev-parse "${localRef}^{commit}" > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"`,
-        localRefs.length > 1
-          ? `Note: this command pushes ${localRefs.length} refs (${localRefs.join(", ")}); each UI-changing ref must be validated.`
-          : "",
-      ]
-        .filter(Boolean)
-        .join("\n"),
+        "BLOCKED: `--no-verify` skips the pre-push hook that enforces the ui-kit quality gate.",
+        "Run the `ui-validate` skill and push normally instead.",
+      ].join("\n"),
     );
     process.exit(2);
   }
 
-  process.exit(0); // every pushed ref is clean or validated
+  process.exit(0);
 });

--- a/libs/ui/agent-plugin/scripts/sync-skills.mjs
+++ b/libs/ui/agent-plugin/scripts/sync-skills.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Bundles the deep skills from libs/ui/skills/ into this plugin so the plugin
+ * can be published standalone (outside the new-engine repo).
+ *
+ * libs/ui/skills/ stays the single source of truth — run this before every
+ * plugin release:
+ *
+ *   node scripts/sync-skills.mjs
+ *
+ * Copies every skill directory except `_artifacts`, refuses to overwrite the
+ * plugin's own authored workflow skills on a name collision.
+ */
+import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const srcDir = resolve(pluginDir, "../skills"); // libs/ui/skills
+const destDir = resolve(pluginDir, "skills");
+
+const AUTHORED = new Set([
+  "ui-new-component",
+  "ui-tokens",
+  "ui-story",
+  "ui-validate",
+  "ui-theme-brand",
+  "ui-figma-sync",
+  "ui-release-check",
+  "ui-component-usage",
+]);
+
+if (!existsSync(srcDir)) {
+  console.error(`Source skills directory not found: ${srcDir}`);
+  console.error("Run this script from a checkout of the new-engine repo (plugin at libs/ui/agent-plugin).");
+  process.exit(1);
+}
+
+const entries = readdirSync(srcDir, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && e.name !== "_artifacts")
+  .map((e) => e.name);
+
+let copied = 0;
+for (const name of entries) {
+  if (AUTHORED.has(name)) {
+    console.error(`COLLISION: repo skill "${name}" clashes with an authored plugin skill — rename one.`);
+    process.exit(1);
+  }
+  const dest = resolve(destDir, name);
+  rmSync(dest, { recursive: true, force: true });
+  cpSync(resolve(srcDir, name), dest, { recursive: true });
+  copied++;
+}
+
+console.log(`Bundled ${copied} skills from ${srcDir} into ${destDir}`);

--- a/libs/ui/agent-plugin/skills/accordion-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/accordion-usage/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: accordion-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Accordion for
+  collapsible sections using the Zag.js-backed compound anatomy, supported
+  variant, shadow, size, value, multiple, and collapsible props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/accordion.tsx"
+  - "libs/ui/src/tokens/components/molecules/_accordion.css"
+  - "libs/ui/stories/molecules/accordion.stories.tsx"
+  - "libs/ui/src/molecules/figma/accordion.figma.tsx"
+  - "https://zagjs.com/components/react/accordion"
+---
+
+# @techsio/ui-kit Accordion Usage
+
+Use Accordion for related collapsible content sections. Do not build disclosure
+behavior with local state and native buttons when this component fits.
+
+## Setup
+
+```tsx
+import { Accordion } from "@techsio/ui-kit/molecules/accordion"
+
+<Accordion defaultValue={["shipping"]} multiple={false}>
+  <Accordion.Item value="shipping">
+    <Accordion.Header>
+      <Accordion.Title>Shipping</Accordion.Title>
+      <Accordion.Indicator />
+    </Accordion.Header>
+    <Accordion.Content>Delivery options and limits.</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+```
+
+Supported root props:
+
+```text
+variant: default | borderless | child
+shadow: sm | md | none
+size: sm | md | lg
+value/defaultValue: string[]
+collapsible, multiple, disabled, dir, onChange
+```
+
+## Core Patterns
+
+### Keep Zag anatomy intact
+
+Use `Accordion.Item`, `Accordion.Header`, `Accordion.Content`, and optional
+`Accordion.Indicator`, `Accordion.Title`, `Accordion.Subtitle`.
+
+### Choose behavior from content model
+
+```text
+single open section -> multiple=false
+FAQ-style independent sections -> multiple=true
+must keep one section open -> collapsible=false
+nested accordion -> variant=child
+```
+
+### Let tokens own visual state
+
+Do not duplicate expanded, hover, padding, border, or icon rotation styling in
+app `className`. Override `_accordion.css` tokens if the app needs a different
+visual system.
+
+## Common Mistakes
+
+### HIGH Native disclosure
+
+Wrong:
+
+```tsx
+<button onClick={() => setOpen(!open)}>Shipping</button>
+{open && <div>Delivery options</div>}
+```
+
+Correct:
+
+```tsx
+<Accordion.Item value="shipping">
+  <Accordion.Header><Accordion.Title>Shipping</Accordion.Title></Accordion.Header>
+  <Accordion.Content>Delivery options</Accordion.Content>
+</Accordion.Item>
+```
+
+Source: libs/ui/src/molecules/accordion.tsx
+
+### HIGH Value type mismatch
+
+Wrong:
+
+```tsx
+<Accordion defaultValue="shipping" />
+```
+
+Correct:
+
+```tsx
+<Accordion defaultValue={["shipping"]} />
+```
+
+Source: libs/ui/src/molecules/accordion.tsx
+
+### HIGH Inline state styling
+
+Wrong:
+
+```tsx
+<Accordion.Content className="bg-white p-4 text-gray-900" />
+```
+
+Correct:
+
+```tsx
+<Accordion.Content />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_accordion.css
+
+## Validation Commands
+
+```sh
+rg -n "setOpen|<details|<summary|<Accordion[^>]*defaultValue=\"|<Accordion[^>]*value=\"" apps
+rg -n "<Accordion[^>]*className=.*(bg-|text-|border-|p-|px-|py-)" apps
+rg -n "<Accordion\\.Content[^>]*className=.*(bg-|text-|p-|px-|py-)" apps
+```
+

--- a/libs/ui/agent-plugin/skills/app-token-initialization/SKILL.md
+++ b/libs/ui/agent-plugin/skills/app-token-initialization/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: app-token-initialization
+description: >
+  Use when adopting @techsio/ui-kit in a new or existing apps/* project and
+  setting up app semantic, typography, spacing, layout, radius, state, and
+  minimal component token override files after a focused design-token interview.
+type: lifecycle
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - tailwind-token-authoring
+sources:
+  - "libs/ui/skills/_artifacts/consumer_app_usage_rules.md"
+  - "libs/ui/src/tokens/index.css"
+  - "libs/ui/src/tokens/_semantic.css"
+  - "libs/ui/src/tokens/_layout.css"
+  - "libs/ui/src/tokens/_spacing.css"
+  - "libs/ui/src/tokens/components/components.css"
+  - "https://github.com/TechsioCZ/new-engine/issues/72"
+---
+
+# @techsio/ui-kit App Token Initialization
+
+Use this in `apps/*`, not for changing `libs/ui` defaults.
+
+## Setup
+
+Start by asking whether values need to change at all.
+
+```text
+For this app, which UI-kit defaults should remain?
+Which values are different: semantic colors, typography, spacing step,
+layout containers, radius, shadows, feedback states, component-specific tokens?
+```
+
+Then create the smallest app token layer that expresses those differences.
+
+```css
+@import "@techsio/ui-kit/tokens";
+
+@theme static {
+  --color-primary: var(--brand-primary);
+  --color-secondary: var(--brand-secondary);
+  --container-xl: 1200px;
+}
+```
+
+## Core Patterns
+
+### Initialize broad layers before component overrides
+
+```css
+@theme static {
+  --color-primary: var(--brand-green);
+  --text-md: 1rem;
+  --spacing-100: 0.5rem;
+}
+```
+
+Only add `_app-button.css` when the broad layer cannot express the component.
+
+### Derive semantic roles from compact inputs
+
+```text
+Input: "main brand is green, danger is red, spacing steps by 2px"
+Output: map primary/danger/state/spacing tokens, then inherit the rest.
+```
+
+Do not ask the maintainer to manually define every component token.
+
+### Keep component override files sparse
+
+```css
+@theme static {
+  --color-button-bg-primary: var(--color-primary);
+}
+```
+
+Do not copy every UI-kit component token into the app.
+
+## Common Mistakes
+
+### HIGH Component overrides before semantic layer
+
+Wrong:
+
+```css
+@theme static {
+  --color-button-bg-primary: #009869;
+  --color-input-border: #009869;
+  --color-badge-bg-success: #009869;
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-primary: var(--brand-green);
+}
+```
+
+Start with semantic tokens, so components inherit consistently.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Raw Figma CSS as final theme
+
+Wrong:
+
+```css
+.button {
+  background: #009869;
+  border-radius: 999px;
+  padding: 8px 20px;
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-button-bg-primary: var(--color-primary);
+  --radius-button-md: var(--radius-full);
+  --padding-button-md: var(--spacing-100) var(--spacing-250);
+}
+```
+
+Figma output is input for token mapping, not the final app theme layer.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### MEDIUM Guessing theme without interview
+
+Wrong:
+
+```text
+Infer all semantic colors and spacing from a screenshot.
+```
+
+Correct:
+
+```text
+Ask what changes and where; accept compact answers such as main colors or a
+spacing rule, then propose the semantic mapping.
+```
+
+The app token setup should avoid unnecessary overrides.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+## Validation Commands
+
+```sh
+pnpm --dir libs/ui validate:tokens
+bunx biome check --write apps/<app>/src/tokens
+```
+
+For app work, also inspect JSX for token-first usage with `app-ui-kit-audit`.

--- a/libs/ui/agent-plugin/skills/app-token-overrides/SKILL.md
+++ b/libs/ui/agent-plugin/skills/app-token-overrides/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: app-token-overrides
+description: >
+  Use when changing app-specific @techsio/ui-kit visuals through semantic,
+  typography, spacing, layout, radius, or component CSS token overrides while
+  avoiding redundant token chains, duplicated JSX className styling, and
+  permanent local API-gap workarounds.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - tailwind-token-authoring
+sources:
+  - "libs/ui/skills/_artifacts/consumer_app_usage_rules.md"
+  - "libs/ui/src/tokens/_semantic.css"
+  - "libs/ui/src/tokens/components/atoms/_button.css"
+  - "libs/ui/src/tokens/components/molecules/_dialog.css"
+  - "libs/ui/src/tokens/components/components.css"
+  - "https://github.com/TechsioCZ/new-engine/issues/72"
+---
+
+# @techsio/ui-kit App Token Overrides
+
+Use this in app code when a UI-kit component visual does not match app design.
+
+## Setup
+
+Work down the token chain:
+
+```text
+1. Does the existing libs/ui token chain already produce the desired value?
+2. Can an app semantic/typography/spacing/layout token solve it globally?
+3. After semantic tokens are correct, does this one component still need to
+   reference a different token/value than the default chain?
+4. If no token/prop can express it, record a UI-kit API gap.
+```
+
+## Core Patterns
+
+### Prefer app semantic overrides
+
+```css
+@theme static {
+  --color-primary: var(--brand-primary);
+  --color-danger: var(--brand-danger);
+}
+```
+
+This lets Button, Badge, Dialog, Toast, and other components inherit the app
+scheme.
+
+### Let semantic tokens remove component overrides
+
+```css
+@theme static {
+  --color-primary: oklch(0.9 0.5 120);
+}
+```
+
+If Button primary should use the app primary color, stop here. Do not also add
+`--color-button-bg-primary: var(--color-primary)` when the UI-kit default chain
+already points Button primary to `--color-primary`.
+
+### Use component overrides only for real exceptions
+
+```css
+@theme static {
+  --color-button-bg-primary: var(--color-cta);
+}
+```
+
+Do this only when Button primary should intentionally reference a different
+token/value than the app's general `--color-primary`.
+
+### Keep className for layout composition
+
+```tsx
+<div className="grid gap-200 md:grid-cols-2">
+  <Button>Save</Button>
+</div>
+```
+
+Layout around components is fine. Component appearance belongs in tokens.
+
+## Common Mistakes
+
+### HIGH Redundant component token
+
+Wrong:
+
+```css
+@theme static {
+  --color-primary: oklch(0.9 0.5 120);
+  --color-button-bg-primary: var(--color-primary);
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-primary: oklch(0.9 0.5 120);
+}
+```
+
+Do not override component tokens when the corrected semantic layer already
+drives the component to the right value.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Component override used instead of semantic source
+
+Wrong:
+
+```css
+@theme static {
+  --color-button-bg-primary: oklch(0.9 0.5 120);
+  --color-badge-bg-primary: oklch(0.9 0.5 120);
+  --color-link-fg-primary: oklch(0.9 0.5 120);
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-primary: oklch(0.9 0.5 120);
+}
+```
+
+If multiple components should follow the same app primary color, set the
+semantic source once instead of duplicating component overrides.
+
+Source: https://github.com/TechsioCZ/new-engine/issues/72
+
+### HIGH JSX className appearance fix
+
+Wrong:
+
+```tsx
+<Button className="bg-surface text-fg-primary rounded-full" />
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-button-bg-primary: var(--color-cta);
+  --color-button-fg-primary: var(--color-fg-primary);
+  --radius-button-md: var(--radius-full);
+}
+```
+
+Use a component override only when Button really should diverge from semantic
+primary/default mappings. Otherwise fix the semantic token.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Font weight token bypassed
+
+Wrong:
+
+```tsx
+<Button className="font-bold" />
+```
+
+Correct:
+
+```css
+@theme static {
+  --font-weight-button: 700;
+}
+```
+
+`--font-weight-*` tokens map to `font-*` classes in TSX.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### MEDIUM Container token misapplied
+
+Wrong:
+
+```css
+@theme static {
+  --spacing-card-gap: var(--container-xl);
+}
+```
+
+Correct:
+
+```tsx
+<section className="max-w-xl">
+  <ProductCard />
+</section>
+```
+
+`--container-*` tokens are for width and max-width utilities, not spacing.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### MEDIUM Permanent API gap workaround
+
+Wrong:
+
+```tsx
+<Button className="px-200 py-unknown-token" />
+```
+
+Correct:
+
+```text
+Use existing size/theme/variant props or app token overrides. If none can
+express the design, record a Button API/token gap for libs/ui.
+```
+
+Do not normalize one-off class hacks into app code.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+## Validation Commands
+
+```sh
+rg -n 'className=.*(bg-|text-|font-|px-|py-|rounded-)' apps/<app>
+rg -n -- '--color-|--spacing-|--font-weight-|--container-' apps/<app>/src
+bunx biome check --write apps/<app>/src
+```

--- a/libs/ui/agent-plugin/skills/app-ui-kit-audit/SKILL.md
+++ b/libs/ui/agent-plugin/skills/app-ui-kit-audit/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: app-ui-kit-audit
+description: >
+  Use when reviewing an apps/* UI for correct @techsio/ui-kit adoption:
+  existing component usage, native HTML replacement, nonexistent props,
+  duplicate className styling, token-first violations, framework adapter
+  mistakes, unnecessary wrappers, and UI-kit API gaps.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/skills/_artifacts/consumer_app_usage_rules.md"
+  - "libs/ui/package.json"
+  - "libs/ui/src/atoms"
+  - "libs/ui/src/molecules"
+  - "libs/ui/src/tokens/components"
+---
+
+# @techsio/ui-kit App Adoption Audit
+
+Run this before handing off app UI that consumes `@techsio/ui-kit`.
+
+## Component Checks
+
+### Check: existing component used
+
+Expected:
+
+```tsx
+import { TreeView } from "@techsio/ui-kit/molecules/tree-view"
+```
+
+Fail condition: custom tree, dialog, toast, button, input, or skeleton exists
+while UI-kit has the component.
+Fix: replace with UI-kit component or record the missing API gap.
+
+### Check: props exist
+
+Expected:
+
+```tsx
+<Button variant="danger" theme="solid" size="md" />
+```
+
+Fail condition: `variant="ghost"` or other props not in component source.
+Fix: load the per-component usage skill and inspect the source props.
+
+### Check: appearance is token-first
+
+Expected:
+
+```tsx
+<Button variant="primary" theme="solid" />
+```
+
+Fail condition: `className` duplicates background, text color, padding, radius,
+or font weight already provided by props/tokens.
+Fix: move visual differences into app token overrides.
+
+## Audit Commands
+
+```sh
+rg -n '<button|<input|<select|<textarea|animate-pulse' apps/<app>
+rg -n 'variant="ghost"|theme="ghost"|size="xl"' apps/<app>
+rg -n 'className=.*(bg-|text-|font-|px-|py-|rounded-|border-)' apps/<app>
+rg -n 'function .*Button|function .*Dialog|function .*Breadcrumb|function .*Tree' apps/<app>
+rg -n '@techsio/ui-kit/tokens|@techsio/ui-kit/tokens-with-tailwind' apps/<app>
+```
+
+## Common Mistakes
+
+### HIGH Missed existing component
+
+Wrong:
+
+```tsx
+function CategoryTree() {
+  return <div>{items.map((item) => <button>{item.label}</button>)}</div>
+}
+```
+
+Correct:
+
+```tsx
+import { TreeView } from "@techsio/ui-kit/molecules/tree-view"
+```
+
+The first audit pass should inventory existing UI-kit components.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Duplicated default style accepted
+
+Wrong:
+
+```tsx
+<Button variant="danger" className="bg-danger text-fg-reverse px-200" />
+```
+
+Correct:
+
+```tsx
+<Button variant="danger" />
+```
+
+Do not allow className to restate what component props and tokens already do.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Native HTML primitive remains
+
+Wrong:
+
+```tsx
+<input className="border-input-border rounded-input-md" />
+```
+
+Correct:
+
+```tsx
+import { Input } from "@techsio/ui-kit/atoms/input"
+
+<Input />
+```
+
+Use UI-kit primitives where possible so props and tokens remain centralized.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### MEDIUM Loading pattern drift
+
+Wrong:
+
+```tsx
+<div className="h-8 animate-pulse rounded bg-gray-200" />
+```
+
+Correct:
+
+```tsx
+import { Skeleton } from "@techsio/ui-kit/atoms/skeleton"
+
+<Skeleton />
+```
+
+Loading placeholders should use token-consistent Skeleton instead of ad-hoc
+animated divs.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+## Validation Commands
+
+```sh
+bunx biome check --write apps/<app>/src
+```
+
+Use the audit `rg` commands above before formatting.
+

--- a/libs/ui/agent-plugin/skills/badge-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/badge-usage/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: badge-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Badge for
+  compact status, category, discount, or metadata labels without duplicating
+  token-backed color and spacing classes in JSX.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/badge.tsx"
+  - "libs/ui/src/tokens/components/atoms/_badge.css"
+  - "libs/ui/stories/atoms/badge.stories.tsx"
+  - "libs/ui/src/atoms/figma/badge.figma.tsx"
+---
+
+# @techsio/ui-kit Badge Usage
+
+Use Badge for short non-interactive labels. It is not a button, link, alert, or
+long message container.
+
+## Setup
+
+```tsx
+import { Badge } from "@techsio/ui-kit/atoms/badge"
+
+<Badge variant="success" size="md">
+  Published
+</Badge>
+```
+
+Supported props from `src/atoms/badge.tsx`:
+
+```text
+variant: primary | secondary | tertiary | discount | info | success | warning | danger | outline | dynamic
+size: sm | md | lg | xl
+children: string
+dynamic: requires bgColor, fgColor, and borderColor
+```
+
+## Core Patterns
+
+### Match the UX role to variant
+
+```text
+success -> completed, published, available
+warning -> needs attention, low stock, pending risk
+danger -> failed, destructive status, critical problem
+info -> neutral informational state
+discount -> price/promotion label
+outline -> low-emphasis label
+```
+
+Do not use `danger` only because the design has red text. If the visual should
+change globally, use `app-token-overrides`.
+
+### Keep Badge text short
+
+```tsx
+<Badge variant="warning">Pending</Badge>
+```
+
+If the content needs a sentence or action, use `StatusText`, `Toast`, `Alert`
+when available, or another molecule/organism usage skill.
+
+### Treat dynamic as an explicit escape hatch
+
+```tsx
+<Badge
+  variant="dynamic"
+  bgColor="var(--color-brand-swatch-bg)"
+  fgColor="var(--color-brand-swatch-fg)"
+  borderColor="var(--color-brand-swatch-border)"
+>
+  Custom
+</Badge>
+```
+
+Use `dynamic` only for values that cannot be represented by the standard
+semantic/component token chain, such as runtime swatches. Prefer semantic
+variants first.
+
+## Common Mistakes
+
+### HIGH Native span badge
+
+Wrong:
+
+```tsx
+<span className="rounded bg-green-500 px-2 py-1 text-white">Active</span>
+```
+
+Correct:
+
+```tsx
+<Badge variant="success">Active</Badge>
+```
+
+Source: libs/ui/src/atoms/badge.tsx
+
+### HIGH Inline color duplicate
+
+Wrong:
+
+```tsx
+<Badge variant="danger" className="bg-danger text-fg-reverse">
+  Failed
+</Badge>
+```
+
+Correct:
+
+```tsx
+<Badge variant="danger">Failed</Badge>
+```
+
+The badge token classes already provide background, foreground, border,
+padding, radius, and text sizing.
+
+Source: libs/ui/src/tokens/components/atoms/_badge.css
+
+### MEDIUM Dynamic variant without required colors
+
+Wrong:
+
+```tsx
+<Badge variant="dynamic">Brand</Badge>
+```
+
+Correct:
+
+```tsx
+<Badge
+  variant="dynamic"
+  bgColor="var(--color-brand-badge-bg)"
+  fgColor="var(--color-brand-badge-fg)"
+  borderColor="var(--color-brand-badge-border)"
+>
+  Brand
+</Badge>
+```
+
+`dynamic` requires explicit color props in the component source.
+
+Source: libs/ui/src/atoms/badge.tsx
+
+### MEDIUM Long actionable content
+
+Wrong:
+
+```tsx
+<Badge variant="warning">Your profile needs attention, click here</Badge>
+```
+
+Correct:
+
+```tsx
+<StatusText status="warning" showIcon>
+  Your profile needs attention.
+</StatusText>
+```
+
+Badge is for compact labels, not messages or actions.
+
+## Validation Commands
+
+```sh
+rg -n "<span[^>]*className=.*(badge|rounded|bg-|text-)" apps
+rg -n "variant=\"(ghost|neutral|error)\"" apps
+rg -n "<Badge[^>]*variant=\"dynamic\"" apps
+rg -n "<Badge[^>]*className=.*(bg-|text-|border-|px-|py-|rounded-)" apps
+```
+

--- a/libs/ui/agent-plugin/skills/breadcrumb-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/breadcrumb-usage/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: breadcrumb-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Breadcrumb for
+  page hierarchy navigation with Link/NextLink adapters, current page state,
+  separators, ellipsis, icons, size, and underline variant.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/breadcrumb.tsx"
+  - "libs/ui/src/tokens/components/molecules/_breadcrumb.css"
+  - "libs/ui/stories/molecules/breadcrumb.stories.tsx"
+  - "libs/ui/src/molecules/figma/breadcrumb.figma.tsx"
+---
+
+# @techsio/ui-kit Breadcrumb Usage
+
+Use Breadcrumb for location hierarchy, not for primary navigation tabs.
+
+## Setup
+
+```tsx
+import NextLink from "next/link"
+import { Breadcrumb } from "@techsio/ui-kit/molecules/breadcrumb"
+
+<Breadcrumb size="md">
+  <Breadcrumb.List>
+    <Breadcrumb.Item><Breadcrumb.Link as={NextLink} href="/">Home</Breadcrumb.Link></Breadcrumb.Item>
+    <Breadcrumb.Separator />
+    <Breadcrumb.Item><Breadcrumb.CurrentLink>Products</Breadcrumb.CurrentLink></Breadcrumb.Item>
+  </Breadcrumb.List>
+</Breadcrumb>
+```
+
+Supported props:
+
+```text
+Breadcrumb: size sm | md | lg, variant plain | underline
+Link: as, href, external, framework link props
+CurrentLink: aria-current page
+Separator/Ellipsis/Icon: token icon defaults with icon override props
+```
+
+## Core Patterns
+
+### Use CurrentLink for the current page
+
+The last breadcrumb should be `Breadcrumb.CurrentLink`, not a clickable link to
+the same page.
+
+### Use framework link adapters
+
+In Next apps, pass `as={NextLink}` to `Breadcrumb.Link` instead of wrapping or
+restyling anchors.
+
+### Use separators and ellipsis components
+
+Let `Breadcrumb.Separator` and `Breadcrumb.Ellipsis` supply token icons and
+ARIA behavior.
+
+## Common Mistakes
+
+### HIGH Native breadcrumb markup
+
+Wrong:
+
+```tsx
+<nav><a href="/">Home</a> / <span>Products</span></nav>
+```
+
+Correct:
+
+```tsx
+<Breadcrumb><Breadcrumb.List>{/* items */}</Breadcrumb.List></Breadcrumb>
+```
+
+Source: libs/ui/src/molecules/breadcrumb.tsx
+
+### HIGH Missing framework adapter
+
+Wrong:
+
+```tsx
+<Breadcrumb.Link href="/products">Products</Breadcrumb.Link>
+```
+
+Correct in Next:
+
+```tsx
+<Breadcrumb.Link as={NextLink} href="/products">Products</Breadcrumb.Link>
+```
+
+Source: libs/ui/src/atoms/link.tsx
+
+### MEDIUM Inline separator or text styling
+
+Wrong:
+
+```tsx
+<span className="mx-2 text-gray-400">/</span>
+```
+
+Correct:
+
+```tsx
+<Breadcrumb.Separator />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_breadcrumb.css
+
+## Validation Commands
+
+```sh
+rg -P -n "<nav[^>]*breadcrumb|/ <span|<Breadcrumb\\.Link(?![^>]*as=)" apps
+rg -P -n "<Breadcrumb\\.Link(?![^>]*as=\\{?NextLink)" apps
+rg -n "<Breadcrumb[^>]*className=.*(gap-|text-|px-|py-)" apps
+```

--- a/libs/ui/agent-plugin/skills/button-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/button-usage/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: button-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Button for
+  actions, including correct variant, theme, size, loading state, icon props,
+  and token-first styling rules.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/button.tsx"
+  - "libs/ui/src/tokens/components/atoms/_button.css"
+  - "libs/ui/stories/atoms/button.stories.tsx"
+  - "libs/ui/src/atoms/figma/button.figma.tsx"
+---
+
+# @techsio/ui-kit Button Usage
+
+Use Button for in-place actions. Use `LinkButton` for navigation that should
+look like a button.
+
+## Setup
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+
+<Button variant="primary" theme="solid" size="md">
+  Save
+</Button>
+```
+
+Supported visual props from `src/atoms/button.tsx`:
+
+```text
+variant: primary | secondary | tertiary | danger | warning
+theme: solid | light | borderless | outlined | unstyled
+size: sm | md | lg | current
+block: boolean
+uppercase: boolean
+isLoading: boolean
+loadingText: string
+icon: IconType
+iconPosition: left | right
+iconSize: xs | sm | md | lg | xl | 2xl | current
+```
+
+## Core Patterns
+
+### Choose variant from action semantics
+
+```text
+primary -> main positive action in the current scope
+secondary -> secondary action with normal emphasis
+tertiary -> quiet tertiary action
+danger -> destructive action such as delete/remove/cancel order
+warning -> risky but not destructive action
+```
+
+### Choose theme from emphasis
+
+```text
+solid -> strongest emphasis
+light -> filled but softer emphasis
+outlined -> boundary/emphasis without solid fill
+borderless -> quiet action, similar to "ghost"
+unstyled -> only when composing inside another component surface
+```
+
+There is no `variant="ghost"`. Use `theme="borderless"` for that intent.
+
+### Let Button own its visual styling
+
+```tsx
+<Button variant="danger" theme="solid" size="sm">
+  Delete
+</Button>
+```
+
+Do not add background, foreground, padding, border, radius, or font classes
+that duplicate Button tokens. If the app needs different colors or sizing,
+change app token overrides first.
+
+### Use loading props instead of custom disabling
+
+```tsx
+<Button isLoading loadingText="Saving" disabled={isSaving}>
+  Save
+</Button>
+```
+
+Use the component API for loading and disabled state instead of wrapping the
+button in a conditional spinner.
+
+## Common Mistakes
+
+### HIGH Native button
+
+Wrong:
+
+```tsx
+<button className="bg-primary text-white px-4 py-2">Save</button>
+```
+
+Correct:
+
+```tsx
+<Button variant="primary" theme="solid">Save</Button>
+```
+
+Source: libs/ui/src/atoms/button.tsx
+
+### HIGH Hallucinated ghost variant
+
+Wrong:
+
+```tsx
+<Button variant="ghost">Cancel</Button>
+```
+
+Correct:
+
+```tsx
+<Button variant="secondary" theme="borderless">Cancel</Button>
+```
+
+Source: libs/ui/src/atoms/button.tsx
+
+### HIGH Duplicated component tokens in className
+
+Wrong:
+
+```tsx
+<Button
+  variant="danger"
+  theme="solid"
+  className="bg-danger text-fg-reverse px-200 py-100"
+>
+  Delete
+</Button>
+```
+
+Correct:
+
+```tsx
+<Button variant="danger" theme="solid">Delete</Button>
+```
+
+If Button danger should look different in the app, override
+`--color-button-*` or related semantic tokens in CSS.
+
+Source: libs/ui/src/tokens/components/atoms/_button.css
+
+### MEDIUM Navigation rendered as Button
+
+Wrong:
+
+```tsx
+<Button onClick={() => router.push("/products")}>Products</Button>
+```
+
+Correct:
+
+```tsx
+<LinkButton href="/products">Products</LinkButton>
+```
+
+Use Button for actions and LinkButton for navigation.
+
+## Validation Commands
+
+```sh
+rg -n "<button|variant=\"ghost\"|variant=\"error\"" apps
+rg -n "<Button[^>]*className=.*(bg-|text-|px-|py-|rounded-|border-)" apps
+rg -n "<Button[^>]*onClick=.*router\\.push" apps
+rg -n "isLoading|loadingText" apps
+```
+

--- a/libs/ui/agent-plugin/skills/carousel-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/carousel-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: carousel-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Carousel for
+  Zag.js-backed slides, images, controls, indicators, autoplay, sizing, aspect
+  ratio, object fit, and framework image adapters.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/carousel.tsx"
+  - "libs/ui/src/tokens/components/molecules/_carousel.css"
+  - "libs/ui/stories/molecules/carousel.stories.tsx"
+  - "libs/ui/src/molecules/figma/carousel.figma.tsx"
+  - "https://zagjs.com/components/react/carousel"
+---
+
+# @techsio/ui-kit Carousel Usage
+
+Use Carousel for slide-based browsing. Use Gallery for product image galleries
+with thumbnails.
+
+## Setup
+
+```tsx
+import NextImage from "next/image"
+import { Carousel } from "@techsio/ui-kit/molecules/carousel"
+
+<Carousel slideCount={slides.length} size="full" aspectRatio="landscape">
+  <Carousel.Slides slides={slides} imageAs={NextImage} />
+  <Carousel.Control><Carousel.Previous /><Carousel.Indicators /><Carousel.Next /></Carousel.Control>
+</Carousel>
+```
+
+Supported root props:
+
+```text
+size: sm | md | lg | full
+aspectRatio: square | landscape | portrait | wide | none
+objectFit: cover | contain | fill | none
+controlPosition: top | bottom | side | unset on Carousel.Control
+orientation, loop, autoplay, allowMouseDrag, slidesPerPage, slidesPerMove
+```
+
+## Core Patterns
+
+### Use slides data or explicit slides
+
+`Carousel.Slides` accepts `{ id, content, src, alt, imageProps }[]`. In Next
+apps pass `imageAs={NextImage}` when rendering images.
+
+### Keep controls as Carousel parts
+
+Use `Carousel.Previous`, `Carousel.Next`, `Carousel.Indicators`, and
+`Carousel.Autoplay` so Zag props and disabled states stay wired.
+
+### Use Gallery for thumbnail product media
+
+If the UX includes selectable thumbnails, start with `gallery-usage`, which
+wraps Carousel correctly.
+
+## Common Mistakes
+
+### HIGH Custom slider state
+
+Wrong:
+
+```tsx
+<button onClick={prev}>Prev</button>{slides[index]}
+```
+
+Correct:
+
+```tsx
+<Carousel slideCount={slides.length}><Carousel.Slides slides={slides} /></Carousel>
+```
+
+Source: libs/ui/src/molecules/carousel.tsx
+
+### HIGH Missing slideCount
+
+Wrong:
+
+```tsx
+<Carousel><Carousel.Slides slides={slides} /></Carousel>
+```
+
+Correct:
+
+```tsx
+<Carousel slideCount={slides.length}><Carousel.Slides slides={slides} /></Carousel>
+```
+
+Source: https://zagjs.com/components/react/carousel
+
+### HIGH Inline image/object-fit styling
+
+Wrong:
+
+```tsx
+<Carousel.Slide className="aspect-video"><img className="object-cover" /></Carousel.Slide>
+```
+
+Correct:
+
+```tsx
+<Carousel aspectRatio="landscape" objectFit="cover" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_carousel.css
+
+## Validation Commands
+
+```sh
+rg -P -n "setSlide|setIndex|<img\\b|<Carousel(?![^>]*slideCount=)" apps
+rg -n "<Carousel[^>]*className=.*(aspect-|object-|w-|h-|rounded-|overflow-)" apps
+rg -P -n "<Carousel\\.Slides(?![^>]*(imageAs|slides=))" apps
+```

--- a/libs/ui/agent-plugin/skills/checkbox-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/checkbox-usage/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: checkbox-usage
+description: >
+  Use after component-usage-ux when an app needs the low-level
+  @techsio/ui-kit Checkbox atom, including invalid and indeterminate states,
+  while preferring form molecules for labeled form rows.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/checkbox.tsx"
+  - "libs/ui/src/molecules/form-checkbox.tsx"
+  - "libs/ui/src/tokens/components/atoms/_checkbox.css"
+  - "libs/ui/stories/atoms/checkbox.stories.tsx"
+  - "libs/ui/src/atoms/figma/checkbox.figma.tsx"
+---
+
+# @techsio/ui-kit Checkbox Usage
+
+Use `Checkbox` for the bare control. Use `FormCheckbox` when the UI includes a
+label, helper text, validation text, or a form-field layout.
+
+## Setup
+
+```tsx
+import { Checkbox } from "@techsio/ui-kit/atoms/checkbox"
+
+<Checkbox name="acceptTerms" required />
+```
+
+Supported component-specific props:
+
+```text
+indeterminate: boolean
+invalid: boolean
+```
+
+The component also accepts native checkbox input attributes.
+
+## Core Patterns
+
+### Prefer FormCheckbox for labeled rows
+
+```tsx
+<FormCheckbox
+  name="newsletter"
+  label="Send me product updates"
+  helperText="You can unsubscribe anytime."
+/>
+```
+
+Do not manually recreate label/help/error layout when the molecule exists.
+
+### Use indeterminate for partial selection
+
+```tsx
+<Checkbox
+  checked={someSelected}
+  indeterminate={someSelected && !allSelected}
+  aria-label="Select all visible rows"
+/>
+```
+
+`indeterminate` is wired to the DOM property in `checkbox.tsx`.
+
+### Use invalid for visual and ARIA state
+
+```tsx
+<Checkbox invalid aria-describedby="terms-error" />
+```
+
+`invalid` maps to `aria-invalid` and `data-invalid`.
+
+## Common Mistakes
+
+### HIGH Native checkbox
+
+Wrong:
+
+```tsx
+<input type="checkbox" className="accent-green-600" />
+```
+
+Correct:
+
+```tsx
+<Checkbox name="enabled" />
+```
+
+Source: libs/ui/src/atoms/checkbox.tsx
+
+### HIGH Manual form row
+
+Wrong:
+
+```tsx
+<label className="flex gap-2">
+  <Checkbox />
+  <span>Accept terms</span>
+</label>
+```
+
+Correct:
+
+```tsx
+<FormCheckbox name="terms" label="Accept terms" />
+```
+
+Source: libs/ui/src/molecules/form-checkbox.tsx
+
+### HIGH Inline state colors
+
+Wrong:
+
+```tsx
+<Checkbox invalid className="border-red-500 bg-red-50" />
+```
+
+Correct:
+
+```tsx
+<Checkbox invalid />
+```
+
+Use `_checkbox.css` or app token overrides for visual changes.
+
+Source: libs/ui/src/tokens/components/atoms/_checkbox.css
+
+### MEDIUM Missing accessible label
+
+Wrong:
+
+```tsx
+<Checkbox />
+```
+
+Correct:
+
+```tsx
+<Checkbox aria-label="Select product" />
+```
+
+or use `FormCheckbox` with a visible label.
+
+## Validation Commands
+
+```sh
+rg -n "<input[^>]*type=\"checkbox\"" apps
+rg -n "<Checkbox[^>]*className=.*(accent-|bg-|border-|text-)" apps
+rg -U -n "<label[^>]*>\\s*<Checkbox|<Checkbox[\\s\\S]*</label>" apps
+rg -P -n "<Checkbox(?![^>]*(aria-label|aria-labelledby|id=))" apps
+```

--- a/libs/ui/agent-plugin/skills/color-select-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/color-select-usage/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: color-select-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit ColorSelect
+  for choosing color swatches with supported layout, size, radius, disabled
+  state, selected state, labels, counts, and single/multiple roles.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/color-select.tsx"
+  - "libs/ui/src/tokens/components/molecules/_color-select.css"
+  - "libs/ui/stories/molecules/color-select.stories.tsx"
+---
+
+# @techsio/ui-kit ColorSelect Usage
+
+Use ColorSelect for product color filters or swatch choices. It is not a
+general Select replacement.
+
+## Setup
+
+```tsx
+import { ColorSelect } from "@techsio/ui-kit/molecules/color-select"
+
+<ColorSelect
+  colors={[{ color: "#0f172a", label: "Navy", selected: true }]}
+  onColorClick={setColor}
+/>
+```
+
+Supported props:
+
+```text
+colors: { id, color, selected, label, count, disabled }[]
+layout: list | grid
+size: sm | md | lg | full
+radius: sm | md | lg | full
+selectionMode: single | multiple
+disabled, onColorClick
+```
+
+## Core Patterns
+
+### Use only for swatches
+
+Use Select or RadioCard when choices are textual. Use ColorSelect when the
+visual color itself is the primary choice signal.
+
+### Keep selected state in data
+
+Update `colors[].selected` from app state. Do not style selected swatches with
+manual `className`.
+
+### Allow runtime color values here
+
+Swatch fill uses inline `backgroundColor` because the data value is the product
+color, not a component theme token.
+
+## Common Mistakes
+
+### HIGH Custom swatch buttons
+
+Wrong:
+
+```tsx
+<button style={{ background: color }} className="h-6 w-6 rounded-full" />
+```
+
+Correct:
+
+```tsx
+<ColorSelect colors={colors} onColorClick={setColor} />
+```
+
+Source: libs/ui/src/molecules/color-select.tsx
+
+### HIGH Textual choice in ColorSelect
+
+Wrong:
+
+```tsx
+<ColorSelect colors={[{ color: "transparent", label: "Small" }]} />
+```
+
+Correct:
+
+```tsx
+<RadioGroup>{/* size choices */}</RadioGroup>
+```
+
+### MEDIUM Inline shape/sizing
+
+Wrong:
+
+```tsx
+<ColorSelect className="grid grid-cols-4 gap-2" colors={colors} />
+```
+
+Correct:
+
+```tsx
+<ColorSelect layout="grid" size="md" radius="full" colors={colors} />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_color-select.css
+
+## Validation Commands
+
+```sh
+rg -n "backgroundColor:.*color|rounded-full.*onClick|<ColorSelect[^>]*className" apps
+rg -n "<ColorSelect[^>]*colors=|selectionMode=|onColorClick=" apps
+rg -n "<ColorSelect[^>]*size=\"(xs|xl)\"|radius=\"(none|circle)\"" apps
+```
+

--- a/libs/ui/agent-plugin/skills/combobox-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/combobox-usage/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: combobox-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Combobox for
+  searchable selection with Zag.js collection behavior, controlled value/input,
+  multiple mode, validation status, clear trigger, and token styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/combobox.tsx"
+  - "libs/ui/src/tokens/components/molecules/_combobox.css"
+  - "libs/ui/stories/molecules/combobox.stories.tsx"
+  - "libs/ui/src/molecules/figma/combobox.figma.tsx"
+  - "https://zagjs.com/components/react/combobox"
+---
+
+# @techsio/ui-kit Combobox Usage
+
+Use Combobox for searchable select-like input. Use Select when search/filtering
+is not needed.
+
+## Setup
+
+```tsx
+import { Combobox } from "@techsio/ui-kit/molecules/combobox"
+
+<Combobox
+  label="Country"
+  name="country"
+  items={[{ label: "Czechia", value: "CZ" }]}
+  onChange={setCountry}
+/>
+```
+
+Supported props:
+
+```text
+items: { id, label, value, disabled, data }[]
+value/defaultValue: string | string[]
+inputValue, multiple, clearable, closeOnSelect, allowCustomValue
+validateStatus: default | error | success | warning
+inputBehavior: autohighlight | autocomplete | none
+onChange, onInputValueChange, onOpenChange
+```
+
+## Core Patterns
+
+### Use Combobox for search
+
+Choose Combobox when the user needs to type and filter options. For short
+static enum choices use Select, RadioGroup, or RadioCard.
+
+### Keep items as collection data
+
+Do not render a custom `<ul>` next to Input. The wrapper builds a Zag
+collection from `items` and handles disabled options.
+
+### Use validation props, not border classes
+
+`validateStatus` controls trigger/input border state and `helpText` renders
+StatusText.
+
+## Common Mistakes
+
+### HIGH Native datalist/custom dropdown
+
+Wrong:
+
+```tsx
+<Input list="countries" /><datalist id="countries" />
+```
+
+Correct:
+
+```tsx
+<Combobox items={countries} label="Country" />
+```
+
+Source: libs/ui/src/molecules/combobox.tsx
+
+### HIGH Wrong value shape for multiple
+
+Wrong:
+
+```tsx
+<Combobox multiple value="CZ" />
+```
+
+Correct:
+
+```tsx
+<Combobox multiple value={["CZ"]} />
+```
+
+Source: https://zagjs.com/components/react/combobox
+
+### HIGH Inline dropdown styling
+
+Wrong:
+
+```tsx
+<Combobox className="border-red-500 bg-white" validateStatus="error" />
+```
+
+Correct:
+
+```tsx
+<Combobox validateStatus="error" helpText="Required" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_combobox.css
+
+## Validation Commands
+
+```sh
+rg -n "<datalist|role=\"listbox\"|<Combobox[^>]*multiple[^>]*value=\"" apps
+rg -n "<Combobox[^>]*className=.*(bg-|text-|border-|p-|px-|py-)" apps
+rg -n "<Combobox[^>]*validateStatus=\"(danger|invalid)\"" apps
+```
+

--- a/libs/ui/agent-plugin/skills/component-authoring/SKILL.md
+++ b/libs/ui/agent-plugin/skills/component-authoring/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: component-authoring
+description: >
+  Use when creating or refactoring @techsio/ui-kit React components in libs/ui,
+  including atoms, molecules, organisms, tv() variants, React 19 ref props,
+  component token CSS, Storybook stories, package subpath exports, and Figma
+  handoff reminders.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - tailwind-token-authoring
+  - storybook-authoring
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/README.md"
+  - "libs/ui/src/atoms/button.tsx"
+  - "libs/ui/src/molecules/carousel.tsx"
+  - "libs/ui/src/organisms/header.tsx"
+  - "libs/ui/src/tokens/components/components.css"
+  - "libs/ui/stories/atoms/button.stories.tsx"
+  - "https://github.com/TechsioCZ/new-engine/issues/295"
+---
+
+# @techsio/ui-kit Component Authoring
+
+Use this for work inside `libs/ui`. For app-side usage, load
+`component-usage-ux` instead.
+
+## Setup
+
+Minimum atom shape for new component code:
+
+```tsx
+import type { ButtonHTMLAttributes, Ref } from "react"
+import type { VariantProps } from "tailwind-variants"
+import { tv } from "../utils"
+
+const actionVariants = tv({
+  base: "inline-flex items-center justify-center rounded-action text-action-fg",
+  variants: {
+    variant: {
+      primary: "bg-action-bg-primary",
+      danger: "bg-action-bg-danger",
+    },
+    size: {
+      sm: "h-action-sm p-action-sm text-action-sm",
+      md: "h-action-md p-action-md text-action-md",
+    },
+  },
+  defaultVariants: { variant: "primary", size: "md" },
+})
+
+type ActionProps = ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof actionVariants> & {
+    ref?: Ref<HTMLButtonElement>
+  }
+
+export function Action({ variant, size, className, ref, ...props }: ActionProps) {
+  return (
+    <button
+      className={actionVariants({ variant, size, className })}
+      ref={ref}
+      {...props}
+    />
+  )
+}
+```
+
+Use `type` for new props. Existing `interface` declarations are legacy unless
+the task is a targeted cleanup.
+
+## Core Patterns
+
+### Create the whole component slice
+
+```text
+src/atoms/action.tsx
+src/tokens/components/atoms/_action.css
+src/tokens/components/components.css import
+stories/atoms/action.stories.tsx
+src/atoms/figma/action.figma.tsx follow-up reminder when public
+```
+
+Do not add a TSX component without token CSS and Storybook coverage.
+
+### Keep component classes component-specific
+
+```tsx
+const badgeVariants = tv({
+  base: "rounded-badge bg-badge-bg text-badge-fg px-badge",
+})
+```
+
+Component implementations use component tokens. Semantic tokens like
+`bg-primary` are allowed in Storybook examples, not in component internals.
+
+### Use public subpath imports
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Dialog } from "@techsio/ui-kit/molecules/dialog"
+```
+
+The package has wildcard subpath exports. It does not expose a root barrel.
+
+### Hand off Figma work, do not perform it
+
+```text
+Public component added or public props/visuals changed
+-> mention figma-sync-handoff
+-> that skill points to component-to-figma
+```
+
+Do not invoke Figma tools from component authoring unless the maintainer asks.
+
+## Common Mistakes
+
+### HIGH Component without tokens or story
+
+Wrong:
+
+```text
+Only create src/atoms/banner.tsx.
+```
+
+Correct:
+
+```text
+Create TSX, component token CSS, components.css import, Storybook story, and
+run the relevant validations.
+```
+
+The library treats component code, tokens, and stories as one component slice.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH Semantic Tailwind in component internals
+
+Wrong:
+
+```tsx
+const card = tv({ base: "bg-primary text-fg p-200" })
+```
+
+Correct:
+
+```tsx
+const card = tv({ base: "bg-card-bg text-card-fg p-card" })
+```
+
+Direct semantic tokens in component implementations bypass component-specific
+token aliases and make app overrides harder.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH React 19 ref regression
+
+Wrong:
+
+```tsx
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>((props, ref) => {
+  return <button ref={ref} {...props} />
+})
+```
+
+Correct:
+
+```tsx
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  ref?: Ref<HTMLButtonElement>
+}
+
+export function Button({ ref, ...props }: ButtonProps) {
+  return <button ref={ref} {...props} />
+}
+```
+
+New React 19 components in this library use `ref` as a prop.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM New interface props
+
+Wrong:
+
+```tsx
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: "success" | "danger"
+}
+```
+
+Correct:
+
+```tsx
+export type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  variant?: "success" | "danger"
+}
+```
+
+The current codebase still has legacy interfaces, but new component work should
+follow `AGENTS.md`.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Callback memoization by habit
+
+Wrong:
+
+```tsx
+const onOpenChange = useCallback((details: { open: boolean }) => {
+  setOpen(details.open)
+}, [])
+```
+
+Correct:
+
+```tsx
+const onOpenChange = (details: { open: boolean }) => {
+  setOpen(details.open)
+}
+```
+
+Do not add `useCallback` by habit. Consumer apps are Next 16+ with React
+Compiler; keep memoization for proven identity or performance needs only.
+
+Source: libs/ui/skills/_artifacts/domain_map.yaml
+
+## Validation Commands
+
+```sh
+bunx biome check --write libs/ui/src/atoms/action.tsx libs/ui/stories/atoms/action.stories.tsx
+pnpm --dir libs/ui validate:tokens
+bunx nx run ui:build
+```
+
+Add Storybook/a11y/component visual checks when visuals or interactions change.
+

--- a/libs/ui/agent-plugin/skills/component-consistency-validation/SKILL.md
+++ b/libs/ui/agent-plugin/skills/component-consistency-validation/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: component-consistency-validation
+description: >
+  Use after changing @techsio/ui-kit component TSX, token CSS, Storybook
+  stories, Figma Code Connect files, package exports, or validation scripts.
+  Checks prop/variant/token/story/Figma consistency and recommends focused
+  commands before maintainer handoff.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/package.json"
+  - "libs/ui/project.json"
+  - "libs/ui/.storybook/main.ts"
+  - "libs/ui/scripts/validate-token-usage.js"
+  - "libs/ui/scripts/validate-token-definitions.js"
+  - "libs/ui/scripts/run-component-tests.mjs"
+  - "libs/ui/figma.config.json"
+  - "libs/ui/skills/_artifacts/domain_map.yaml"
+---
+
+# @techsio/ui-kit Component Consistency Validation
+
+Use this as the validation pass after changing a component slice.
+
+## Setup
+
+Pick checks by touched area:
+
+```text
+TSX only      -> Biome + build
+Token CSS     -> token validators + build
+Stories       -> Biome + Storybook build when visual/docs behavior changed
+Zag/compound  -> build + Storybook/a11y or component tests when practical
+Figma mapping -> figma connect parse
+Release       -> ui-kit-publish-readiness
+```
+
+## Core Patterns
+
+### Compare TSX props to stories
+
+```text
+src/atoms/button.tsx:
+  variant: primary | secondary | tertiary | danger | warning
+  theme: solid | light | borderless | outlined | unstyled
+  size: sm | md | lg | current
+
+stories/atoms/button.stories.tsx:
+  argTypes.variant.options must match real variants
+  argTypes.theme.options must match real themes
+  argTypes.size.options must match real sizes
+```
+
+Stories must not document variants or props that the component cannot accept.
+
+### Compare classes to token CSS
+
+```text
+TSX class: bg-button-bg-primary
+CSS token: --color-button-bg-primary
+
+TSX class: p-button-md
+CSS token: --padding-button-md
+```
+
+Use the validators for missing token classes and unused token definitions.
+
+### Check package exports by subpath
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Carousel } from "@techsio/ui-kit/molecules/carousel"
+```
+
+The package exports wildcard subpaths for atoms, molecules, organisms,
+templates, tokens, and utils. Do not expect a root barrel export.
+
+### Check Code Connect when public props change
+
+```sh
+pnpm --dir libs/ui figma:connect:parse
+```
+
+Use `figma-sync-handoff` for follow-up ownership. Do not publish or edit Figma
+unless the maintainer asks.
+
+## Common Mistakes
+
+### HIGH Variant drift between code and docs
+
+Wrong:
+
+```tsx
+argTypes: {
+  variant: { options: ["primary", "ghost"] },
+}
+```
+
+Correct:
+
+```tsx
+argTypes: {
+  variant: { options: ["primary", "secondary", "tertiary", "warning", "danger"] },
+}
+```
+
+Storybook controls are copied by app developers, so undocumented or
+nonexistent options become app bugs.
+
+Source: libs/ui/src/atoms/button.tsx and libs/ui/stories/atoms/button.stories.tsx
+
+### HIGH Token validation ignored
+
+Wrong:
+
+```text
+Add className "z-(--z-index)" and skip token validation.
+```
+
+Correct:
+
+```sh
+pnpm --dir libs/ui validate:tokens
+```
+
+The token usage validator maps Tailwind utility namespaces to required CSS
+custom properties.
+
+Source: libs/ui/scripts/validate-token-usage.js
+
+### HIGH Compound context hole
+
+Wrong:
+
+```tsx
+<Carousel.Next />
+```
+
+Correct:
+
+```tsx
+<Carousel.Root slideCount={3}>
+  <Carousel.Next />
+</Carousel.Root>
+```
+
+Compound children rely on context guards such as
+`Carousel components must be used within Carousel.Root`.
+
+Source: libs/ui/src/molecules/carousel.tsx
+
+## Validation Commands
+
+```sh
+bunx biome check --write libs/ui/src/atoms/button.tsx libs/ui/stories/atoms/button.stories.tsx
+pnpm --dir libs/ui validate:tokens
+bunx nx run ui:build
+pnpm --dir libs/ui figma:connect:parse
+pnpm --dir libs/ui build:storybook
+pnpm --dir libs/ui storybook:a11y
+pnpm --dir libs/ui test:components
+```
+
+Run only commands relevant to the changed area unless the maintainer asks for
+a full readiness pass.
+

--- a/libs/ui/agent-plugin/skills/component-usage-ux/SKILL.md
+++ b/libs/ui/agent-plugin/skills/component-usage-ux/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: component-usage-ux
+description: >
+  Use as the apps/* UI-kit usage orchestrator. Chooses which @techsio/ui-kit
+  component and per-component *-usage skill to load before selecting props,
+  variants, themes, sizes, slots, framework adapters, and token overrides.
+type: composition
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - app-token-overrides
+sources:
+  - "libs/ui/skills/_artifacts/consumer_app_usage_rules.md"
+  - "libs/ui/src/atoms"
+  - "libs/ui/src/molecules"
+  - "libs/ui/src/organisms"
+  - "libs/ui/package.json"
+  - "https://zagjs.com/components/react/combobox"
+---
+
+# @techsio/ui-kit Component Usage UX
+
+Use this in apps. It is a router, not a complete component manual.
+
+## Setup
+
+Find the component and load its usage skill:
+
+```sh
+rg --files libs/ui/src/atoms libs/ui/src/molecules libs/ui/src/organisms
+rg -n "name: .*usage" libs/ui/skills/*/SKILL.md
+```
+
+Then choose the exact skill:
+
+```text
+Button action -> button-usage
+Dialog confirmation -> dialog-usage
+Toast feedback -> toast-usage
+Tree navigation -> tree-view-usage
+Loading placeholder -> skeleton-usage
+```
+
+## Core Patterns
+
+### Start from UX intent
+
+```text
+Destructive action -> Button danger, maybe Dialog confirmation
+CRUD success/error -> Toast or StatusText depending persistence and context
+Hierarchical navigation -> TreeView
+Page trail -> Breadcrumb with framework link adapter when needed
+```
+
+Do not begin by writing native HTML.
+
+### Verify props before use
+
+```sh
+rg -n "variant:|theme:|size:|export type .*Props|export interface .*Props" libs/ui/src/atoms/button.tsx
+```
+
+Never invent props such as `variant="ghost"` unless the component source
+actually supports them.
+
+### Read Zag docs for Zag-backed components
+
+```text
+Combobox usage
+-> read libs/ui/src/molecules/combobox.tsx
+-> read https://zagjs.com/components/react/combobox
+-> compare our wrapper props/slots to Zag machine props and anatomy
+```
+
+Use Zag docs to understand machine capabilities such as collections,
+controlled `value`/`inputValue`, `defaultValue`, `multiple`, disabled items,
+`closeOnSelect`, open state, and required part props. Then use only the API
+that `@techsio/ui-kit` exposes.
+
+### Let tokens handle appearance
+
+```tsx
+<Button variant="danger" theme="solid" size="md">
+  Delete
+</Button>
+```
+
+Do not duplicate the component's background, foreground, padding, radius, or
+font className when props and tokens already provide it.
+
+### Avoid wrappers before API review
+
+```text
+Need NextLink in Breadcrumb?
+-> check Breadcrumb.Link props and Link as prop support
+-> use framework-consumer-integration
+-> wrapper only after proving the component cannot support it
+```
+
+Local wrappers are a last resort.
+
+## Common Mistakes
+
+### HIGH Generic usage without component skill
+
+Wrong:
+
+```text
+Choose Button props from memory and skip button-usage.
+```
+
+Correct:
+
+```text
+Load button-usage, inspect Button props, then choose variant/theme/size.
+```
+
+Usage rules are intentionally per-component because props differ.
+
+Source: libs/ui/skills/_artifacts/skill_spec.md
+
+### HIGH Native or custom primitive
+
+Wrong:
+
+```tsx
+<button className="bg-danger text-white">Delete</button>
+```
+
+Correct:
+
+```tsx
+<Button variant="danger" theme="solid">Delete</Button>
+```
+
+Apps should use UI-kit components when the library already has the primitive.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Hallucinated component prop
+
+Wrong:
+
+```tsx
+<Button variant="ghost">Cancel</Button>
+```
+
+Correct:
+
+```tsx
+<Button theme="borderless">Cancel</Button>
+```
+
+The Button source defines `theme`, not a `ghost` variant.
+
+Source: libs/ui/src/atoms/button.tsx
+
+### HIGH Duplicate prop styling
+
+Wrong:
+
+```tsx
+<Button variant="danger" theme="solid" className="bg-danger text-fg-reverse" />
+```
+
+Correct:
+
+```tsx
+<Button variant="danger" theme="solid" />
+```
+
+Component props already map to token-backed visual classes.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### MEDIUM Wrapper before API check
+
+Wrong:
+
+```tsx
+function AppBreadcrumbLink(props: Props) {
+  return <NextLink className="text-primary underline" {...props} />
+}
+```
+
+Correct:
+
+```tsx
+<Breadcrumb.Link as={NextLink} href="/products">
+  Products
+</Breadcrumb.Link>
+```
+
+Check slots, adapter props, and token overrides before creating wrappers.
+
+Source: libs/ui/src/molecules/breadcrumb.tsx
+
+### MEDIUM Zag docs skipped for interactive usage
+
+Wrong:
+
+```text
+Implement a custom searchable dropdown because Combobox source looks complex.
+```
+
+Correct:
+
+```text
+Read combobox-usage, libs/ui/src/molecules/combobox.tsx, and
+https://zagjs.com/components/react/combobox before deciding whether the UI-kit
+API is missing anything.
+```
+
+Zag docs explain the machine props and anatomy behind our wrapper; skipping
+them causes unnecessary custom primitives.
+
+Source: https://zagjs.com/components/react/combobox
+
+## Validation Commands
+
+```sh
+rg -n '<button|<input|<select|<textarea|animate-pulse|variant="ghost"' apps/<app>
+rg -n 'className=.*(bg-|text-|font-|px-|py-|rounded-)' apps/<app>
+```

--- a/libs/ui/agent-plugin/skills/dialog-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/dialog-usage/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: dialog-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Dialog for
+  modal dialogs, alert dialogs, drawers, actions, focus management, placement,
+  size, and close behavior backed by Zag.js.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/dialog.tsx"
+  - "libs/ui/src/tokens/components/molecules/_dialog.css"
+  - "libs/ui/stories/molecules/dialog.stories.tsx"
+  - "libs/ui/src/molecules/figma/dialog.figma.tsx"
+  - "https://zagjs.com/components/react/dialog"
+---
+
+# @techsio/ui-kit Dialog Usage
+
+Use Dialog for focused overlays and confirmations. Use Popover for lightweight
+anchored content and Tooltip for short supplemental help.
+
+## Setup
+
+```tsx
+import { Dialog } from "@techsio/ui-kit/molecules/dialog"
+import { Button } from "@techsio/ui-kit/atoms/button"
+
+<Dialog
+  role="alertdialog"
+  title="Delete product?"
+  description="This action cannot be undone."
+  actions={<Button variant="danger">Delete</Button>}
+/>
+```
+
+Supported props:
+
+```text
+placement: center | left | right | top | bottom
+size: xs | sm | md | lg | xl | full
+behavior: modal | modeless
+position: fixed | absolute | sticky | relative
+role: dialog | alertdialog
+open, onOpenChange, customTrigger, triggerText, title, description, actions
+closeOnEscape, closeOnInteractOutside, preventScroll, trapFocus, modal, portal
+```
+
+## Core Patterns
+
+### Use alertdialog for destructive confirmation
+
+Use `role="alertdialog"` and a danger Button action for irreversible actions.
+
+### Use placement for drawers
+
+`placement="left" | "right" | "top" | "bottom"` creates drawer behavior with
+size-driven width or height.
+
+### Use tokens for visual changes
+
+Do not patch overlay, padding, width, or close button classes in apps. Override
+dialog tokens when the app theme needs changes.
+
+## Common Mistakes
+
+### HIGH Custom modal
+
+Wrong:
+
+```tsx
+{open && <div className="fixed inset-0"><div role="dialog" /></div>}
+```
+
+Correct:
+
+```tsx
+<Dialog open={open} onOpenChange={setOpenDetails} title="Edit product" />
+```
+
+Source: libs/ui/src/molecules/dialog.tsx
+
+### HIGH Popover used for blocking confirmation
+
+Wrong:
+
+```tsx
+<Popover><Button variant="danger">Delete</Button></Popover>
+```
+
+Correct:
+
+```tsx
+<Dialog role="alertdialog" actions={<Button variant="danger">Delete</Button>} />
+```
+
+### HIGH Inline dialog sizing
+
+Wrong:
+
+```tsx
+<Dialog className="w-[720px] p-8 rounded-xl" />
+```
+
+Correct:
+
+```tsx
+<Dialog size="lg" placement="center" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_dialog.css
+
+## Validation Commands
+
+```sh
+rg -n "role=\"dialog\"|fixed inset-0|alertdialog|<Dialog[^>]*className=.*(w-|h-|p-|rounded-|bg-)" apps
+rg -U -n "<Popover[\\s\\S]{0,300}(Delete|Remove|danger)" apps
+rg -n "<Dialog[^>]*role=\"(modal|drawer)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/figma-sync-handoff/SKILL.md
+++ b/libs/ui/agent-plugin/skills/figma-sync-handoff/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: figma-sync-handoff
+description: >
+  Use when @techsio/ui-kit component work should flag a Figma library or Figma
+  Code Connect follow-up. Prepares a reminder and points to the
+  component-to-figma skill; never edits Figma or runs Figma MCP tools
+  automatically.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/figma.config.json"
+  - "libs/ui/src/atoms/figma/button.figma.tsx"
+  - "libs/ui/src/molecules/figma/dialog.figma.tsx"
+  - ".agents/skills/component-to-figma/SKILL.md"
+---
+
+# @techsio/ui-kit Figma Sync Handoff
+
+Use this after component work changes public visuals, public props, variants,
+tokens, or Code Connect mappings.
+
+## Setup
+
+Figma handoff is reminder-only:
+
+```text
+Changed public component API or visual behavior
+-> mention component-to-figma follow-up
+-> do not call Figma tools
+-> do not publish Code Connect unless maintainer asks
+```
+
+The authoritative workflow is:
+
+```text
+.agents/skills/component-to-figma/SKILL.md
+```
+
+## Core Patterns
+
+### Check Code Connect coverage
+
+```sh
+pnpm --dir libs/ui figma:connect:parse
+```
+
+Use parse as a local consistency check when Code Connect files change.
+
+### Keep Figma props aligned with code props
+
+```tsx
+figma.connect(Button, "https://www.figma.com/design/...", {
+  imports: ['import { Button } from "@techsio/ui-kit/atoms/button"'],
+  props: {
+    variant: figma.enum("variant", {
+      primary: "primary",
+      danger: "danger",
+    }),
+    theme: figma.enum("theme", {
+      solid: "solid",
+      outlined: "outlined",
+    }),
+  },
+})
+```
+
+Public prop additions or renames should trigger a mapping review.
+
+### Preserve token hierarchy in Figma
+
+```text
+primitive/core values -> semantic aliases -> component-specific aliases
+```
+
+Component-specific Figma variables should alias upper-layer variables when the
+code token chain already provides them.
+
+## Common Mistakes
+
+### HIGH Automatic Figma side effect
+
+Wrong:
+
+```text
+After editing Button.tsx, call Figma MCP and update the design file.
+```
+
+Correct:
+
+```text
+Report: "This changes public Button props/visuals. Per figma-sync-handoff,
+consider running component-to-figma."
+```
+
+Figma credentials, active user, and library context may not be available.
+
+Source: libs/ui/skills/_artifacts/domain_map.yaml
+
+### HIGH Raw Figma component variable
+
+Wrong:
+
+```text
+color/button/bg/primary = #009869
+```
+
+Correct:
+
+```text
+color/button/bg/primary -> alias color/primary
+```
+
+Code token architecture is the source of truth for Figma library variables.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Code Connect prop drift
+
+Wrong:
+
+```tsx
+// Button adds theme="unstyled"; button.figma.tsx still omits it.
+```
+
+Correct:
+
+```tsx
+theme: figma.enum("theme", {
+  solid: "solid",
+  light: "light",
+  outlined: "outlined",
+  borderless: "borderless",
+  unstyled: "unstyled",
+})
+```
+
+Figma examples should not teach a stale public API.
+
+Source: libs/ui/src/atoms/figma/button.figma.tsx
+
+## Validation Commands
+
+```sh
+pnpm --dir libs/ui figma:connect:parse
+bunx biome check --write libs/ui/src/atoms/figma/button.figma.tsx
+```
+
+Run `figma:connect:publish` only when the maintainer explicitly asks.

--- a/libs/ui/agent-plugin/skills/footer-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/footer-usage/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: footer-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Footer for
+  site footer composition with container, section, title, list, link, text,
+  divider, bottom area, size, layout, direction, section flow, and framework
+  link adapters.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/organisms/footer.tsx"
+  - "libs/ui/src/tokens/components/organisms/_footer.css"
+  - "libs/ui/stories/organisms/footer.stories.tsx"
+---
+
+# @techsio/ui-kit Footer Usage
+
+Use Footer for global footer layout. Do not build app footers from raw divs and
+anchors when this organism fits.
+
+## Setup
+
+```tsx
+import NextLink from "next/link"
+import { Footer } from "@techsio/ui-kit/organisms/footer"
+
+<Footer size="md">
+  <Footer.Container>
+    <Footer.Section>
+      <Footer.Title>Shop</Footer.Title>
+      <Footer.List>
+        <li><Footer.Link as={NextLink} href="/products">Products</Footer.Link></li>
+      </Footer.List>
+    </Footer.Section>
+    <Footer.Bottom><Footer.Text>(c) Techsio</Footer.Text></Footer.Bottom>
+  </Footer.Container>
+</Footer>
+```
+
+Supported props:
+
+```text
+Footer size: sm | md | lg
+direction: vertical | horizontal
+layout: col | row
+sectionFlow: col | row
+Link: href/external/as framework adapter
+parts: Container, Section, Title, List, Link, Text, Divider, Bottom
+```
+
+## Core Patterns
+
+### Use Footer.Link for footer navigation
+
+It wraps the UI-kit Link atom and supports framework adapters.
+
+### Use sections for groups
+
+Group footer columns with `Footer.Section`, `Footer.Title`, and `Footer.List`.
+
+### Let footer tokens define density
+
+Use `size`, `layout`, and `sectionFlow` instead of local gap/padding classes.
+
+## Common Mistakes
+
+### HIGH Raw footer layout
+
+Wrong:
+
+```tsx
+<footer className="grid gap-8 p-8"><a href="/products">Products</a></footer>
+```
+
+Correct:
+
+```tsx
+<Footer><Footer.Container><Footer.Section><Footer.Link href="/products">Products</Footer.Link></Footer.Section></Footer.Container></Footer>
+```
+
+Source: libs/ui/src/organisms/footer.tsx
+
+### HIGH Missing NextLink adapter
+
+Wrong:
+
+```tsx
+<Footer.Link href="/products">Products</Footer.Link>
+```
+
+Correct in Next:
+
+```tsx
+<Footer.Link as={NextLink} href="/products">Products</Footer.Link>
+```
+
+Source: libs/ui/src/atoms/link.tsx
+
+### HIGH Inline footer spacing/colors
+
+Wrong:
+
+```tsx
+<Footer.Container className="grid grid-cols-4 gap-6 bg-slate-900 p-8" />
+```
+
+Correct:
+
+```tsx
+<Footer layout="col" size="lg"><Footer.Container /></Footer>
+```
+
+Source: libs/ui/src/tokens/components/organisms/_footer.css
+
+## Validation Commands
+
+```sh
+rg -n "<footer\\b|<Footer\\.(Container|Section|Link)[^>]*className=.*(grid|gap-|p-|bg-|text-)" apps
+rg -P -n "<Footer\\.Link(?![^>]*as=\\{?NextLink)" apps
+rg -n "<Footer[^>]*size=\"(xs|xl)\"|layout=\"(grid|columns)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/form-checkbox-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/form-checkbox-usage/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: form-checkbox-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit FormCheckbox
+  for labeled checkbox fields with Zag.js checked/indeterminate state, help
+  text, validation status, required, disabled, and read-only props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/form-checkbox.tsx"
+  - "libs/ui/src/tokens/components/atoms/_checkbox.css"
+  - "libs/ui/stories/molecules/form-checkbox.stories.tsx"
+  - "libs/ui/src/molecules/figma/form-checkbox.figma.tsx"
+  - "https://zagjs.com/components/react/checkbox"
+---
+
+# @techsio/ui-kit FormCheckbox Usage
+
+Use FormCheckbox for checkbox fields with label/help/error structure. Use the
+Checkbox atom only for bare table/list controls.
+
+## Setup
+
+```tsx
+import { FormCheckbox } from "@techsio/ui-kit/molecules/form-checkbox"
+
+<FormCheckbox
+  name="newsletter"
+  label="Send me updates"
+  helpText="You can unsubscribe anytime."
+/>
+```
+
+Supported props:
+
+```text
+checked/defaultChecked, indeterminate, onCheckedChange
+validateStatus: default | error | success | warning
+label or children, helpText, showHelpTextIcon, size sm | md | lg
+name, value, required, disabled, readOnly
+```
+
+## Core Patterns
+
+### Use this for labeled checkbox UX
+
+It wires root, hidden input, control, indicator, label, and StatusText.
+
+### Use indeterminate for partial selection
+
+For parent selection states, pass `indeterminate` and a controlled `checked`
+value.
+
+### Use validateStatus for errors
+
+`validateStatus="error"` maps to Zag invalid state and token styling.
+
+## Common Mistakes
+
+### HIGH Manual checkbox row
+
+Wrong:
+
+```tsx
+<label><Checkbox /> Accept terms</label>
+```
+
+Correct:
+
+```tsx
+<FormCheckbox name="terms" label="Accept terms" required />
+```
+
+Source: libs/ui/src/molecules/form-checkbox.tsx
+
+### HIGH Wrong callback
+
+Wrong:
+
+```tsx
+<FormCheckbox onChange={(e) => setChecked(e.target.checked)} />
+```
+
+Correct:
+
+```tsx
+<FormCheckbox onCheckedChange={setChecked} />
+```
+
+Source: libs/ui/src/molecules/form-checkbox.tsx
+
+### HIGH Inline error classes
+
+Wrong:
+
+```tsx
+<FormCheckbox validateStatus="error" className="text-red-500" />
+```
+
+Correct:
+
+```tsx
+<FormCheckbox validateStatus="error" helpText="Required" />
+```
+
+Source: libs/ui/src/tokens/components/atoms/_checkbox.css
+
+## Validation Commands
+
+```sh
+rg -U -n "<label[\\s\\S]{0,240}<Checkbox|<FormCheckbox[^>]*onChange=|<FormCheckbox[^>]*className=.*(text-|border-|bg-)" apps
+rg -n "<input[^>]*type=\"checkbox\"" apps
+rg -n "<FormCheckbox[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/form-input-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/form-input-usage/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: form-input-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit FormInput for
+  labeled single-line fields with Label, Input, StatusText, validation status,
+  help text, required, disabled, and size props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - input-usage
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/form-input.tsx"
+  - "libs/ui/src/atoms/input.tsx"
+  - "libs/ui/stories/molecules/form-input.stories.tsx"
+  - "libs/ui/src/molecules/figma/form-input.figma.tsx"
+---
+
+# @techsio/ui-kit FormInput Usage
+
+Use FormInput for labeled text-like inputs. Prefer this over manually composing
+Label, Input, and StatusText in apps.
+
+## Setup
+
+```tsx
+import { FormInput } from "@techsio/ui-kit/molecules/form-input"
+
+<FormInput
+  id="email"
+  name="email"
+  type="email"
+  label="Email"
+  validateStatus="default"
+/>
+```
+
+Supported props:
+
+```text
+id: required
+label: ReactNode
+validateStatus: default | error | success | warning
+helpText, showHelpTextIcon
+all Input props except where FormInput sets label/status behavior
+```
+
+## Core Patterns
+
+### Use for complete field rows
+
+If the field needs label, help, or validation text, start with FormInput.
+
+### Use validateStatus instead of Input variant
+
+FormInput maps `validateStatus` to the underlying Input `variant` and
+StatusText status.
+
+### Keep field spacing token-owned
+
+Do not add local `gap`, `mt`, or error text classes around FormInput.
+
+## Common Mistakes
+
+### HIGH Manual field composition
+
+Wrong:
+
+```tsx
+<Label htmlFor="email">Email</Label><Input id="email" /><StatusText>Email required</StatusText>
+```
+
+Correct:
+
+```tsx
+<FormInput id="email" label="Email" helpText="Email required" validateStatus="error" />
+```
+
+Source: libs/ui/src/molecules/form-input.tsx
+
+### HIGH Wrong validation prop
+
+Wrong:
+
+```tsx
+<FormInput id="email" label="Email" variant="error" />
+```
+
+Correct:
+
+```tsx
+<FormInput id="email" label="Email" validateStatus="error" />
+```
+
+Source: libs/ui/src/molecules/form-input.tsx
+
+### HIGH Inline spacing/styling
+
+Wrong:
+
+```tsx
+<FormInput className="mb-4 border-red-500" id="email" label="Email" />
+```
+
+Correct:
+
+```tsx
+<FormInput id="email" label="Email" validateStatus="error" />
+```
+
+Source: libs/ui/src/molecules/form-input.tsx
+
+## Validation Commands
+
+```sh
+rg -U -n "<Label[\\s\\S]{0,240}<Input|<FormInput[^>]*variant=|<FormInput[^>]*className=.*(mb-|mt-|gap-|border-|text-)" apps
+rg -P -n "<FormInput(?![^>]*id=)|<FormInput(?![^>]*label=)" apps
+rg -n "<FormInput[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/form-numeric-input-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/form-numeric-input-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: form-numeric-input-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit
+  FormNumericInput for labeled numeric fields using NumericInput compound
+  children, validation status, help text, and number-specific constraints.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - numeric-input-usage
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/form-numeric-input.tsx"
+  - "libs/ui/src/atoms/numeric-input.tsx"
+  - "libs/ui/stories/molecules/form-numeric-input.stories.tsx"
+  - "libs/ui/src/molecules/figma/form-numeric-input.figma.tsx"
+  - "https://zagjs.com/components/react/number-input"
+---
+
+# @techsio/ui-kit FormNumericInput Usage
+
+Use FormNumericInput for labeled quantities, limits, prices, or measurements.
+It requires NumericInput compound children.
+
+## Setup
+
+```tsx
+<FormNumericInput id="qty" label="Quantity" min={1} defaultValue={1}>
+  <NumericInput.Control>
+    <NumericInput.Input />
+    <NumericInput.TriggerContainer>
+      <NumericInput.IncrementTrigger />
+      <NumericInput.DecrementTrigger />
+    </NumericInput.TriggerContainer>
+  </NumericInput.Control>
+</FormNumericInput>
+```
+
+Supported props:
+
+```text
+id: required
+label: ReactNode
+children: NumericInput compound parts
+validateStatus: default | error | success | warning
+helpText, showHelpTextIcon
+NumericInputProps excluding children
+```
+
+## Core Patterns
+
+### Keep NumericInput anatomy inside
+
+Do not pass plain `<input>` or native buttons as children. Use NumericInput
+parts.
+
+### Express domain constraints with props
+
+Use `min`, `max`, `step`, `precision`, and `locale`, not custom blur parsing.
+
+### Use validateStatus for errors
+
+FormNumericInput maps `validateStatus="error"` to `invalid` on NumericInput.
+
+## Common Mistakes
+
+### HIGH Missing NumericInput children
+
+Wrong:
+
+```tsx
+<FormNumericInput id="qty" label="Quantity" />
+```
+
+Correct:
+
+```tsx
+<FormNumericInput id="qty" label="Quantity"><NumericInput.Control><NumericInput.Input /></NumericInput.Control></FormNumericInput>
+```
+
+Source: libs/ui/src/molecules/form-numeric-input.tsx
+
+### HIGH Native number field
+
+Wrong:
+
+```tsx
+<FormInput id="qty" label="Quantity" type="number" />
+```
+
+Correct:
+
+```tsx
+<FormNumericInput id="qty" label="Quantity" min={1} />
+```
+
+Source: libs/ui/src/atoms/numeric-input.tsx
+
+### HIGH String value
+
+Wrong:
+
+```tsx
+<FormNumericInput id="qty" label="Quantity" value="1" />
+```
+
+Correct:
+
+```tsx
+<FormNumericInput id="qty" label="Quantity" value={1} />
+```
+
+Source: libs/ui/src/atoms/numeric-input.tsx
+
+## Validation Commands
+
+```sh
+rg -U -P -n "type=\"number\"|<FormNumericInput[^>]*value=\"|<FormNumericInput(?![\\s\\S]{0,500}<NumericInput\\.Input)" apps
+rg -P -n "<FormNumericInput(?![^>]*id=)|<FormNumericInput(?![^>]*label=)" apps
+rg -n "<FormNumericInput[^>]*className=.*(border-|text-|px-|py-|gap-)" apps
+```

--- a/libs/ui/agent-plugin/skills/form-textarea-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/form-textarea-usage/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: form-textarea-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit FormTextarea
+  for labeled multi-line text fields with Textarea, Label, StatusText,
+  validation status, help text, size, resize, required, and disabled props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - textarea-usage
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/form-textarea.tsx"
+  - "libs/ui/src/atoms/textarea.tsx"
+  - "libs/ui/stories/molecules/form-textarea.stories.tsx"
+  - "libs/ui/src/molecules/figma/form-textarea.figma.tsx"
+---
+
+# @techsio/ui-kit FormTextarea Usage
+
+Use FormTextarea for labeled long text fields such as notes, comments, and
+descriptions.
+
+## Setup
+
+```tsx
+import { FormTextarea } from "@techsio/ui-kit/molecules/form-textarea"
+
+<FormTextarea
+  id="description"
+  label="Description"
+  resize="y"
+  validateStatus="default"
+/>
+```
+
+Supported props:
+
+```text
+id: required
+label: ReactNode
+validateStatus: default | error | success | warning
+helpText, showHelpTextIcon
+Textarea props: size, resize, readonly, required, disabled
+```
+
+## Core Patterns
+
+### Use for complete textarea fields
+
+Prefer FormTextarea over manual Label + Textarea + StatusText composition.
+
+### Use validateStatus for field state
+
+FormTextarea maps validation to Textarea variant and StatusText.
+
+### Use Textarea resize API
+
+Choose `resize="y" | "none" | "auto"` from layout needs, not custom classes.
+
+## Common Mistakes
+
+### HIGH Manual textarea field
+
+Wrong:
+
+```tsx
+<Label htmlFor="note">Note</Label><Textarea id="note" /><p className="text-red-500">Required</p>
+```
+
+Correct:
+
+```tsx
+<FormTextarea id="note" label="Note" helpText="Required" validateStatus="error" />
+```
+
+Source: libs/ui/src/molecules/form-textarea.tsx
+
+### HIGH Wrong validation prop
+
+Wrong:
+
+```tsx
+<FormTextarea id="note" label="Note" variant="error" />
+```
+
+Correct:
+
+```tsx
+<FormTextarea id="note" label="Note" validateStatus="error" />
+```
+
+Source: libs/ui/src/molecules/form-textarea.tsx
+
+### HIGH Inline textarea styling
+
+Wrong:
+
+```tsx
+<FormTextarea id="note" label="Note" className="border-red-500 p-4" />
+```
+
+Correct:
+
+```tsx
+<FormTextarea id="note" label="Note" validateStatus="error" />
+```
+
+Source: libs/ui/src/tokens/components/atoms/_textarea.css
+
+## Validation Commands
+
+```sh
+rg -U -n "<Label[\\s\\S]{0,240}<Textarea|<textarea\\b|<FormTextarea[^>]*variant=" apps
+rg -P -n "<FormTextarea(?![^>]*id=)|<FormTextarea(?![^>]*label=)" apps
+rg -n "<FormTextarea[^>]*className=.*(border-|bg-|text-|p-|px-|py-)" apps
+```

--- a/libs/ui/agent-plugin/skills/framework-consumer-integration/SKILL.md
+++ b/libs/ui/agent-plugin/skills/framework-consumer-integration/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: framework-consumer-integration
+description: >
+  Use when consuming @techsio/ui-kit in framework apps, especially Next.js 16+
+  with React Compiler, NextLink, NextImage, token CSS imports, polymorphic `as`
+  props, adapter prop forwarding, and wrapper-avoidance checks.
+type: framework
+framework: react
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+sources:
+  - "libs/ui/skills/_artifacts/consumer_app_usage_rules.md"
+  - "libs/ui/package.json"
+  - "libs/ui/src/atoms/link.tsx"
+  - "libs/ui/src/atoms/link-button.tsx"
+  - "libs/ui/src/atoms/image.tsx"
+  - "libs/ui/src/molecules/breadcrumb.tsx"
+  - "libs/ui/src/molecules/pagination.tsx"
+---
+
+This skill builds on `component-usage-ux`. Read it first for component
+selection before applying framework adapters.
+
+# @techsio/ui-kit Framework Consumer Integration
+
+Use this in React/Next app consumers.
+
+## Setup
+
+Next apps should prefer framework-native adapters:
+
+```tsx
+import NextImage from "next/image"
+import NextLink from "next/link"
+import { Image } from "@techsio/ui-kit/atoms/image"
+import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
+
+export function ProductCta() {
+  return (
+    <>
+      <Image alt="Product" as={NextImage} height={320} src="/product.jpg" width={320} />
+      <LinkButton as={NextLink} href="/products">
+        View products
+      </LinkButton>
+    </>
+  )
+}
+```
+
+## Core Patterns
+
+### Use agnostic Link and Image as adapter-capable primitives
+
+```tsx
+<Image as={NextImage} alt="Hero" height={600} src="/hero.jpg" width={1200} />
+<LinkButton as={NextLink} href="/checkout">Checkout</LinkButton>
+```
+
+In Next apps, default to `NextImage` and `NextLink` when rendering app pages.
+
+### Pass adapters through molecules
+
+```tsx
+<Breadcrumb.Link as={NextLink} href="/products">
+  Products
+</Breadcrumb.Link>
+```
+
+Molecules should preserve link/image props instead of forcing native anchors or
+images.
+
+### Avoid memoization cargo-culting
+
+```text
+Next 16+ apps use React Compiler.
+Do not add useCallback/useMemo around UI-kit handlers by default.
+```
+
+Only memoize when a real identity or performance issue is proven.
+
+## Common Mistakes
+
+### HIGH Agnostic Link/Image used directly in Next
+
+Wrong:
+
+```tsx
+<Image alt="Product" src="/product.jpg" />
+<Link href="/products">Products</Link>
+```
+
+Correct:
+
+```tsx
+<Image as={NextImage} alt="Product" height={320} src="/product.jpg" width={320} />
+<LinkButton as={NextLink} href="/products">Products</LinkButton>
+```
+
+UI-kit Link/Image are framework-agnostic; Next apps should use adapters.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Missing token imports
+
+Wrong:
+
+```css
+/* app global CSS has no UI-kit token import */
+```
+
+Correct:
+
+```css
+@import "@techsio/ui-kit/tokens-with-tailwind";
+```
+
+UI-kit component classes need the token CSS loaded in the app.
+
+Source: libs/ui/package.json
+
+### HIGH Adapter prop mismatch
+
+Wrong:
+
+```tsx
+<Breadcrumb.Link href={{ pathname: "/products" } as string}>
+  Products
+</Breadcrumb.Link>
+```
+
+Correct:
+
+```tsx
+<Breadcrumb.Link as={NextLink} href={{ pathname: "/products" }}>
+  Products
+</Breadcrumb.Link>
+```
+
+The generic `as` prop lets framework href types flow from the adapter.
+
+Source: libs/ui/src/molecules/breadcrumb.tsx
+
+### MEDIUM Wrapper before API check
+
+Wrong:
+
+```tsx
+function NextLinkButton(props: NextLinkProps) {
+  return <NextLink className="bg-primary px-200" {...props} />
+}
+```
+
+Correct:
+
+```tsx
+<LinkButton as={NextLink} href="/account" variant="primary" theme="solid">
+  Account
+</LinkButton>
+```
+
+Do not create wrappers until supported adapter props and UI-kit props have been
+checked.
+
+Source: libs/ui/src/atoms/link-button.tsx
+
+## Validation Commands
+
+```sh
+rg -n '@techsio/ui-kit/atoms/(link|image)|<Link |<Image ' apps/<app>
+rg -n 'as=\\{Next(Link|Image)\\}|from "next/(link|image)"' apps/<app>
+rg -n '@techsio/ui-kit/tokens' apps/<app>
+```
+

--- a/libs/ui/agent-plugin/skills/gallery-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/gallery-usage/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: gallery-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Gallery for
+  product or media image galleries with Carousel integration, thumbnails,
+  controlled page, orientation, thumbnail image adapters, thumbnail aria labels,
+  empty state, and NextImage support.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - carousel-usage
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/organisms/gallery.tsx"
+  - "libs/ui/src/tokens/components/organisms/_gallery.css"
+  - "libs/ui/stories/organisms/gallery.stories.tsx"
+---
+
+# @techsio/ui-kit Gallery Usage
+
+Use Gallery for product or media galleries with thumbnails. Use Carousel
+directly when thumbnails are not part of the UX.
+
+## Setup
+
+```tsx
+import NextImage from "next/image"
+import { Gallery } from "@techsio/ui-kit/organisms/gallery"
+
+<Gallery
+  items={items}
+  thumbnailImageAs={NextImage}
+  carouselProps={{ imageAs: NextImage, aspectRatio: "square", size: "full" }}
+>
+  <Gallery.Main><Gallery.Carousel /></Gallery.Main>
+  <Gallery.Thumbnails />
+</Gallery>
+```
+
+Supported props:
+
+```text
+items: GalleryItem[]
+orientation: horizontal | vertical
+value/defaultValue, onValueChange
+showThumbnails, hideThumbnailsWhenSingle, thumbnailSize
+thumbnailImageAs, getThumbnailAriaLabel, carouselProps, emptyState
+parts: Main, Thumbnails, Thumbnail, Carousel, Slides
+```
+
+## Core Patterns
+
+### Use Gallery for thumbnail UX
+
+It coordinates active page state between thumbnails and Carousel.
+
+### Use NextImage adapters in Next apps
+
+Pass `thumbnailImageAs={NextImage}` and `carouselProps.imageAs`.
+
+### Keep thumbnail labels meaningful
+
+Override `getThumbnailAriaLabel` when "Show slide N" is not enough.
+
+## Common Mistakes
+
+### HIGH Custom thumbnail state
+
+Wrong:
+
+```tsx
+<img src={items[active].src} />{items.map((item, i) => <button onClick={() => setActive(i)} />)}
+```
+
+Correct:
+
+```tsx
+<Gallery items={items}><Gallery.Main><Gallery.Carousel /></Gallery.Main><Gallery.Thumbnails /></Gallery>
+```
+
+Source: libs/ui/src/organisms/gallery.tsx
+
+### HIGH Carousel used when thumbnails required
+
+Wrong:
+
+```tsx
+<Carousel slideCount={items.length}><Carousel.Slides slides={items} /></Carousel>
+```
+
+Correct:
+
+```tsx
+<Gallery items={items}><Gallery.Carousel /><Gallery.Thumbnails /></Gallery>
+```
+
+Source: libs/ui/src/organisms/gallery.tsx
+
+### HIGH Inline thumbnail styling
+
+Wrong:
+
+```tsx
+<Gallery.Thumbnail className="h-16 w-16 rounded border" />
+```
+
+Correct:
+
+```tsx
+<Gallery thumbnailSize={64}><Gallery.Thumbnails /></Gallery>
+```
+
+Source: libs/ui/src/tokens/components/organisms/_gallery.css
+
+## Validation Commands
+
+```sh
+rg -n "setActive|setPage|<Gallery\\.Thumbnail[^>]*className=.*(h-|w-|rounded-|border-)" apps
+rg -U -P -n "<Gallery(?![\\s\\S]{0,800}<Gallery\\.Thumbnails)" apps
+rg -P -n "<Gallery(?![^>]*(thumbnailImageAs|carouselProps=\\{\\{[^}]*imageAs))" apps
+```

--- a/libs/ui/agent-plugin/skills/header-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/header-usage/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: header-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Header for
+  responsive site header composition with desktop/mobile sections, containers,
+  nav, nav items, actions, hamburger, active state, size, direction, and token
+  styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/organisms/header.tsx"
+  - "libs/ui/src/tokens/components/organisms/_header.css"
+  - "libs/ui/stories/organisms/header.stories.tsx"
+---
+
+# @techsio/ui-kit Header Usage
+
+Use Header for global page header/navigation layout. Compose it with Link or
+LinkButton for actual navigation items.
+
+## Setup
+
+```tsx
+<Header size="md">
+  <Header.Desktop>
+    <Header.Container position="start">
+      <Header.Nav>
+        <Header.NavItem active><Link as={NextLink} href="/">Home</Link></Header.NavItem>
+      </Header.Nav>
+      <Header.Actions><Header.ActionItem><Button>Account</Button></Header.ActionItem></Header.Actions>
+    </Header.Container>
+  </Header.Desktop>
+  <Header.Hamburger />
+  <Header.Mobile position="right">{/* mobile nav */}</Header.Mobile>
+</Header>
+```
+
+Supported props:
+
+```text
+Header size: sm | md | lg
+direction: vertical | horizontal
+Container position: start | center | end
+Mobile position: left | right
+NavItem active
+parts: Desktop, Mobile, Container, Nav, NavItem, Actions, ActionItem, Hamburger
+```
+
+## Core Patterns
+
+### Use Header.Hamburger for mobile menu state
+
+Do not duplicate mobile state externally unless the current Header API cannot
+support the UX.
+
+### Put links/buttons inside slots
+
+Header slots provide layout and token styling; Link/LinkButton/Button provide
+navigation/action semantics.
+
+### Use active on NavItem
+
+Set `active` based on current route; do not style active nav with classes.
+
+## Common Mistakes
+
+### HIGH Raw responsive header
+
+Wrong:
+
+```tsx
+<header className="flex justify-between"><button onClick={toggle}>Menu</button></header>
+```
+
+Correct:
+
+```tsx
+<Header><Header.Hamburger /><Header.Mobile /></Header>
+```
+
+Source: libs/ui/src/organisms/header.tsx
+
+### HIGH Active nav styled inline
+
+Wrong:
+
+```tsx
+<Header.NavItem className="font-bold text-primary">Home</Header.NavItem>
+```
+
+Correct:
+
+```tsx
+<Header.NavItem active>Home</Header.NavItem>
+```
+
+Source: libs/ui/src/tokens/components/organisms/_header.css
+
+### HIGH Native nav action instead of component
+
+Wrong:
+
+```tsx
+<a className="px-3 py-2" href="/cart">Cart</a>
+```
+
+Correct:
+
+```tsx
+<Link as={NextLink} href="/cart">Cart</Link>
+```
+
+## Validation Commands
+
+```sh
+rg -n "<header\\b|setIsMobileMenuOpen|toggleMobile|<Header\\.NavItem[^>]*className=.*(font-|text-|bg-)" apps
+rg -n "<a[^>]*href=|<Header\\.Hamburger|<Header\\.Mobile" apps
+rg -n "<Header[^>]*size=\"(xs|xl)\"|position=\"(left|right)\".*Header\\.Container" apps
+```
+

--- a/libs/ui/agent-plugin/skills/icon-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/icon-usage/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: icon-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Icon tokens or
+  Iconify classes with the library's supported size and semantic color props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/icon.tsx"
+  - "libs/ui/src/tokens/components/atoms/_icon.css"
+  - "libs/ui/stories/atoms/icon.stories.tsx"
+  - "libs/ui/src/atoms/figma/icon.figma.tsx"
+---
+
+# @techsio/ui-kit Icon Usage
+
+Use Icon for decorative or component-adjacent icons. The Icon atom renders
+`aria-hidden`, so it must not be the only accessible content for an action.
+
+## Setup
+
+```tsx
+import { Icon } from "@techsio/ui-kit/atoms/icon"
+
+<Icon icon="token-icon-status-text-success" size="md" color="success" />
+```
+
+Supported props:
+
+```text
+icon: token-icon-${string} | icon-[${string}]
+size: current | xs | sm | md | lg | xl | 2xl
+color: current | primary | secondary | danger | success | warning
+```
+
+## Core Patterns
+
+### Prefer token icons for UI-kit semantics
+
+```tsx
+<Icon icon="token-icon-status-text-warning" color="warning" />
+```
+
+Use `icon-[...]` for specific Iconify icons only when there is no token icon
+for that component state.
+
+### Match icon size to component size
+
+```tsx
+<Button icon="token-icon-button-add" iconSize="sm">
+  Add
+</Button>
+```
+
+When a component has an `icon` prop, use that prop instead of placing a
+separate Icon next to text.
+
+### Provide accessible text outside Icon
+
+```tsx
+<Button aria-label="Search" icon="icon-[mdi--magnify]" />
+```
+
+Icon itself is decorative. The parent action or surrounding text carries the
+accessible name.
+
+## Common Mistakes
+
+### HIGH Inline SVG instead of token/icon class
+
+Wrong:
+
+```tsx
+<svg className="h-4 w-4 text-green-600" />
+```
+
+Correct:
+
+```tsx
+<Icon icon="token-icon-status-text-success" size="sm" color="success" />
+```
+
+Source: libs/ui/src/atoms/icon.tsx
+
+### HIGH Icon-only button without accessible name
+
+Wrong:
+
+```tsx
+<Button icon="icon-[mdi--trash-can-outline]" />
+```
+
+Correct:
+
+```tsx
+<Button aria-label="Delete" icon="icon-[mdi--trash-can-outline]" />
+```
+
+The icon is `aria-hidden`.
+
+Source: libs/ui/src/atoms/icon.tsx
+
+### MEDIUM Arbitrary color class
+
+Wrong:
+
+```tsx
+<Icon icon="icon-[mdi--alert]" className="text-red-500" />
+```
+
+Correct:
+
+```tsx
+<Icon icon="token-icon-status-text-error" color="danger" />
+```
+
+Change component or semantic tokens when the app needs different color mapping.
+
+### MEDIUM Separate Icon beside Button text
+
+Wrong:
+
+```tsx
+<Button>
+  <Icon icon="icon-[mdi--plus]" />
+  Add
+</Button>
+```
+
+Correct:
+
+```tsx
+<Button icon="icon-[mdi--plus]">Add</Button>
+```
+
+Use component icon props when they exist.
+
+## Validation Commands
+
+```sh
+rg -n "<svg|<Icon[^>]*className=.*(text-|size-|h-|w-)" apps
+rg -n "<Button[^>]*>\\s*<Icon" apps
+rg -P -n "<Button(?![^>]*aria-label)[^>]*icon=" apps
+rg -P -n "icon=\"(?!token-icon-|icon-\\[)" apps
+```

--- a/libs/ui/agent-plugin/skills/image-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/image-usage/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: image-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Image or a
+  framework image adapter such as NextImage through the Image atom's as prop.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/image.tsx"
+  - "libs/ui/src/tokens/components/atoms/_image.css"
+  - "libs/ui/stories/atoms/image.stories.tsx"
+  - "libs/ui/src/atoms/figma/image.figma.tsx"
+---
+
+# @techsio/ui-kit Image Usage
+
+Use Image when the UI-kit or a molecule needs a framework-agnostic image slot.
+In Next apps, prefer NextImage through `as` when the app needs framework image
+optimization.
+
+## Setup
+
+```tsx
+import NextImage from "next/image"
+import { Image } from "@techsio/ui-kit/atoms/image"
+
+<Image as={NextImage} src="/product.jpg" alt="Ceramic bowl" size="full" />
+```
+
+Supported props:
+
+```text
+as: component accepting src and alt
+src: string
+alt: string
+size: sm | md | lg | full | custom
+```
+
+## Core Patterns
+
+### Use NextImage adapter in Next apps
+
+```tsx
+<Image
+  as={NextImage}
+  src={product.image}
+  alt={product.title}
+  size="full"
+/>
+```
+
+The UI-kit Image is intentionally framework agnostic. Let the app framework
+provide image behavior when available.
+
+### Use size prop before layout className
+
+```tsx
+<Image src={avatarUrl} alt={name} size="sm" />
+```
+
+Use `size="custom"` only when layout constraints must come from the parent or
+component token overrides.
+
+### Keep alt text meaningful
+
+```tsx
+<Image src={product.image} alt={product.title} />
+```
+
+Empty alt is only for decorative images, and that should be a deliberate
+accessibility choice.
+
+## Common Mistakes
+
+### HIGH Raw img in app UI
+
+Wrong:
+
+```tsx
+<img src={product.image} alt={product.title} className="rounded-lg" />
+```
+
+Correct:
+
+```tsx
+<Image as={NextImage} src={product.image} alt={product.title} size="full" />
+```
+
+Source: libs/ui/src/atoms/image.tsx
+
+### HIGH Styling the component shape inline
+
+Wrong:
+
+```tsx
+<Image src="/avatar.jpg" alt="Avatar" className="h-10 w-10 rounded-full" />
+```
+
+Correct:
+
+```tsx
+<Image src="/avatar.jpg" alt="Avatar" size="sm" />
+```
+
+Use Image size/tokens first. Use layout classes only around the component when
+the image is part of a larger layout.
+
+Source: libs/ui/src/tokens/components/atoms/_image.css
+
+### MEDIUM Next app without framework adapter
+
+Wrong:
+
+```tsx
+<Image src="/hero.jpg" alt="Hero" />
+```
+
+Correct:
+
+```tsx
+<Image as={NextImage} src="/hero.jpg" alt="Hero" size="full" />
+```
+
+In Next apps, default to NextImage unless the image is intentionally plain.
+
+### MEDIUM Missing useful alt
+
+Wrong:
+
+```tsx
+<Image src={product.image} alt="" />
+```
+
+Correct:
+
+```tsx
+<Image src={product.image} alt={product.title} />
+```
+
+## Validation Commands
+
+```sh
+rg -n "<img\\b|<Image[^>]*className=.*(rounded-|h-|w-|object-)" apps
+rg -P -n "<Image(?![^>]*alt=)" apps
+rg -P -n "<Image(?![^>]*as=\\{?NextImage)" apps
+rg -n "from \"next/image\"|from '@techsio/ui-kit/atoms/image'" apps
+```

--- a/libs/ui/agent-plugin/skills/input-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/input-usage/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: input-usage
+description: >
+  Use after component-usage-ux when an app needs the low-level
+  @techsio/ui-kit Input atom, including valid size, variant, embedded button
+  spacing, and token-first validation styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/input.tsx"
+  - "libs/ui/src/molecules/form-input.tsx"
+  - "libs/ui/src/tokens/components/atoms/_input.css"
+  - "libs/ui/stories/atoms/input.stories.tsx"
+  - "libs/ui/src/atoms/figma/input.figma.tsx"
+---
+
+# @techsio/ui-kit Input Usage
+
+Use Input for a bare text-like control. Use `FormInput` when the UI includes a
+label, helper text, validation text, or full form-field spacing.
+
+## Setup
+
+```tsx
+import { Input } from "@techsio/ui-kit/atoms/input"
+
+<Input name="email" type="email" variant="default" size="md" />
+```
+
+Supported component-specific props:
+
+```text
+variant: default | error | success | warning
+size: sm | md | lg
+withButtonInside: false | right | left
+hideSearchClear: boolean
+disabled: native boolean
+```
+
+## Core Patterns
+
+### Prefer form molecules for fields
+
+```tsx
+<FormInput
+  name="email"
+  label="Email"
+  type="email"
+  helperText="We will send the receipt here."
+/>
+```
+
+Use Input directly only when layout/label/error is already handled by a parent
+component.
+
+### Use variant for validation state
+
+```tsx
+<Input aria-describedby="email-error" variant="error" />
+```
+
+Do not style border or placeholder error colors in JSX.
+
+### Use withButtonInside for embedded actions
+
+```tsx
+<Input withButtonInside="right" type="search" />
+```
+
+This prop adjusts input spacing for an action inside the field. Do not fake it
+with arbitrary padding classes.
+
+## Common Mistakes
+
+### HIGH Native input
+
+Wrong:
+
+```tsx
+<input className="border px-3 py-2" />
+```
+
+Correct:
+
+```tsx
+<Input size="md" />
+```
+
+Source: libs/ui/src/atoms/input.tsx
+
+### HIGH Nonexistent variant
+
+Wrong:
+
+```tsx
+<Input variant="danger" />
+```
+
+Correct:
+
+```tsx
+<Input variant="error" />
+```
+
+Source: libs/ui/src/atoms/input.tsx
+
+### HIGH Inline validation styling
+
+Wrong:
+
+```tsx
+<Input className="border-red-500 placeholder:text-red-400" />
+```
+
+Correct:
+
+```tsx
+<Input variant="error" />
+```
+
+If the error color is wrong for the app, change app token overrides.
+
+Source: libs/ui/src/tokens/components/atoms/_input.css
+
+### MEDIUM Manual label/error composition
+
+Wrong:
+
+```tsx
+<Label htmlFor="email">Email</Label>
+<Input id="email" />
+<p className="text-red-500">Required</p>
+```
+
+Correct:
+
+```tsx
+<FormInput id="email" label="Email" errorText="Required" variant="error" />
+```
+
+Use the form molecule when it exists.
+
+## Validation Commands
+
+```sh
+rg -n "<input\\b|variant=\"(danger|invalid|primary)\"" apps
+rg -n "<Input[^>]*className=.*(border-|bg-|text-|placeholder:|px-|py-)" apps
+rg -U -n "<Label[\\s\\S]{0,240}<Input" apps
+rg -n "withButtonInside|hideSearchClear" apps
+```

--- a/libs/ui/agent-plugin/skills/intent-skill-maintenance/SKILL.md
+++ b/libs/ui/agent-plugin/skills/intent-skill-maintenance/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: intent-skill-maintenance
+description: >
+  Use when @techsio/ui-kit component APIs, token rules, Storybook rules, app
+  usage patterns, Figma handoff practices, validation commands, or generated
+  skills change and the TanStack Intent skill artifacts or SKILL.md files need
+  review or regeneration.
+type: lifecycle
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/skills/_artifacts/domain_map.yaml"
+  - "libs/ui/skills/_artifacts/skill_spec.md"
+  - "libs/ui/skills/_artifacts/skill_tree.yaml"
+  - "package:@tanstack/intent@0.0.41/meta/domain-discovery"
+  - "package:@tanstack/intent@0.0.41/meta/tree-generator"
+  - "package:@tanstack/intent@0.0.41/meta/generate-skill"
+---
+
+# @techsio/ui-kit Intent Skill Maintenance
+
+Use this when skills may be stale.
+
+## Setup
+
+Check the change type:
+
+```text
+New/changed component prop, variant, theme, size, slot, token, story rule,
+framework adapter rule, Figma handoff rule, validation command, or app usage
+pattern
+-> review affected skills
+```
+
+Use TanStack Intent meta-skills in order when regenerating the tree:
+
+```text
+1. domain-discovery
+2. tree-generator
+3. generate-skill
+```
+
+## Core Patterns
+
+### Update source artifacts first
+
+```text
+skills/_artifacts/domain_map.yaml
+skills/_artifacts/skill_spec.md
+skills/_artifacts/skill_tree.yaml
+```
+
+Do not patch many `SKILL.md` files from memory when the source artifacts are
+stale.
+
+### Keep examples grounded
+
+```text
+Use examples from libs/ui/src, libs/ui/stories, libs/ui/src/tokens, scripts,
+consumer_app_usage_rules.md, and maintainer interview evidence.
+```
+
+Generic React or Storybook advice is not enough for this library.
+
+### Propose skill updates during normal work
+
+```text
+Button adds theme="ghost"
+-> update button-usage
+-> update component-usage-ux if routing changes
+-> update Storybook and Figma handoff skills if public docs/mapping change
+```
+
+Skill maintenance can be advisory unless the user asks to update skills now.
+
+## Common Mistakes
+
+### HIGH Stale skill after API change
+
+Wrong:
+
+```text
+Add Button theme="ghost" and leave button-usage warning that ghost is invalid.
+```
+
+Correct:
+
+```text
+Update component source, stories, Figma mapping, and affected usage skills
+together.
+```
+
+Skills must track the public API they teach.
+
+Source: libs/ui/skills/_artifacts/domain_map.yaml
+
+### HIGH Meta-skill order skipped
+
+Wrong:
+
+```text
+Regenerate skill files without checking domain_map.yaml or skill_tree.yaml.
+```
+
+Correct:
+
+```text
+Re-read domain_map.yaml and skill_tree.yaml, then generate or surgically update
+affected SKILL.md files.
+```
+
+The artifacts are the source of truth for generated skill structure.
+
+Source: libs/ui/skills/_artifacts/skill_tree.yaml
+
+### MEDIUM Generic skill drift
+
+Wrong:
+
+```text
+Write broad "React component best practices" with no ui-kit sources.
+```
+
+Correct:
+
+```text
+Tie every rule to libs/ui code, AGENTS.md, token scripts, Storybook stories,
+consumer usage rules, or maintainer interview findings.
+```
+
+Skills are loaded into coding agents, so local specificity matters.
+
+Source: libs/ui/skills/_artifacts/skill_spec.md
+
+## Validation Commands
+
+```sh
+node -e 'const fs=require("node:fs"); const YAML=require("yaml"); YAML.parse(fs.readFileSync("libs/ui/skills/_artifacts/domain_map.yaml","utf8")); YAML.parse(fs.readFileSync("libs/ui/skills/_artifacts/skill_tree.yaml","utf8"))'
+rg -n '^name:|^description:|^type:|^library_version:' libs/ui/skills
+```

--- a/libs/ui/agent-plugin/skills/label-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/label-usage/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: label-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Label for
+  form-control labels with valid size, disabled, required, and htmlFor usage.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/label.tsx"
+  - "libs/ui/src/tokens/components/atoms/_label.css"
+  - "libs/ui/src/atoms/figma/label.figma.tsx"
+---
+
+# @techsio/ui-kit Label Usage
+
+Use Label for standalone form-control labels. Prefer form molecules when the
+whole field structure is available.
+
+## Setup
+
+```tsx
+import { Label } from "@techsio/ui-kit/atoms/label"
+
+<Label htmlFor="email" required>
+  Email
+</Label>
+```
+
+Supported props:
+
+```text
+size: sm | md | lg | current
+disabled: boolean
+required: boolean
+htmlFor: native label target
+```
+
+## Core Patterns
+
+### Pair Label with the control id
+
+```tsx
+<Label htmlFor="email">Email</Label>
+<Input id="email" name="email" />
+```
+
+Use `htmlFor` unless the control is explicitly nested.
+
+### Use required prop for required marker
+
+```tsx
+<Label htmlFor="email" required>
+  Email
+</Label>
+```
+
+Do not manually add a red star.
+
+### Keep size aligned with the field
+
+```tsx
+<Label htmlFor="email" size="sm">Email</Label>
+<Input id="email" size="sm" />
+```
+
+Use `size="current"` only inside components that inherit text sizing.
+
+## Common Mistakes
+
+### HIGH Native label with hardcoded styling
+
+Wrong:
+
+```tsx
+<label className="text-sm font-medium text-gray-700">Email</label>
+```
+
+Correct:
+
+```tsx
+<Label htmlFor="email">Email</Label>
+```
+
+Source: libs/ui/src/atoms/label.tsx
+
+### HIGH Manual required marker
+
+Wrong:
+
+```tsx
+<Label htmlFor="email">Email <span className="text-red-500">*</span></Label>
+```
+
+Correct:
+
+```tsx
+<Label htmlFor="email" required>Email</Label>
+```
+
+Source: libs/ui/src/tokens/components/atoms/_label.css
+
+### MEDIUM Missing association
+
+Wrong:
+
+```tsx
+<Label>Email</Label>
+<Input id="email" />
+```
+
+Correct:
+
+```tsx
+<Label htmlFor="email">Email</Label>
+<Input id="email" />
+```
+
+### MEDIUM Field built manually when molecule exists
+
+Wrong:
+
+```tsx
+<Label htmlFor="email">Email</Label>
+<Input id="email" />
+```
+
+Correct when helper/error/layout is part of the field:
+
+```tsx
+<FormInput id="email" label="Email" />
+```
+
+## Validation Commands
+
+```sh
+rg -n "<label\\b|<Label[^>]*className=.*(text-|font-|mb-|gap-)" apps
+rg -P -n "<Label(?![^>]*htmlFor=)" apps
+rg -n "<span[^>]*>\\*</span>|text-red-500.*\\*" apps
+rg -U -n "<Label[\\s\\S]{0,240}<Input" apps
+```

--- a/libs/ui/agent-plugin/skills/link-button-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/link-button-usage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: link-button-usage
+description: >
+  Use after component-usage-ux when navigation should look like a Button using
+  @techsio/ui-kit LinkButton, including framework link adapters, href, disabled
+  state, icons, and Button-compatible variants/themes/sizes.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/link-button.tsx"
+  - "libs/ui/src/atoms/link.tsx"
+  - "libs/ui/src/atoms/button.tsx"
+  - "libs/ui/src/tokens/components/atoms/_button.css"
+  - "libs/ui/src/atoms/figma/link-button.figma.tsx"
+---
+
+# @techsio/ui-kit LinkButton Usage
+
+Use LinkButton for navigation that needs Button styling. Use Button for
+actions that stay in the current page state.
+
+## Setup
+
+```tsx
+import NextLink from "next/link"
+import { LinkButton } from "@techsio/ui-kit/atoms/link-button"
+
+<LinkButton as={NextLink} href="/products" variant="primary" theme="solid">
+  Products
+</LinkButton>
+```
+
+Supported LinkButton-specific props:
+
+```text
+as: React element type
+href: string
+disabled: boolean
+variant/theme/size/block/uppercase: Button visual props
+icon/iconPosition/iconSize: Button icon props
+```
+
+## Core Patterns
+
+### Use for navigational CTA
+
+```tsx
+<LinkButton as={NextLink} href="/checkout" variant="primary">
+  Checkout
+</LinkButton>
+```
+
+If clicking submits, deletes, saves, opens a dialog, or mutates state, use
+Button instead.
+
+### Use framework adapters directly
+
+```tsx
+<LinkButton as={NextLink} href="/account/orders" theme="outlined">
+  Orders
+</LinkButton>
+```
+
+Do not create a local wrapper until `framework-consumer-integration` proves the
+component cannot accept the framework prop shape.
+
+### Reuse Button visual semantics
+
+```text
+danger -> destructive navigation such as leave/cancel flow
+borderless -> low-emphasis navigation action
+current -> inherit size from parent surface
+```
+
+The visual props come from Button variants and tokens.
+
+## Common Mistakes
+
+### HIGH Button used for route navigation
+
+Wrong:
+
+```tsx
+<Button onClick={() => router.push("/products")}>Products</Button>
+```
+
+Correct:
+
+```tsx
+<LinkButton as={NextLink} href="/products">Products</LinkButton>
+```
+
+Source: libs/ui/src/atoms/link-button.tsx
+
+### HIGH Native anchor styled like a button
+
+Wrong:
+
+```tsx
+<a href="/checkout" className="rounded bg-primary px-4 py-2 text-white">
+  Checkout
+</a>
+```
+
+Correct:
+
+```tsx
+<LinkButton as={NextLink} href="/checkout" variant="primary">
+  Checkout
+</LinkButton>
+```
+
+Source: libs/ui/src/tokens/components/atoms/_button.css
+
+### HIGH Hallucinated button prop
+
+Wrong:
+
+```tsx
+<LinkButton href="/help" variant="ghost">Help</LinkButton>
+```
+
+Correct:
+
+```tsx
+<LinkButton href="/help" variant="secondary" theme="borderless">
+  Help
+</LinkButton>
+```
+
+Source: libs/ui/src/atoms/button.tsx
+
+### MEDIUM Wrapper before adapter check
+
+Wrong:
+
+```tsx
+function AppLinkButton(props: Props) {
+  return <NextLink className="btn-primary" {...props} />
+}
+```
+
+Correct:
+
+```tsx
+<LinkButton as={NextLink} href="/profile">Profile</LinkButton>
+```
+
+## Validation Commands
+
+```sh
+rg -n "<Button[^>]*onClick=.*router\\.push|<a[^>]*className=.*(bg-|px-|py-)" apps
+rg -n "<LinkButton[^>]*variant=\"ghost\"" apps
+rg -n "<LinkButton[^>]*className=.*(bg-|text-|px-|py-|rounded-|border-)" apps
+rg -n "function .*LinkButton|const .*LinkButton" apps
+```
+

--- a/libs/ui/agent-plugin/skills/link-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/link-usage/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: link-usage
+description: >
+  Use after component-usage-ux when an app needs the low-level
+  @techsio/ui-kit Link atom for inline or unstyled navigation, including
+  external links and framework adapter usage.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+sources:
+  - "libs/ui/src/atoms/link.tsx"
+  - "libs/ui/src/atoms/link-button.tsx"
+  - "libs/ui/src/atoms/figma/link.figma.tsx"
+---
+
+# @techsio/ui-kit Link Usage
+
+Use Link for inline navigation or when a molecule needs a framework-agnostic
+link. Use LinkButton when the link should look like a button.
+
+## Setup
+
+```tsx
+import NextLink from "next/link"
+import { Link } from "@techsio/ui-kit/atoms/link"
+
+<Link as={NextLink} href="/terms">
+  Terms
+</Link>
+```
+
+Supported props:
+
+```text
+as: React element type
+external: boolean
+href and other props from the chosen element/component
+```
+
+## Core Patterns
+
+### Use external for off-site links
+
+```tsx
+<Link href="https://example.com" external>
+  External docs
+</Link>
+```
+
+`external` sets safe target/rel defaults unless they are explicitly supplied.
+
+### Use NextLink in Next apps
+
+```tsx
+<Link as={NextLink} href="/account">
+  Account
+</Link>
+```
+
+Default to the framework link adapter in Next apps.
+
+### Escalate styled CTA to LinkButton
+
+```tsx
+<LinkButton as={NextLink} href="/checkout" variant="primary">
+  Checkout
+</LinkButton>
+```
+
+Do not build button visual styling on top of Link.
+
+## Common Mistakes
+
+### HIGH Native anchor for normal app link
+
+Wrong:
+
+```tsx
+<a href="/account">Account</a>
+```
+
+Correct:
+
+```tsx
+<Link as={NextLink} href="/account">Account</Link>
+```
+
+Source: libs/ui/src/atoms/link.tsx
+
+### HIGH Link styled as button
+
+Wrong:
+
+```tsx
+<Link href="/checkout" className="rounded bg-primary px-4 py-2 text-white">
+  Checkout
+</Link>
+```
+
+Correct:
+
+```tsx
+<LinkButton href="/checkout" variant="primary">Checkout</LinkButton>
+```
+
+Source: libs/ui/src/atoms/link-button.tsx
+
+### MEDIUM External link without external prop
+
+Wrong:
+
+```tsx
+<Link href="https://vendor.example">Vendor</Link>
+```
+
+Correct:
+
+```tsx
+<Link href="https://vendor.example" external>Vendor</Link>
+```
+
+Source: libs/ui/src/atoms/link.tsx
+
+### MEDIUM Custom framework wrapper
+
+Wrong:
+
+```tsx
+const AppLink = (props: Props) => <NextLink className="underline" {...props} />
+```
+
+Correct:
+
+```tsx
+<Link as={NextLink} href="/blog">Blog</Link>
+```
+
+## Validation Commands
+
+```sh
+rg -n "<a\\b|<Link[^>]*className=.*(bg-|px-|py-|rounded-)" apps
+rg -P -n "<Link[^>]*href=\"https?://(?![^>]*external)" apps
+rg -n "function .*Link|const .*Link" apps
+rg -n "<LinkButton|<Link\\b" apps
+```

--- a/libs/ui/agent-plugin/skills/menu-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/menu-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: menu-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Menu for
+  action, radio, checkbox, separator, or submenu items using the Zag.js menu
+  wrapper, Button trigger, icons, and supported open/highlight/select props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/menu.tsx"
+  - "libs/ui/src/tokens/components/molecules/_menu.css"
+  - "libs/ui/stories/molecules/menu.stories.tsx"
+  - "libs/ui/src/molecules/figma/menu.figma.tsx"
+  - "https://zagjs.com/components/react/menu"
+---
+
+# @techsio/ui-kit Menu Usage
+
+Use Menu for contextual command lists. Use Select for choosing a value in a
+form, Tabs for switching panels, and Popover for custom content.
+
+## Setup
+
+```tsx
+import { Menu, type MenuItem } from "@techsio/ui-kit/molecules/menu"
+
+const items: MenuItem[] = [
+  { type: "action", value: "edit", label: "Edit", icon: "token-icon-edit" },
+  { type: "separator", id: "main" },
+  { type: "action", value: "delete", label: "Delete" },
+]
+
+<Menu items={items} onSelect={({ value }) => runAction(value)} />
+```
+
+Supported item types:
+
+```text
+action: value, label, icon, disabled
+radio: value, label, name, checked
+checkbox: value, label, checked
+separator: id
+submenu: value, label, icon, disabled, items
+```
+
+## Core Patterns
+
+### Model menu items as data
+
+Use `MenuItem[]`; do not render custom `<li>` elements in apps.
+
+### Use menu for commands
+
+Menu actions should trigger commands. For destructive commands, pair with
+Dialog confirmation when needed.
+
+### Use customTrigger carefully
+
+Prefer the default Button trigger. If custom trigger is needed, pass a valid
+React element so Zag trigger props can be cloned onto it.
+
+## Common Mistakes
+
+### HIGH Custom dropdown command list
+
+Wrong:
+
+```tsx
+<Button onClick={toggle}>Actions</Button>{open && <ul><li>Edit</li></ul>}
+```
+
+Correct:
+
+```tsx
+<Menu items={items} onSelect={handleSelect} />
+```
+
+Source: libs/ui/src/molecules/menu.tsx
+
+### HIGH Invented item type
+
+Wrong:
+
+```tsx
+{ type: "danger", value: "delete", label: "Delete" }
+```
+
+Correct:
+
+```tsx
+{ type: "action", value: "delete", label: "Delete" }
+```
+
+Source: libs/ui/src/molecules/menu.tsx
+
+### HIGH Inline item styling
+
+Wrong:
+
+```tsx
+<Menu items={items} className="rounded bg-white p-2 shadow" />
+```
+
+Correct:
+
+```tsx
+<Menu items={items} size="md" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_menu.css
+
+## Validation Commands
+
+```sh
+rg -n "role=\"menu\"|<ul[^>]*className=.*(absolute|shadow)|type: \"(danger|link|item)\"" apps
+rg -n "<Menu[^>]*className=.*(bg-|text-|rounded-|p-|shadow-)" apps
+rg -n "customTrigger=|type: \"submenu\"|onCheckedChange" apps
+```
+

--- a/libs/ui/agent-plugin/skills/numeric-input-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/numeric-input-usage/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: numeric-input-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit NumericInput
+  for accessible number entry with Zag.js spinbutton behavior, compound parts,
+  numeric public values, locale formatting, min/max/step, and token-first
+  styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/numeric-input.tsx"
+  - "libs/ui/src/tokens/components/atoms/_numeric-input.css"
+  - "libs/ui/stories/atoms/numeric-input.stories.tsx"
+  - "libs/ui/src/atoms/figma/numeric-input.figma.tsx"
+  - "https://zagjs.com/components/react/number-input"
+---
+
+# @techsio/ui-kit NumericInput Usage
+
+Use NumericInput for quantities, percentages, currency-like values, or bounded
+numbers where keyboard, wheel, increment/decrement, and validation behavior
+matter.
+
+## Setup
+
+```tsx
+import { NumericInput } from "@techsio/ui-kit/atoms/numeric-input"
+
+<NumericInput id="quantity" name="quantity" defaultValue={1} min={1} step={1}>
+  <NumericInput.Control>
+    <NumericInput.Input />
+    <NumericInput.TriggerContainer>
+      <NumericInput.IncrementTrigger />
+      <NumericInput.DecrementTrigger />
+    </NumericInput.TriggerContainer>
+  </NumericInput.Control>
+</NumericInput>
+```
+
+Public wrapper props use numbers:
+
+```text
+value/defaultValue: number
+onChange: (value: number) => void
+size: sm | md | lg
+locale: string, default cs-CZ
+precision, min, max, step, name, disabled, required, invalid
+allowMouseWheel, allowOverflow, clampValueOnBlur, spinOnPress, formatOptions
+```
+
+## Core Patterns
+
+### Keep the compound anatomy intact
+
+```tsx
+<NumericInput defaultValue={50} min={0} max={100}>
+  <NumericInput.Control>
+    <NumericInput.Input />
+    <NumericInput.TriggerContainer>
+      <NumericInput.IncrementTrigger />
+      <NumericInput.DecrementTrigger />
+    </NumericInput.TriggerContainer>
+  </NumericInput.Control>
+</NumericInput>
+```
+
+Do not replace trigger parts with native buttons. The subcomponents spread Zag
+part props and use Button/Input tokens.
+
+### Respect wrapper value types
+
+Zag number-input documents string values internally, but this UI-kit wrapper
+converts public `number` values to the Zag string format and calls `onChange`
+with `valueAsNumber`.
+
+```tsx
+const [quantity, setQuantity] = useState(1)
+
+<NumericInput value={quantity} onChange={setQuantity} min={1} />
+```
+
+### Use locale and precision deliberately
+
+```tsx
+<NumericInput
+  defaultValue={12.5}
+  locale="cs-CZ"
+  precision={1}
+  step={0.1}
+/>
+```
+
+Use `formatOptions` for currency/percent formatting only after checking that
+the output is still a usable input value.
+
+### Use describedBy for external help/error text
+
+```tsx
+<NumericInput id="stock" describedBy="stock-help" invalid>
+  <NumericInput.Control>
+    <NumericInput.Input />
+  </NumericInput.Control>
+</NumericInput>
+```
+
+`describedBy` is merged into the input `aria-describedby`.
+
+## Common Mistakes
+
+### HIGH Passing Zag string values to the wrapper
+
+Wrong:
+
+```tsx
+<NumericInput value="10" onValueChange={setValue} />
+```
+
+Correct:
+
+```tsx
+<NumericInput value={10} onChange={setValue} />
+```
+
+Source: libs/ui/src/atoms/numeric-input.tsx
+
+### HIGH Custom steppers
+
+Wrong:
+
+```tsx
+<NumericInput defaultValue={1}>
+  <Input />
+  <button>+</button>
+</NumericInput>
+```
+
+Correct:
+
+```tsx
+<NumericInput defaultValue={1}>
+  <NumericInput.Control>
+    <NumericInput.Input />
+    <NumericInput.TriggerContainer>
+      <NumericInput.IncrementTrigger />
+      <NumericInput.DecrementTrigger />
+    </NumericInput.TriggerContainer>
+  </NumericInput.Control>
+</NumericInput>
+```
+
+Source: https://zagjs.com/components/react/number-input
+
+### HIGH Inline sizing/color classes
+
+Wrong:
+
+```tsx
+<NumericInput className="w-24 text-sm">
+  <NumericInput.Control className="border-red-500 px-2">
+    <NumericInput.Input />
+  </NumericInput.Control>
+</NumericInput>
+```
+
+Correct:
+
+```tsx
+<NumericInput size="sm" invalid>
+  <NumericInput.Control>
+    <NumericInput.Input />
+  </NumericInput.Control>
+</NumericInput>
+```
+
+Source: libs/ui/src/tokens/components/atoms/_numeric-input.css
+
+### MEDIUM Missing min/max semantics
+
+Wrong:
+
+```tsx
+<NumericInput defaultValue={1} />
+```
+
+Correct for a quantity:
+
+```tsx
+<NumericInput defaultValue={1} min={1} step={1} />
+```
+
+Use min/max/step to express domain constraints, not custom blur handlers.
+
+## Validation Commands
+
+```sh
+rg -n "<input[^>]*type=\"number\"|<NumericInput\\b(?!\\.)[^>]*(onValueChange|value=\")" apps
+rg -U -n "<NumericInput\\b(?!\\.)[\\s\\S]{0,400}<button|<NumericInput\\b(?!\\.)[\\s\\S]{0,400}<Input" apps
+rg -n "<NumericInput\\b(?!\\.)[^>]*className=.*(bg-|text-|border-|px-|py-)" apps
+rg -U -P -n "<NumericInput\\b(?!\\.)(?![\\s\\S]{0,600}<NumericInput\\.Input)" apps
+```

--- a/libs/ui/agent-plugin/skills/pagination-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/pagination-usage/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: pagination-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Pagination for
+  link-based paginated navigation with Zag.js pagination, getPageUrl,
+  LinkButton, NextLink adapters, compact mode, variants, and sizes.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/pagination.tsx"
+  - "libs/ui/src/tokens/components/molecules/_pagination.css"
+  - "libs/ui/stories/molecules/pagination.stories.tsx"
+  - "libs/ui/src/molecules/figma/pagination.figma.tsx"
+  - "https://zagjs.com/components/react/pagination"
+---
+
+# @techsio/ui-kit Pagination Usage
+
+Use Pagination for page-based navigation. Do not use it for infinite scroll or
+stepper/wizard progress.
+
+## Setup
+
+```tsx
+import NextLink from "next/link"
+import { Pagination, createPaginationGetPageUrl } from "@techsio/ui-kit/molecules/pagination"
+
+<Pagination
+  count={120}
+  pageSize={12}
+  linkAs={NextLink}
+  getPageUrl={createPaginationGetPageUrl({ pathname: "/products", searchParams })}
+/>
+```
+
+Supported props:
+
+```text
+count: total items, pageSize, page/defaultPage
+getPageUrl: required link generator
+linkAs, linkProps for framework adapters
+variant: filled | outlined | minimal
+size: sm | md | lg
+compact, compactLabel, showPrevNext, siblingCount, boundaryCount
+onChange/onPageChange, translations
+```
+
+## Core Patterns
+
+### Always provide getPageUrl
+
+Pagination is link-based. Use `createPaginationGetPageUrl` to preserve query
+params and avoid ad hoc URL string handling.
+
+### Use NextLink in Next apps
+
+Pass `linkAs={NextLink}`; do not wrap individual page links.
+
+### Use compact for constrained surfaces
+
+Compact mode displays text instead of every page item.
+
+## Common Mistakes
+
+### HIGH Button-only pagination
+
+Wrong:
+
+```tsx
+<button onClick={() => setPage(page + 1)}>Next</button>
+```
+
+Correct:
+
+```tsx
+<Pagination count={count} pageSize={pageSize} getPageUrl={getPageUrl} />
+```
+
+Source: libs/ui/src/molecules/pagination.tsx
+
+### HIGH Missing getPageUrl
+
+Wrong:
+
+```tsx
+<Pagination count={100} />
+```
+
+Correct:
+
+```tsx
+<Pagination count={100} getPageUrl={getPageUrl} />
+```
+
+Source: libs/ui/src/molecules/pagination.tsx
+
+### HIGH Inline page button styling
+
+Wrong:
+
+```tsx
+<Pagination className="flex gap-2 text-sm" />
+```
+
+Correct:
+
+```tsx
+<Pagination variant="outlined" size="sm" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_pagination.css
+
+## Validation Commands
+
+```sh
+rg -P -n "<Pagination(?![^>]*getPageUrl=)|<Pagination[^>]*className=.*(gap-|text-|bg-|border-|p-)" apps
+rg -P -n "<Pagination(?![^>]*linkAs=\\{?NextLink)" apps
+rg -n "createPaginationGetPageUrl|compactLabel|siblingCount|boundaryCount" apps
+```

--- a/libs/ui/agent-plugin/skills/phone-input-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/phone-input-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: phone-input-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit PhoneInput for
+  international phone entry with country selection, libphonenumber details,
+  hidden E.164 form value, native validation, validation status, and compound
+  country picker slots.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - select-usage
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/phone-input.tsx"
+  - "libs/ui/src/tokens/components/molecules/_phone-input.css"
+  - "libs/ui/stories/molecules/phone-input.stories.tsx"
+---
+
+# @techsio/ui-kit PhoneInput Usage
+
+Use PhoneInput for telephone fields. Do not compose country Select and Input
+manually.
+
+## Setup
+
+```tsx
+import { PhoneInput } from "@techsio/ui-kit/molecules/phone-input"
+
+<PhoneInput name="phone" defaultCountry="CZ" onValueChange={setPhoneDetails}>
+  <PhoneInput.Label>Phone</PhoneInput.Label>
+  <PhoneInput.Control>
+    <PhoneInput.CountryPicker />
+    <PhoneInput.Input />
+  </PhoneInput.Control>
+</PhoneInput>
+```
+
+Supported root props:
+
+```text
+countries, country/defaultCountry, value/defaultValue
+name, countryName, form
+required, disabled, readOnly, nativeValidation, nativeValidationMessage
+validateStatus: default | error | success | warning
+onValueChange(details), onCountryChange(details)
+size: sm | md | lg
+```
+
+## Core Patterns
+
+### Use the compound parts
+
+Use `Label`, `Control`, `CountryPicker` or lower-level country slots, and
+`Input`.
+
+### Consume structured details
+
+`onValueChange` gives `value`, `e164`, `country`, `callingCode`,
+`nationalNumber`, `isPossible`, and `isValid`.
+
+### Let PhoneInput own country selection
+
+It uses Select internally for countries and syncs country from typed values.
+
+## Common Mistakes
+
+### HIGH Native tel input only
+
+Wrong:
+
+```tsx
+<Input type="tel" name="phone" />
+```
+
+Correct:
+
+```tsx
+<PhoneInput name="phone"><PhoneInput.Control><PhoneInput.CountryPicker /><PhoneInput.Input /></PhoneInput.Control></PhoneInput>
+```
+
+Source: libs/ui/src/molecules/phone-input.tsx
+
+### HIGH Manual country select wrapper
+
+Wrong:
+
+```tsx
+<Select items={countries} /><Input type="tel" />
+```
+
+Correct:
+
+```tsx
+<PhoneInput.CountryPicker />
+```
+
+Source: libs/ui/src/molecules/phone-input.tsx
+
+### HIGH Inline validation styling
+
+Wrong:
+
+```tsx
+<PhoneInput validateStatus="error" className="border-red-500" />
+```
+
+Correct:
+
+```tsx
+<PhoneInput validateStatus="error" nativeValidation />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_phone-input.css
+
+## Validation Commands
+
+```sh
+rg -n "type=\"tel\"|<PhoneInput\\b(?!\\.)[^>]*className=.*(border-|bg-|text-|p-)" apps
+rg -U -P -n "<PhoneInput\\b(?!\\.)(?![\\s\\S]{0,600}<PhoneInput\\.Input)" apps
+rg -n "<PhoneInput\\b(?!\\.)[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/popover-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/popover-usage/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: popover-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Popover for
+  anchored non-blocking content using Zag.js compound parts, placement,
+  portalling, close behavior, arrow, title, description, and close trigger.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/popover.tsx"
+  - "libs/ui/src/tokens/components/molecules/_popover.css"
+  - "libs/ui/stories/molecules/popover.stories.tsx"
+  - "libs/ui/src/molecules/figma/popover.figma.tsx"
+  - "https://zagjs.com/components/react/popover"
+---
+
+# @techsio/ui-kit Popover Usage
+
+Use Popover for anchored, dismissible content. Use Dialog for modal flows and
+Tooltip for tiny supplemental text.
+
+## Setup
+
+```tsx
+import { Popover } from "@techsio/ui-kit/molecules/popover"
+
+<Popover placement="bottom-end">
+  <Popover.Trigger>Filters</Popover.Trigger>
+  <Popover.Positioner>
+    <Popover.Content>
+      <Popover.Arrow />
+      <Popover.Title>Filters</Popover.Title>
+      <Popover.Description>Refine results.</Popover.Description>
+      <Popover.CloseTrigger />
+    </Popover.Content>
+  </Popover.Positioner>
+</Popover>
+```
+
+Supported root props:
+
+```text
+size sm | md | lg, shadow, border
+placement, gutter, offset, flip, sameWidth, slide, overflowPadding
+open/defaultOpen, onOpenChange, modal, portalled
+closeOnEscape, closeOnInteractOutside, autoFocus
+```
+
+## Core Patterns
+
+### Keep positioner/content anatomy
+
+`Popover.Positioner` conditionally renders and portals content. Do not move
+Content outside the root.
+
+### Use for non-blocking anchored content
+
+Filters, small menus with custom controls, and contextual panels fit Popover.
+Confirmations and forms that must trap focus should use Dialog.
+
+### Use close trigger for explicit close
+
+`Popover.CloseTrigger` wires Zag close behavior and supplies a token close icon.
+
+## Common Mistakes
+
+### HIGH Custom positioned panel
+
+Wrong:
+
+```tsx
+<div className="absolute right-0 top-full rounded bg-white shadow" />
+```
+
+Correct:
+
+```tsx
+<Popover><Popover.Trigger>Open</Popover.Trigger><Popover.Positioner><Popover.Content /></Popover.Positioner></Popover>
+```
+
+Source: libs/ui/src/molecules/popover.tsx
+
+### HIGH Dialog-worthy content in Popover
+
+Wrong:
+
+```tsx
+<Popover><FormInput id="email" label="Email" /></Popover>
+```
+
+Correct:
+
+```tsx
+<Dialog title="Edit email">{/* form */}</Dialog>
+```
+
+### HIGH Inline panel visuals
+
+Wrong:
+
+```tsx
+<Popover.Content className="bg-white p-4 shadow-xl rounded-xl" />
+```
+
+Correct:
+
+```tsx
+<Popover size="md" shadow border />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_popover.css
+
+## Validation Commands
+
+```sh
+rg -n "absolute.*top-full|<Popover\\.Content[^>]*className=.*(bg-|p-|rounded-|shadow-)" apps
+rg -U -P -n "<Popover(?![\\s\\S]{0,500}<Popover\\.Positioner)" apps
+rg -U -n "<Popover[\\s\\S]{0,400}<Form(Input|Textarea|Checkbox)" apps
+```

--- a/libs/ui/agent-plugin/skills/product-card-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/product-card-usage/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: product-card-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit ProductCard
+  for product summaries with image adapter, name, price, stock, badges,
+  rating, actions, and card button variants.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - framework-consumer-integration
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/product-card.tsx"
+  - "libs/ui/src/tokens/components/molecules/_product-card.css"
+  - "libs/ui/stories/molecules/product-card.stories.tsx"
+  - "libs/ui/src/molecules/figma/product-card.figma.tsx"
+---
+
+# @techsio/ui-kit ProductCard Usage
+
+Use ProductCard for product listing and recommendation surfaces. It is a
+compound component; do not rebuild product card structure with generic divs.
+
+## Setup
+
+```tsx
+<ProductCard layout="column">
+  <ProductCard.Image as={NextImage} src={product.image} alt={product.title} />
+  <ProductCard.Name>{product.title}</ProductCard.Name>
+  <ProductCard.Price>{price}</ProductCard.Price>
+  <ProductCard.Stock status="in-stock">In stock</ProductCard.Stock>
+  <ProductCard.Actions><ProductCard.Button buttonVariant="cart">Add</ProductCard.Button></ProductCard.Actions>
+</ProductCard>
+```
+
+Supported parts:
+
+```text
+Root layout: column | row
+Image as adapter
+Stock status: in-stock | limited-stock | out-of-stock
+Button buttonVariant: cart | detail | wishlist | custom
+Badges, Rating, Actions, Name, Price
+```
+
+## Core Patterns
+
+### Use slots for meaning
+
+Name, Price, Stock, Rating, Badges, Actions and Button each map to component
+tokens. Do not replace them with local headings and paragraphs.
+
+### Use NextImage adapter in Next apps
+
+Pass `as={NextImage}` to `ProductCard.Image`.
+
+### Choose buttonVariant by action
+
+Use `cart` for add-to-cart, `detail` for details, `wishlist` for wishlist
+actions, and `custom` only when tokens/API cannot express the action.
+
+## Common Mistakes
+
+### HIGH Custom product card
+
+Wrong:
+
+```tsx
+<div className="rounded border p-4"><img /><h3>{name}</h3></div>
+```
+
+Correct:
+
+```tsx
+<ProductCard><ProductCard.Image /><ProductCard.Name>{name}</ProductCard.Name></ProductCard>
+```
+
+Source: libs/ui/src/molecules/product-card.tsx
+
+### HIGH Wrong stock status
+
+Wrong:
+
+```tsx
+<ProductCard.Stock status="available">Available</ProductCard.Stock>
+```
+
+Correct:
+
+```tsx
+<ProductCard.Stock status="in-stock">Available</ProductCard.Stock>
+```
+
+Source: libs/ui/src/molecules/product-card.tsx
+
+### HIGH Inline card styling
+
+Wrong:
+
+```tsx
+<ProductCard className="rounded-xl border p-6 shadow" />
+```
+
+Correct:
+
+```tsx
+<ProductCard layout="column" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_product-card.css
+
+## Validation Commands
+
+```sh
+rg -U -n "<img\\b[\\s\\S]{0,500}<h3|<ProductCard[^>]*className=.*(rounded-|border-|p-|shadow-)" apps
+rg -n "status=\"(available|sold-out|low-stock)\"|buttonVariant=\"(primary|danger)\"" apps
+rg -P -n "<ProductCard\\.Image(?![^>]*as=\\{?NextImage)" apps
+```

--- a/libs/ui/agent-plugin/skills/radio-card-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/radio-card-usage/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: radio-card-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit RadioCard for
+  prominent single-choice cards with Zag.js radio behavior, label, item,
+  hidden input, control, text, description, addon, indicator, and status text.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/radio-card.tsx"
+  - "libs/ui/src/tokens/components/molecules/_radio-card.css"
+  - "libs/ui/stories/molecules/radio-card.stories.tsx"
+  - "libs/ui/src/molecules/figma/radio-card.figma.tsx"
+  - "https://zagjs.com/components/react/radio-group"
+---
+
+# @techsio/ui-kit RadioCard Usage
+
+Use RadioCard for prominent exclusive choices with title, description, or addon
+content. Use RadioGroup for simple text options.
+
+## Setup
+
+```tsx
+<RadioCard name="shipping" defaultValue="standard" variant="outline">
+  <RadioCard.Label>Shipping method</RadioCard.Label>
+  <RadioCard.Item value="standard">
+    <RadioCard.ItemHiddenInput />
+    <RadioCard.ItemControl>
+      <RadioCard.ItemContent>
+        <RadioCard.ItemText>Standard</RadioCard.ItemText>
+        <RadioCard.ItemDescription>3-5 business days</RadioCard.ItemDescription>
+      </RadioCard.ItemContent>
+      <RadioCard.ItemIndicator />
+    </RadioCard.ItemControl>
+  </RadioCard.Item>
+</RadioCard>
+```
+
+Supported props:
+
+```text
+variant: outline | subtle | solid
+size: sm | md | lg
+itemOrientation: horizontal | vertical
+align: start | center | end
+justify: start | center | end | between
+validateStatus: default | error | success | warning
+orientation, value/defaultValue, disabled, required, onValueChange
+```
+
+## Core Patterns
+
+### Use for rich options
+
+Plans, delivery methods, payment methods, and selectable cards belong here.
+
+### Keep item hidden input
+
+Each item should include `RadioCard.ItemHiddenInput` for form behavior.
+
+### Use StatusText part for field status
+
+Use `RadioCard.StatusText` instead of external paragraphs for validation.
+
+## Common Mistakes
+
+### HIGH Selectable div cards
+
+Wrong:
+
+```tsx
+<div onClick={() => setPlan("pro")} className="border p-4" />
+```
+
+Correct:
+
+```tsx
+<RadioCard.Item value="pro"><RadioCard.ItemHiddenInput /></RadioCard.Item>
+```
+
+Source: libs/ui/src/molecules/radio-card.tsx
+
+### HIGH Missing hidden input
+
+Wrong:
+
+```tsx
+<RadioCard.Item value="pro"><RadioCard.ItemText>Pro</RadioCard.ItemText></RadioCard.Item>
+```
+
+Correct:
+
+```tsx
+<RadioCard.Item value="pro"><RadioCard.ItemHiddenInput /><RadioCard.ItemControl /></RadioCard.Item>
+```
+
+Source: https://zagjs.com/components/react/radio-group
+
+### HIGH Inline selected styling
+
+Wrong:
+
+```tsx
+<RadioCard.Item className="border-primary bg-primary/10" value="pro" />
+```
+
+Correct:
+
+```tsx
+<RadioCard variant="subtle"><RadioCard.Item value="pro" /></RadioCard>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_radio-card.css
+
+## Validation Commands
+
+```sh
+rg -U -P -n "onClick=.*set.*(Plan|Method)|<RadioCard\\.Item(?![\\s\\S]{0,300}<RadioCard\\.ItemHiddenInput)" apps
+rg -n "<RadioCard[^>]*variant=\"(primary|outlined)\"|<RadioCard[^>]*className=.*(border-|bg-|p-)" apps
+rg -n "<RadioCard[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/radio-group-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/radio-group-usage/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: radio-group-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit RadioGroup for
+  simple exclusive choices with Zag.js radio behavior, label, item group,
+  hidden inputs, controls, text, descriptions, validation status, variants, and
+  sizes.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/radio-group.tsx"
+  - "libs/ui/src/tokens/components/molecules/_radio-group.css"
+  - "libs/ui/stories/molecules/radio-group.stories.tsx"
+  - "libs/ui/src/molecules/figma/radio-group.figma.tsx"
+  - "https://zagjs.com/components/react/radio-group"
+---
+
+# @techsio/ui-kit RadioGroup Usage
+
+Use RadioGroup for simple exclusive text choices. Use RadioCard for larger
+card-like choices.
+
+## Setup
+
+```tsx
+<RadioGroup name="payment" defaultValue="card">
+  <RadioGroup.Label>Payment method</RadioGroup.Label>
+  <RadioGroup.ItemGroup>
+    <RadioGroup.Item value="card">
+      <RadioGroup.ItemHiddenInput />
+      <RadioGroup.ItemControl />
+      <RadioGroup.ItemContent><RadioGroup.ItemText>Card</RadioGroup.ItemText></RadioGroup.ItemContent>
+    </RadioGroup.Item>
+  </RadioGroup.ItemGroup>
+</RadioGroup>
+```
+
+Supported props:
+
+```text
+variant: outline | subtle | solid
+size: sm | md | lg
+orientation: horizontal | vertical
+validateStatus: default | error | success | warning
+value/defaultValue, disabled, required, readOnly, onValueChange
+```
+
+## Core Patterns
+
+### Use item group for options
+
+Keep options inside `RadioGroup.ItemGroup` and each item as a label with
+hidden input and control.
+
+### Use descriptions for explanatory text
+
+Use `RadioGroup.ItemDescription`, not loose paragraphs.
+
+### Use value strings
+
+Radio values are strings; map domain IDs to strings consistently.
+
+## Common Mistakes
+
+### HIGH Native radio inputs
+
+Wrong:
+
+```tsx
+<input type="radio" name="payment" value="card" />
+```
+
+Correct:
+
+```tsx
+<RadioGroup.Item value="card"><RadioGroup.ItemHiddenInput /></RadioGroup.Item>
+```
+
+Source: libs/ui/src/molecules/radio-group.tsx
+
+### HIGH Missing item group
+
+Wrong:
+
+```tsx
+<RadioGroup><RadioGroup.Item value="a" /></RadioGroup>
+```
+
+Correct:
+
+```tsx
+<RadioGroup><RadioGroup.ItemGroup><RadioGroup.Item value="a" /></RadioGroup.ItemGroup></RadioGroup>
+```
+
+Source: libs/ui/src/molecules/radio-group.tsx
+
+### HIGH Inline checked styling
+
+Wrong:
+
+```tsx
+<RadioGroup.Item className="text-primary border-primary" value="a" />
+```
+
+Correct:
+
+```tsx
+<RadioGroup variant="solid"><RadioGroup.Item value="a" /></RadioGroup>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_radio-group.css
+
+## Validation Commands
+
+```sh
+rg -U -P -n "<input[^>]*type=\"radio\"|<RadioGroup\\.Item(?![\\s\\S]{0,300}<RadioGroup\\.ItemHiddenInput)" apps
+rg -n "<RadioGroup[^>]*variant=\"(primary|outlined)\"|<RadioGroup[^>]*className=.*(border-|bg-|text-)" apps
+rg -n "<RadioGroup[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/rating-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/rating-usage/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: rating-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Rating for
+  accessible rating capture or display using the Zag.js rating-group wrapper,
+  supported value/count/allowHalf/readOnly/disabled props, and token styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/rating.tsx"
+  - "libs/ui/src/tokens/components/atoms/_rating.css"
+  - "libs/ui/stories/atoms/rating.stories.tsx"
+  - "libs/ui/src/atoms/figma/rating.figma.tsx"
+  - "https://zagjs.com/components/react/rating-group"
+---
+
+# @techsio/ui-kit Rating Usage
+
+Use Rating for product reviews, satisfaction scores, and read-only rating
+display. Do not build custom star maps.
+
+## Setup
+
+```tsx
+import { Rating } from "@techsio/ui-kit/atoms/rating"
+
+<Rating name="score" defaultValue={4} count={5} allowHalf />
+```
+
+Supported props:
+
+```text
+value/defaultValue: number
+onChange: (value: number) => void
+onHoverChange: (value: number) => void
+count: number, default 5
+allowHalf: boolean, default true
+readOnly, disabled, name, labelText, translations, dir
+size: sm | md | lg
+```
+
+## Core Patterns
+
+### Use controlled mode for editable rating state
+
+```tsx
+const [rating, setRating] = useState(0)
+
+<Rating
+  name="rating"
+  value={rating}
+  onChange={setRating}
+  labelText="Product rating"
+/>
+```
+
+Zag exposes hover/value changes; the wrapper converts them to numbers.
+
+### Use readOnly for display-only ratings
+
+```tsx
+<Rating value={4.5} readOnly labelText="Average product rating" />
+```
+
+Use `disabled` when the control is unavailable, not for normal display.
+
+### Use token-backed size and state styling
+
+```tsx
+<Rating size="sm" value={3.5} readOnly />
+```
+
+The rating token file owns checked, highlighted, half, disabled, and readonly
+visuals.
+
+## Common Mistakes
+
+### HIGH Custom star rendering
+
+Wrong:
+
+```tsx
+{[1, 2, 3, 4, 5].map((i) => (
+  <button className="text-yellow-500" key={i}>*</button>
+))}
+```
+
+Correct:
+
+```tsx
+<Rating name="rating" defaultValue={3} />
+```
+
+Source: libs/ui/src/atoms/rating.tsx
+
+### HIGH Inline star colors
+
+Wrong:
+
+```tsx
+<Rating className="text-yellow-500" value={4} />
+```
+
+Correct:
+
+```tsx
+<Rating value={4} />
+```
+
+Change `_rating.css` or app token overrides if the star colors need to change.
+
+Source: libs/ui/src/tokens/components/atoms/_rating.css
+
+### MEDIUM Missing label/name in forms
+
+Wrong:
+
+```tsx
+<Rating value={rating} onChange={setRating} />
+```
+
+Correct for form capture:
+
+```tsx
+<Rating
+  name="rating"
+  labelText="Product rating"
+  value={rating}
+  onChange={setRating}
+/>
+```
+
+Zag rating docs note `name` plus the hidden input for form usage.
+
+Source: https://zagjs.com/components/react/rating-group
+
+### MEDIUM Disabled used for read-only display
+
+Wrong:
+
+```tsx
+<Rating value={4.5} disabled />
+```
+
+Correct:
+
+```tsx
+<Rating value={4.5} readOnly />
+```
+
+## Validation Commands
+
+```sh
+rg -n "map\\(.*\\*|text-yellow|<Rating[^>]*className=.*(text-|fill-|stroke-)" apps
+rg -P -n "<Rating(?![^>]*(name=|readOnly|labelText=))" apps
+rg -n "<Rating[^>]*disabled" apps
+rg -n "onHoverChange|allowHalf|count=" apps
+```

--- a/libs/ui/agent-plugin/skills/search-form-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/search-form-usage/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: search-form-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit SearchForm for
+  search landmarks, controlled or uncontrolled search text, label, control,
+  input, submit button, clear button, icon props, and token-backed field
+  layout.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/search-form.tsx"
+  - "libs/ui/src/tokens/components/molecules/_search-form.css"
+  - "libs/ui/stories/molecules/search-form.stories.tsx"
+  - "libs/ui/src/molecules/figma/search-form.figma.tsx"
+---
+
+# @techsio/ui-kit SearchForm Usage
+
+Use SearchForm for search input and submit/clear actions. It wraps a semantic
+`<search>` and `<form>`.
+
+## Setup
+
+```tsx
+<SearchForm onSubmit={handleSubmit} value={query} onValueChange={setQuery}>
+  <SearchForm.Label>Search products</SearchForm.Label>
+  <SearchForm.Control>
+    <SearchForm.Input />
+    <SearchForm.ClearButton />
+    <SearchForm.Button showSearchIcon>Search</SearchForm.Button>
+  </SearchForm.Control>
+</SearchForm>
+```
+
+Supported props:
+
+```text
+size: sm | md | lg
+value/defaultValue, onValueChange, onSubmit
+Label, Control, Input, Button, ClearButton
+Button showSearchIcon, icon, iconPosition
+```
+
+## Core Patterns
+
+### Use for actual search workflows
+
+Use Input/FormInput for non-search text entry.
+
+### Keep clear behavior in ClearButton
+
+`SearchForm.ClearButton` only renders when the field has a value.
+
+### Use Button part for submit
+
+Do not place a native submit button inside the control.
+
+## Common Mistakes
+
+### HIGH Manual search form
+
+Wrong:
+
+```tsx
+<form><input type="search" /><button>Search</button></form>
+```
+
+Correct:
+
+```tsx
+<SearchForm><SearchForm.Control><SearchForm.Input /><SearchForm.Button /></SearchForm.Control></SearchForm>
+```
+
+Source: libs/ui/src/molecules/search-form.tsx
+
+### HIGH Native clear button
+
+Wrong:
+
+```tsx
+{query && <button onClick={() => setQuery("")}>x</button>}
+```
+
+Correct:
+
+```tsx
+<SearchForm.ClearButton />
+```
+
+Source: libs/ui/src/molecules/search-form.tsx
+
+### HIGH Inline field styling
+
+Wrong:
+
+```tsx
+<SearchForm.Control className="rounded border px-2" />
+```
+
+Correct:
+
+```tsx
+<SearchForm size="md"><SearchForm.Control /></SearchForm>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_search-form.css
+
+## Validation Commands
+
+```sh
+rg -n "<input[^>]*type=\"search\"|<SearchForm\\.(Control|Input)[^>]*className=.*(border-|rounded-|px-|py-|bg-)" apps
+rg -U -P -n "<SearchForm(?![\\s\\S]{0,500}<SearchForm\\.Input)" apps
+rg -n "<SearchForm\\.Button[^>]*type=" apps
+```

--- a/libs/ui/agent-plugin/skills/select-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/select-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: select-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Select for
+  non-search selection with Zag.js collection behavior, hidden form select,
+  trigger, value text, clear trigger, item groups, item indicators, validation
+  status, size, and multiple mode.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/select.tsx"
+  - "libs/ui/src/tokens/components/molecules/_select.css"
+  - "libs/ui/stories/molecules/select.stories.tsx"
+  - "libs/ui/src/molecules/figma/select.figma.tsx"
+  - "https://zagjs.com/components/react/select"
+---
+
+# @techsio/ui-kit Select Usage
+
+Use Select for choosing from known options. Use Combobox when the user needs
+search/filter text input.
+
+## Setup
+
+```tsx
+<Select items={items} name="country">
+  <Select.Label>Country</Select.Label>
+  <Select.Control>
+    <Select.Trigger><Select.ValueText placeholder="Choose country" /></Select.Trigger>
+    <Select.ClearTrigger />
+  </Select.Control>
+  <Select.Positioner><Select.Content>{items.map((item) => <Select.Item item={item} key={item.value}><Select.ItemText /><Select.ItemIndicator /></Select.Item>)}</Select.Content></Select.Positioner>
+</Select>
+```
+
+Supported props:
+
+```text
+items: { label, value, disabled, displayValue }[]
+size: xs | sm | md | lg
+validateStatus: default | error | success | warning
+value/defaultValue: string[]
+multiple, disabled, required, readOnly, closeOnSelect, loopFocus
+name, form, onValueChange, onOpenChange, onHighlightChange
+```
+
+## Core Patterns
+
+### Keep Select anatomy intact
+
+Use Label, Control, Trigger, ValueText, Positioner, Content, Item, ItemText,
+and ItemIndicator.
+
+### Use array values
+
+Zag Select values are arrays, including single-select values.
+
+### Use StatusText part for help/error
+
+Use `Select.StatusText` with `validateStatus`, not external paragraphs.
+
+## Common Mistakes
+
+### HIGH Native select
+
+Wrong:
+
+```tsx
+<select><option value="CZ">Czechia</option></select>
+```
+
+Correct:
+
+```tsx
+<Select items={[{ label: "Czechia", value: "CZ" }]} />
+```
+
+Source: libs/ui/src/molecules/select.tsx
+
+### HIGH String value
+
+Wrong:
+
+```tsx
+<Select value="CZ" items={items} />
+```
+
+Correct:
+
+```tsx
+<Select value={["CZ"]} items={items} />
+```
+
+Source: https://zagjs.com/components/react/select
+
+### HIGH Inline trigger styling
+
+Wrong:
+
+```tsx
+<Select.Trigger className="border-red-500 bg-white" />
+```
+
+Correct:
+
+```tsx
+<Select validateStatus="error"><Select.Trigger /></Select>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_select.css
+
+## Validation Commands
+
+```sh
+rg -n "<select\\b|<Select\\b(?!\\.)[^>]*value=\"|<Select\\.Trigger[^>]*className=.*(border-|bg-|p-|text-)" apps
+rg -U -P -n "<Select\\b(?!\\.)(?![\\s\\S]{0,700}<Select\\.Item)" apps
+rg -n "<Select\\b(?!\\.)[^>]*validateStatus=\"(danger|invalid)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/skeleton-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/skeleton-usage/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skeleton-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Skeleton for
+  loading placeholders using Root, Circle, Text, and Rectangle compound parts
+  with token-backed variants, sizes, and animation speeds.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/skeleton.tsx"
+  - "libs/ui/src/tokens/components/atoms/_skeleton.css"
+  - "libs/ui/stories/atoms/skeleton.stories.tsx"
+  - "libs/ui/src/atoms/figma/skeleton.figma.tsx"
+---
+
+# @techsio/ui-kit Skeleton Usage
+
+Use Skeleton for loading placeholders that preserve the final layout shape.
+
+## Setup
+
+```tsx
+import { Skeleton } from "@techsio/ui-kit/atoms/skeleton"
+
+<Skeleton isLoaded={Boolean(product)}>
+  <Skeleton.Text noOfLines={2} />
+</Skeleton>
+```
+
+Supported props:
+
+```text
+Skeleton: isLoaded, variant primary | secondary, speed slow | normal | fast
+Skeleton.Circle: size sm | md | lg | xl
+Skeleton.Text: noOfLines, size, lastLineWidth, containerClassName
+Skeleton.Rectangle: variant, speed, isLoaded
+```
+
+## Core Patterns
+
+### Mirror final content shape
+
+```tsx
+<Skeleton isLoaded={isLoaded}>
+  <div className="flex items-center gap-100">
+    <Skeleton.Circle size="md" />
+    <Skeleton.Text noOfLines={2} size="sm" />
+  </div>
+</Skeleton>
+```
+
+Use Circle for avatars/icons, Text for lines, and Rectangle for media/cards.
+
+### Use isLoaded to reveal children
+
+```tsx
+<Skeleton isLoaded={Boolean(product)}>
+  {product ? <ProductSummary product={product} /> : <Skeleton.Text />}
+</Skeleton>
+```
+
+The component returns children directly when loaded.
+
+### Use layout className only for dimensions
+
+```tsx
+<Skeleton.Rectangle className="h-1000 w-full" />
+```
+
+Skeleton rectangle needs a box size from layout. Do not use className for
+colors/radius/animation when props/tokens already cover those.
+
+## Common Mistakes
+
+### HIGH Custom loading divs
+
+Wrong:
+
+```tsx
+<div className="h-4 animate-pulse rounded bg-gray-200" />
+```
+
+Correct:
+
+```tsx
+<Skeleton.Text noOfLines={1} />
+```
+
+Source: libs/ui/src/atoms/skeleton.tsx
+
+### HIGH Inline skeleton colors
+
+Wrong:
+
+```tsx
+<Skeleton.Text className="bg-gray-200 dark:bg-gray-800" />
+```
+
+Correct:
+
+```tsx
+<Skeleton.Text variant="secondary" />
+```
+
+Use `_skeleton.css` or app token overrides for color changes.
+
+Source: libs/ui/src/tokens/components/atoms/_skeleton.css
+
+### MEDIUM Wrong placeholder shape
+
+Wrong:
+
+```tsx
+<Skeleton.Text noOfLines={5} />
+```
+
+for an avatar.
+
+Correct:
+
+```tsx
+<Skeleton.Circle size="lg" />
+```
+
+Match the final layout.
+
+### MEDIUM Unstable line count
+
+Wrong:
+
+```tsx
+<Skeleton.Text noOfLines={items.length} />
+```
+
+Correct:
+
+```tsx
+<Skeleton.Text noOfLines={3} lastLineWidth="70%" />
+```
+
+Skeletons should keep predictable dimensions while loading.
+
+## Validation Commands
+
+```sh
+rg -n "animate-pulse|bg-gray|skeleton" apps
+rg -n "<Skeleton[^>]*className=.*(bg-|rounded-|animate-)" apps
+rg -n "<Skeleton\\.Text[^>]*noOfLines=\\{.*\\.length" apps
+rg -P -n "<Skeleton\\.Rectangle(?![^>]*className=)" apps
+```

--- a/libs/ui/agent-plugin/skills/slider-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/slider-usage/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: slider-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Slider for
+  single or range numeric adjustment with Zag.js slider behavior, label,
+  markers, value text, orientation, min/max/step, validation status, and token
+  styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/slider.tsx"
+  - "libs/ui/src/tokens/components/molecules/_slider.css"
+  - "libs/ui/stories/molecules/slider.stories.tsx"
+  - "https://zagjs.com/components/react/slider"
+---
+
+# @techsio/ui-kit Slider Usage
+
+Use Slider for bounded numeric adjustment. Use NumericInput when exact typed
+entry is required.
+
+## Setup
+
+```tsx
+<Slider
+  label="Price range"
+  defaultValue={[10, 100]}
+  min={0}
+  max={200}
+  step={5}
+  showValueText
+/>
+```
+
+Supported props:
+
+```text
+value/defaultValue: number[]
+min, max, step, minStepsBetweenThumbs
+orientation: horizontal | vertical
+origin: start | center | end
+thumbAlignment: center | contain
+showMarkers, markerCount, showValueText
+formatRangeText, formatValue
+validateStatus, helpText, onChange, onChangeEnd
+size: sm | md | lg
+```
+
+## Core Patterns
+
+### Use array values
+
+Slider values are arrays. A range has two numbers; a single slider can use one
+number.
+
+### Use markers for scale cues
+
+Use `showMarkers` and `markerCount`, not custom tick markup.
+
+### Use NumericInput for precision
+
+If the user must type an exact value, use NumericInput or pair both components
+deliberately.
+
+## Common Mistakes
+
+### HIGH Native range input
+
+Wrong:
+
+```tsx
+<input type="range" min={0} max={100} />
+```
+
+Correct:
+
+```tsx
+<Slider min={0} max={100} defaultValue={[50]} />
+```
+
+Source: libs/ui/src/molecules/slider.tsx
+
+### HIGH Scalar value
+
+Wrong:
+
+```tsx
+<Slider value={50} />
+```
+
+Correct:
+
+```tsx
+<Slider value={[50]} />
+```
+
+Source: https://zagjs.com/components/react/slider
+
+### HIGH Inline track styling
+
+Wrong:
+
+```tsx
+<Slider className="h-2 rounded bg-gray-200" />
+```
+
+Correct:
+
+```tsx
+<Slider size="md" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_slider.css
+
+## Validation Commands
+
+```sh
+rg -n "<input[^>]*type=\"range\"|<Slider[^>]*value=\\{[0-9]" apps
+rg -n "<Slider[^>]*className=.*(bg-|rounded-|h-|w-|text-)" apps
+rg -n "showMarkers|markerCount|formatRangeText|onChangeEnd" apps
+```
+

--- a/libs/ui/agent-plugin/skills/status-text-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/status-text-usage/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: status-text-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit StatusText
+  for inline validation, success, warning, or default status messages with
+  optional token icons and size/alignment props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/status-text.tsx"
+  - "libs/ui/src/tokens/components/atoms/_status-text.css"
+  - "libs/ui/stories/atoms/status-text.stories.tsx"
+  - "libs/ui/src/atoms/figma/status-text.figma.tsx"
+---
+
+# @techsio/ui-kit StatusText Usage
+
+Use StatusText for short inline messages that describe a nearby field, section,
+or operation result.
+
+## Setup
+
+```tsx
+import { StatusText } from "@techsio/ui-kit/atoms/status-text"
+
+<StatusText status="error" showIcon>
+  Email is required.
+</StatusText>
+```
+
+Supported props:
+
+```text
+status: error | success | warning | default
+size: sm | md | lg
+align: start | center
+showIcon: boolean
+icon: IconType override
+```
+
+## Core Patterns
+
+### Use status for message meaning
+
+```text
+error -> validation or failed operation
+success -> completed operation or valid state
+warning -> risky/incomplete state
+default -> neutral help text
+```
+
+Do not choose status only from color preference.
+
+### Use showIcon for scannable state
+
+```tsx
+<StatusText status="warning" showIcon>
+  Low stock.
+</StatusText>
+```
+
+Default icons are mapped from status in `status-text.tsx`.
+
+### Use align start for long text
+
+```tsx
+<StatusText status="error" align="start" showIcon>
+  Password must include at least 12 characters and one symbol.
+</StatusText>
+```
+
+This keeps the icon aligned with multi-line text.
+
+## Common Mistakes
+
+### HIGH Native paragraph with color class
+
+Wrong:
+
+```tsx
+<p className="text-red-500 text-sm">Email is required.</p>
+```
+
+Correct:
+
+```tsx
+<StatusText status="error">Email is required.</StatusText>
+```
+
+Source: libs/ui/src/atoms/status-text.tsx
+
+### HIGH Wrong status name
+
+Wrong:
+
+```tsx
+<StatusText status="danger">Failed</StatusText>
+```
+
+Correct:
+
+```tsx
+<StatusText status="error">Failed</StatusText>
+```
+
+Source: libs/ui/src/atoms/status-text.tsx
+
+### HIGH Inline icon/color duplication
+
+Wrong:
+
+```tsx
+<StatusText status="success" className="text-green-600">
+  Saved
+</StatusText>
+```
+
+Correct:
+
+```tsx
+<StatusText status="success" showIcon>
+  Saved
+</StatusText>
+```
+
+Source: libs/ui/src/tokens/components/atoms/_status-text.css
+
+### MEDIUM Badge used for message text
+
+Wrong:
+
+```tsx
+<Badge variant="danger">Email is required.</Badge>
+```
+
+Correct:
+
+```tsx
+<StatusText status="error">Email is required.</StatusText>
+```
+
+## Validation Commands
+
+```sh
+rg -n "<p[^>]*className=.*(text-red|text-green|text-warning|text-success)" apps
+rg -n "<StatusText[^>]*status=\"(danger|info|primary)\"" apps
+rg -n "<StatusText[^>]*className=.*(text-|gap-|mt-|mb-)" apps
+rg -n "<Badge[^>]*>[^<]{30,}</Badge>" apps
+```
+

--- a/libs/ui/agent-plugin/skills/steps-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/steps-usage/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: steps-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Steps for
+  multi-step workflows using the Zag.js steps machine, compound list/items,
+  panels, progress, navigation triggers, linear flow, controlled step, and
+  variants.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/steps.tsx"
+  - "libs/ui/src/tokens/components/molecules/_steps.css"
+  - "libs/ui/stories/molecules/steps.stories.tsx"
+  - "libs/ui/src/molecules/figma/steps.figma.tsx"
+  - "https://zagjs.com/components/react/steps"
+---
+
+# @techsio/ui-kit Steps Usage
+
+Use Steps for wizard/progress workflows. Use Tabs for peer panels, and
+Pagination for page navigation.
+
+## Setup
+
+```tsx
+<Steps count={3} linear>
+  <Steps.List>
+    <Steps.Item index={0}><Steps.Trigger><Steps.Indicator /><Steps.Title>Cart</Steps.Title></Steps.Trigger><Steps.Separator /></Steps.Item>
+  </Steps.List>
+  <Steps.Panels><Steps.Content index={0}>Cart content</Steps.Content></Steps.Panels>
+  <Steps.Navigation><Steps.PrevTrigger>Back</Steps.PrevTrigger><Steps.NextTrigger>Next</Steps.NextTrigger></Steps.Navigation>
+</Steps>
+```
+
+Supported props:
+
+```text
+count, step/defaultStep, linear, orientation horizontal | vertical
+variant: subtle | solid
+size: sm | md | lg
+onStepChange, onStepComplete
+RootProvider/useSteps for external store
+```
+
+## Core Patterns
+
+### Use for ordered workflows
+
+Checkout, onboarding, setup, and import flows fit Steps.
+
+### Keep item indexes aligned
+
+`Steps.Item index` and `Steps.Content index` must match the intended step.
+
+### Use navigation triggers
+
+Use `PrevTrigger` and `NextTrigger` so disabled/completed state comes from the
+machine.
+
+## Common Mistakes
+
+### HIGH Custom wizard state
+
+Wrong:
+
+```tsx
+{step === 1 && <Panel />}<Button onClick={() => setStep(step + 1)}>Next</Button>
+```
+
+Correct:
+
+```tsx
+<Steps count={3}><Steps.Panels><Steps.Content index={0} /></Steps.Panels></Steps>
+```
+
+Source: libs/ui/src/molecules/steps.tsx
+
+### HIGH Missing count
+
+Wrong:
+
+```tsx
+<Steps><Steps.Item index={0} /></Steps>
+```
+
+Correct:
+
+```tsx
+<Steps count={3}><Steps.Item index={0} /></Steps>
+```
+
+Source: https://zagjs.com/components/react/steps
+
+### HIGH Inline progress styling
+
+Wrong:
+
+```tsx
+<Steps.Progress className="h-2 bg-gray-200" />
+```
+
+Correct:
+
+```tsx
+<Steps.Progress />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_steps.css
+
+## Validation Commands
+
+```sh
+rg -P -n "setStep|<Steps\\b(?!\\.)(?![^>]*count=)|<Steps\\.Progress[^>]*className=.*(bg-|h-|rounded-)" apps
+rg -P -n "<Steps\\.Item(?![^>]*index=)|<Steps\\.Content(?![^>]*index=)" apps
+rg -n "<Steps\\.NextTrigger|<Steps\\.PrevTrigger|linear" apps
+```

--- a/libs/ui/agent-plugin/skills/storybook-authoring/SKILL.md
+++ b/libs/ui/agent-plugin/skills/storybook-authoring/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: storybook-authoring
+description: >
+  Use when creating or editing Storybook CSF3 stories for @techsio/ui-kit in
+  libs/ui, including Playground stories, argTypes controls, VariantContainer
+  and VariantGroup matrices, fn() handlers, token-based story layout classes,
+  and UI-kit components instead of native HTML.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/.storybook/main.ts"
+  - "libs/ui/.storybook/preview.ts"
+  - "libs/ui/stories/atoms/button.stories.tsx"
+  - "libs/ui/stories/molecules/dialog.stories.tsx"
+  - "libs/ui/stories/molecules/tree-view.stories.tsx"
+  - "libs/ui/local/storybook-practice.md"
+  - "libs/ui/local/storybook-migration.md"
+---
+
+# @techsio/ui-kit Storybook Authoring
+
+Use this for `libs/ui/stories/**/*.stories.tsx`.
+
+## Setup
+
+Minimum story shape:
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react"
+import { fn } from "storybook/test"
+import { VariantContainer, VariantGroup } from "../../.storybook/decorator"
+import { Button } from "../../src/atoms/button"
+
+const meta: Meta<typeof Button> = {
+  title: "Atoms/Button",
+  component: Button,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["primary", "secondary", "tertiary", "warning", "danger"],
+    },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    variant: "primary",
+    disabled: false,
+    children: "Button",
+    onClick: fn(),
+  },
+  parameters: { layout: "centered" },
+}
+
+export default meta
+type Story = StoryObj<typeof Button>
+
+export const Playground: Story = {
+  render: (args) => <Button {...args} />,
+}
+```
+
+Storybook files may use the required default export.
+
+## Core Patterns
+
+### Add stories in local order
+
+```text
+Playground
+Variants
+Sizes
+States
+Component-specific stories
+```
+
+Include a section only when the component supports it.
+
+### Use select controls for enum-like props
+
+```tsx
+argTypes: {
+  theme: {
+    control: "select",
+    options: ["solid", "light", "outlined", "borderless", "unstyled"],
+  },
+}
+```
+
+Controls should cover visible behavior. Avoid controls for `ref`, internal ids,
+or callbacks with no visible effect.
+
+### Use UI-kit components in examples
+
+```tsx
+<VariantGroup title="Disabled states">
+  <Button disabled>Disabled</Button>
+  <Button theme="outlined" disabled>Outlined</Button>
+</VariantGroup>
+```
+
+Do not demonstrate native primitives when the UI kit has a component.
+
+### Use tokens for story layout
+
+```tsx
+export const Playground: Story = {
+  render: (args) => (
+    <div className="w-md p-200">
+      <Button {...args} />
+    </div>
+  ),
+}
+```
+
+Story layout may use semantic/layout/spacing tokens. Avoid hardcoded palette or
+spacing utilities.
+
+## Common Mistakes
+
+### HIGH Native HTML and hardcoded Tailwind
+
+Wrong:
+
+```tsx
+export const Example: Story = {
+  render: () => (
+    <button className="rounded bg-blue-500 px-4 py-2 text-white">
+      Save
+    </button>
+  ),
+}
+```
+
+Correct:
+
+```tsx
+export const Default: Story = {
+  render: () => <Button>Save</Button>,
+}
+```
+
+Stories are consumer-facing documentation; they should teach UI-kit usage and
+the token system.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH Missing Playground controls
+
+Wrong:
+
+```tsx
+export const Default: Story = {
+  render: () => <Button variant="primary">Button</Button>,
+}
+```
+
+Correct:
+
+```tsx
+export const Playground: Story = {
+  args: { variant: "primary", children: "Button" },
+  render: (args) => <Button {...args} />,
+}
+```
+
+Every component should have an interactive Playground where visible props are
+driven through Controls.
+
+Source: libs/ui/stories/atoms/button.stories.tsx
+
+### MEDIUM Unclear story names
+
+Wrong:
+
+```tsx
+export const Example: Story = {}
+export const Demo: Story = {}
+```
+
+Correct:
+
+```tsx
+export const Default: Story = {}
+export const WithIcon: Story = {}
+export const Disabled: Story = {}
+export const Error: Story = {}
+```
+
+Names should describe the exact state or variation the story demonstrates.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Controls for non-visual internals
+
+Wrong:
+
+```tsx
+argTypes: {
+  id: { control: "text" },
+  ref: { control: "object" },
+}
+```
+
+Correct:
+
+```tsx
+argTypes: {
+  variant: { control: "select", options: ["primary", "danger"] },
+  disabled: { control: "boolean" },
+}
+```
+
+Controls should help inspect appearance or behavior, not internal wiring.
+
+Source: libs/ui/AGENTS.md
+
+## Validation Commands
+
+```sh
+bunx biome check --write libs/ui/stories/atoms/button.stories.tsx
+bunx nx run ui:build
+pnpm --dir libs/ui build:storybook
+pnpm --dir libs/ui storybook:a11y
+```
+

--- a/libs/ui/agent-plugin/skills/switch-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/switch-usage/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: switch-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Switch for
+  boolean settings using Zag.js switch behavior, hidden input, label children,
+  checked/defaultChecked, validation status, help text, required, disabled, and
+  read-only state.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/switch.tsx"
+  - "libs/ui/src/tokens/components/molecules/_switch.css"
+  - "libs/ui/stories/molecules/switch.stories.tsx"
+  - "libs/ui/src/molecules/figma/switch.figma.tsx"
+  - "https://zagjs.com/components/react/switch"
+---
+
+# @techsio/ui-kit Switch Usage
+
+Use Switch for immediate boolean settings. Use Checkbox for terms, multi-select
+lists, or non-immediate boolean form choices.
+
+## Setup
+
+```tsx
+<Switch name="marketing" defaultChecked onCheckedChange={setEnabled}>
+  Marketing emails
+</Switch>
+```
+
+Supported props:
+
+```text
+checked/defaultChecked, onCheckedChange
+name, value, required, disabled, readOnly, dir
+validateStatus: default | error | success | warning
+helpText, showHelpTextIcon
+```
+
+## Core Patterns
+
+### Use for settings
+
+Feature toggles, notification preferences, and visibility toggles fit Switch.
+
+### Use children as label
+
+The component renders Label and hidden input internally.
+
+### Use validateStatus for invalid state
+
+Do not style invalid switch state manually.
+
+## Common Mistakes
+
+### HIGH Checkbox for setting toggle
+
+Wrong:
+
+```tsx
+<Checkbox checked={enabled} /> Enable notifications
+```
+
+Correct:
+
+```tsx
+<Switch checked={enabled} onCheckedChange={setEnabled}>Enable notifications</Switch>
+```
+
+Source: libs/ui/src/molecules/switch.tsx
+
+### HIGH Wrong callback
+
+Wrong:
+
+```tsx
+<Switch onChange={(e) => setEnabled(e.target.checked)} />
+```
+
+Correct:
+
+```tsx
+<Switch onCheckedChange={setEnabled} />
+```
+
+Source: https://zagjs.com/components/react/switch
+
+### HIGH Inline state styling
+
+Wrong:
+
+```tsx
+<Switch className="data-[state=checked]:bg-green-600" />
+```
+
+Correct:
+
+```tsx
+<Switch validateStatus="default" />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_switch.css
+
+## Validation Commands
+
+```sh
+rg -n "<Switch[^>]*onChange=|<Switch[^>]*className=.*(bg-|text-|data-\\[state|rounded-)" apps
+rg -n "<Checkbox[\\s\\S]{0,120}(Enable|Disable|notifications|toggle)" apps -U
+rg -n "<Switch[^>]*validateStatus=\"(danger|invalid)\"" apps
+```
+

--- a/libs/ui/agent-plugin/skills/table-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/table-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: table-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Table for
+  semantic tabular data with caption, header, body, footer, rows, column
+  headers, numeric cells, selected rows, variants, interactive rows, sticky
+  header/first column, column borders, and size props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/organisms/table.tsx"
+  - "libs/ui/src/tokens/components/organisms/_table.css"
+  - "libs/ui/stories/organisms/table.stories.tsx"
+---
+
+# @techsio/ui-kit Table Usage
+
+Use Table for semantic tabular data. Do not use div grids for data tables when
+table semantics are needed.
+
+## Setup
+
+```tsx
+<Table variant="line" size="md" stickyHeader>
+  <Table.Caption>Orders</Table.Caption>
+  <Table.Header>
+    <Table.Row><Table.ColumnHeader>Order</Table.ColumnHeader><Table.ColumnHeader numeric>Total</Table.ColumnHeader></Table.Row>
+  </Table.Header>
+  <Table.Body>
+    <Table.Row selected={isSelected}><Table.Cell>#1001</Table.Cell><Table.Cell numeric>129 EUR</Table.Cell></Table.Row>
+  </Table.Body>
+</Table>
+```
+
+Supported props:
+
+```text
+variant: line | outline | striped
+size: sm | md | lg
+interactive, stickyHeader, stickyFirstColumn, showColumnBorder
+captionPlacement: top | bottom
+Row selected
+ColumnHeader/Cell numeric
+parts: Caption, Header, Body, Footer, Row, ColumnHeader, Cell
+```
+
+## Core Patterns
+
+### Use semantic table parts
+
+Use Table.Header/Body/Footer and ColumnHeader/Cell rather than div grids.
+
+### Mark numeric columns
+
+Use `numeric` on headers and cells for right alignment.
+
+### Use selected/interactive props
+
+Use `selected` on rows and `interactive` on the root; do not add hover/selected
+classes to rows.
+
+## Common Mistakes
+
+### HIGH Div-based data table
+
+Wrong:
+
+```tsx
+<div className="grid grid-cols-3"><div>Order</div><div>Total</div></div>
+```
+
+Correct:
+
+```tsx
+<Table><Table.Header><Table.Row><Table.ColumnHeader>Order</Table.ColumnHeader></Table.Row></Table.Header></Table>
+```
+
+Source: libs/ui/src/organisms/table.tsx
+
+### HIGH Inline row/cell styling
+
+Wrong:
+
+```tsx
+<Table.Row className="hover:bg-gray-50 border-b" />
+```
+
+Correct:
+
+```tsx
+<Table interactive><Table.Row selected={selected} /></Table>
+```
+
+Source: libs/ui/src/tokens/components/organisms/_table.css
+
+### MEDIUM Numeric alignment via class
+
+Wrong:
+
+```tsx
+<Table.Cell className="text-right">{total}</Table.Cell>
+```
+
+Correct:
+
+```tsx
+<Table.Cell numeric>{total}</Table.Cell>
+```
+
+Source: libs/ui/src/organisms/table.tsx
+
+## Validation Commands
+
+```sh
+rg -n "grid-cols.*(Order|Total|Price)|<table\\b|<Table\\.(Row|Cell|ColumnHeader)[^>]*className=.*(hover:|border-|text-right|p-)" apps
+rg -n "<Table\\.Cell[^>]*className=\"[^\"]*text-right|<Table\\.ColumnHeader[^>]*className=\"[^\"]*text-right" apps
+rg -n "<Table[^>]*variant=\"(default|bordered)\"|captionPlacement=\"(left|right)\"" apps
+```
+

--- a/libs/ui/agent-plugin/skills/tabs-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/tabs-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: tabs-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Tabs for
+  switching peer content panels with Zag.js tabs behavior, compound list,
+  triggers, content, indicator, orientation, activation mode, variants, fitted,
+  and justify props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/tabs.tsx"
+  - "libs/ui/src/tokens/components/molecules/_tabs.css"
+  - "libs/ui/stories/molecules/tabs.stories.tsx"
+  - "libs/ui/src/molecules/figma/tabs.figma.tsx"
+  - "https://zagjs.com/components/react/tabs"
+---
+
+# @techsio/ui-kit Tabs Usage
+
+Use Tabs for peer panels in the same page context. Use Steps for ordered
+workflow progress and Breadcrumb for hierarchy.
+
+## Setup
+
+```tsx
+<Tabs defaultValue="details" variant="line">
+  <Tabs.List>
+    <Tabs.Trigger value="details">Details</Tabs.Trigger>
+    <Tabs.Trigger value="reviews">Reviews</Tabs.Trigger>
+    <Tabs.Indicator />
+  </Tabs.List>
+  <Tabs.Content value="details">Details content</Tabs.Content>
+  <Tabs.Content value="reviews">Reviews content</Tabs.Content>
+</Tabs>
+```
+
+Supported props:
+
+```text
+variant: default | line | solid | outline
+size: sm | md | lg
+orientation: horizontal | vertical
+activationMode: automatic | manual
+fitted, justify start | center | end
+value/defaultValue, loopFocus, onValueChange
+```
+
+## Core Patterns
+
+### Match trigger and content values
+
+Every trigger value should have matching content value.
+
+### Use line variant with indicator
+
+`Tabs.Indicator` is meaningful for `line`; other variants hide it.
+
+### Do not use Tabs for navigation pages
+
+If changing the URL/page hierarchy, use Link/Breadcrumb/Pagination.
+
+## Common Mistakes
+
+### HIGH Button state tabs
+
+Wrong:
+
+```tsx
+<Button onClick={() => setTab("a")}>A</Button>{tab === "a" && <div />}
+```
+
+Correct:
+
+```tsx
+<Tabs defaultValue="a"><Tabs.Trigger value="a">A</Tabs.Trigger><Tabs.Content value="a" /></Tabs>
+```
+
+Source: libs/ui/src/molecules/tabs.tsx
+
+### HIGH Value mismatch
+
+Wrong:
+
+```tsx
+<Tabs.Trigger value="details" /><Tabs.Content value="detail" />
+```
+
+Correct:
+
+```tsx
+<Tabs.Trigger value="details" /><Tabs.Content value="details" />
+```
+
+Source: https://zagjs.com/components/react/tabs
+
+### HIGH Inline selected styling
+
+Wrong:
+
+```tsx
+<Tabs.Trigger className="data-[selected]:bg-primary" value="a" />
+```
+
+Correct:
+
+```tsx
+<Tabs variant="solid"><Tabs.Trigger value="a" /></Tabs>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_tabs.css
+
+## Validation Commands
+
+```sh
+rg -n "setTab|<Tabs\\.Trigger[^>]*className=.*(bg-|text-|border-|data-\\[selected)" apps
+rg -P -n "<Tabs\\.Trigger(?![^>]*value=)|<Tabs\\.Content(?![^>]*value=)" apps
+rg -n "<Tabs[^>]*variant=\"(primary|underline)\"" apps
+```

--- a/libs/ui/agent-plugin/skills/tailwind-token-authoring/SKILL.md
+++ b/libs/ui/agent-plugin/skills/tailwind-token-authoring/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: tailwind-token-authoring
+description: >
+  Use when adding or changing Tailwind v4 tokens in @techsio/ui-kit, including
+  @theme static, semantic aliases, two-layer component tokens, component CSS
+  imports, Tailwind token utility class mapping, app override compatibility, and
+  token validator commands.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/token-contribution.md"
+  - "libs/ui/src/tokens/index.css"
+  - "libs/ui/src/tokens/_semantic.css"
+  - "libs/ui/src/tokens/_layout.css"
+  - "libs/ui/src/tokens/_spacing.css"
+  - "libs/ui/src/tokens/components/atoms/_button.css"
+  - "libs/ui/src/tokens/components/components.css"
+  - "libs/ui/scripts/validate-token-usage.js"
+  - "libs/ui/scripts/validate-token-definitions.js"
+  - "https://github.com/TechsioCZ/new-engine/issues/72"
+  - "https://github.com/TechsioCZ/new-engine/issues/329"
+---
+
+# @techsio/ui-kit Tailwind Token Authoring
+
+Use this for `libs/ui/src/tokens/**/*.css` and component token classes used from
+`tv()`.
+
+## Setup
+
+Component token files use Tailwind v4 `@theme static` and two layers:
+
+```css
+@theme static {
+  /* Reference layer */
+  --color-alert-danger: var(--color-danger);
+
+  /* Derived layer */
+  --color-alert-bg-danger: var(--color-alert-danger);
+  --color-alert-fg-danger: var(--color-fg-light);
+
+  --padding-alert-md: var(--spacing-200);
+  --radius-alert-md: var(--radius-md);
+  --border-width-alert-md: var(--border-width-md);
+}
+```
+
+Then import the component file from `src/tokens/components/components.css`.
+
+## Core Patterns
+
+### Map token namespace to Tailwind class
+
+```tsx
+const alert = tv({
+  base: "rounded-alert-md bg-alert-bg-danger text-alert-fg-danger p-alert-md",
+})
+```
+
+`--color-*` maps to `bg-*`, `text-*`, `border-*`, and related color utilities.
+`--padding-*` maps to `p-*`. `--font-weight-*` maps to `font-*`.
+
+### Keep component tokens app-overridable
+
+```css
+@theme static {
+  --color-button-primary: var(--color-primary);
+  --color-button-bg-primary: var(--color-button-primary);
+}
+```
+
+Apps can change `--color-primary` globally or override
+`--color-button-bg-primary` only when the component needs a specific exception.
+
+### Use component utilities for focus
+
+```tsx
+const input = tv({
+  base: "focus-visible:outline-input-focus-style focus-visible:outline-input-focus-ring",
+})
+```
+
+Issue 329 standardizes focus-visible outline utilities in component CSS instead
+of long arbitrary outline expressions in TSX.
+
+### Preserve token entrypoints
+
+```css
+@import "@techsio/ui-kit/tokens";
+@import "@techsio/ui-kit/tokens-with-tailwind";
+```
+
+Use package token exports instead of deep-importing `src/tokens` from apps.
+
+## Common Mistakes
+
+### HIGH Raw component token value
+
+Wrong:
+
+```css
+@theme static {
+  --color-button-bg-primary: #009869;
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-button-primary: var(--color-primary);
+  --color-button-bg-primary: var(--color-button-primary);
+}
+```
+
+Raw component values break the primitive to semantic to component token chain.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH Abbreviated or unsuffixed token
+
+Wrong:
+
+```css
+@theme static {
+  --color-btn-primary: var(--color-primary);
+  --color-button-primary: var(--color-primary);
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --color-button-primary: var(--color-primary);
+  --color-button-bg-primary: var(--color-button-primary);
+}
+```
+
+Derived color tokens must use `-bg`, `-fg`, or `-border`; component names are
+not abbreviated.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH Missing Tailwind token class
+
+Wrong:
+
+```tsx
+const panel = tv({ base: "z-(--z-index)" })
+```
+
+Correct:
+
+```tsx
+const panel = tv({ base: "z-popover" })
+```
+
+Every custom token utility used in TSX must have a matching theme token or be a
+recognized standard utility.
+
+Source: libs/ui/scripts/validate-token-usage.js
+
+### MEDIUM Legacy border token shape
+
+Wrong:
+
+```css
+@theme static {
+  --border-button-width-md: var(--border-width-md);
+}
+```
+
+Correct:
+
+```css
+@theme static {
+  --border-width-button-md: var(--border-width-md);
+}
+```
+
+New work follows `--border-width-<component>`. Existing old shapes are legacy
+unless a migration is explicitly in scope.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Arbitrary focus outline in TSX
+
+Wrong:
+
+```tsx
+const trigger = tv({
+  base: "focus-visible:outline-(style:--default-ring-style)",
+})
+```
+
+Correct:
+
+```tsx
+const trigger = tv({
+  base: "focus-visible:outline-combobox-focus-style",
+})
+```
+
+Focus styling should use readable component utilities defined in the component
+token file.
+
+Source: https://github.com/TechsioCZ/new-engine/issues/329
+
+## Validation Commands
+
+```sh
+pnpm --dir libs/ui validate:token-usage
+pnpm --dir libs/ui validate:token-definitions
+pnpm --dir libs/ui validate:tokens
+bunx biome check --write libs/ui/src/tokens/components/atoms/_button.css
+```
+

--- a/libs/ui/agent-plugin/skills/textarea-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/textarea-usage/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: textarea-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Textarea for
+  multi-line text entry with valid variant, size, resize, readonly styling, and
+  token-first validation.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/textarea.tsx"
+  - "libs/ui/src/tokens/components/atoms/_textarea.css"
+  - "libs/ui/stories/atoms/textarea.stories.tsx"
+  - "libs/ui/src/atoms/figma/textarea.figma.tsx"
+---
+
+# @techsio/ui-kit Textarea Usage
+
+Use Textarea for multi-line text entry. Use form molecules when a complete
+label/help/error field abstraction exists for the current app context.
+
+## Setup
+
+```tsx
+import { Textarea } from "@techsio/ui-kit/atoms/textarea"
+
+<Textarea name="note" variant="default" size="md" resize="y" />
+```
+
+Supported component props:
+
+```text
+variant: default | error | success | warning | borderless
+size: sm | md | lg
+resize: none | y | x | both | auto
+readonly: boolean
+```
+
+Use `readonly` when you need the UI-kit readonly visual variant.
+
+## Core Patterns
+
+### Use variant for validation
+
+```tsx
+<Textarea aria-describedby="note-error" variant="error" />
+```
+
+Do not style borders or placeholders inline for validation.
+
+### Choose resize from layout
+
+```text
+y -> normal notes/comments
+none -> fixed layout surfaces
+auto -> content-sized field when supported by the target browser matrix
+both/x -> rare, only when the product explicitly needs it
+```
+
+### Use readonly for read-only styling
+
+```tsx
+<Textarea readonly value={note} />
+```
+
+The component-specific `readonly` prop drives both the visual variant and the
+`readOnly` attribute.
+
+## Common Mistakes
+
+### HIGH Native textarea
+
+Wrong:
+
+```tsx
+<textarea className="rounded border p-2" />
+```
+
+Correct:
+
+```tsx
+<Textarea />
+```
+
+Source: libs/ui/src/atoms/textarea.tsx
+
+### HIGH Nonexistent validation variant
+
+Wrong:
+
+```tsx
+<Textarea variant="danger" />
+```
+
+Correct:
+
+```tsx
+<Textarea variant="error" />
+```
+
+Source: libs/ui/src/atoms/textarea.tsx
+
+### HIGH Inline validation styling
+
+Wrong:
+
+```tsx
+<Textarea className="border-red-500 placeholder:text-red-400" />
+```
+
+Correct:
+
+```tsx
+<Textarea variant="error" />
+```
+
+Source: libs/ui/src/tokens/components/atoms/_textarea.css
+
+### MEDIUM readOnly without readonly styling
+
+Wrong:
+
+```tsx
+<Textarea readOnly value={note} />
+```
+
+Correct:
+
+```tsx
+<Textarea readonly value={note} />
+```
+
+Use `readonly` so the token-backed readonly styles apply.
+
+## Validation Commands
+
+```sh
+rg -n "<textarea\\b|<Textarea[^>]*variant=\"(danger|invalid|primary)\"" apps
+rg -n "<Textarea[^>]*className=.*(border-|bg-|text-|placeholder:|p-|px-|py-)" apps
+rg -n "<Textarea[^>]*readOnly" apps
+rg -n "resize=\"(none|y|x|both|auto)\"" apps
+```
+

--- a/libs/ui/agent-plugin/skills/toast-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/toast-usage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: toast-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Toast for
+  transient CRUD feedback using the global Zag.js toaster store, Toaster
+  portal, useToast, toast types, title, description, close trigger, and token
+  styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/toast.tsx"
+  - "libs/ui/src/tokens/components/molecules/_toast.css"
+  - "libs/ui/stories/molecules/toast.stories.tsx"
+  - "libs/ui/src/molecules/figma/toast.figma.tsx"
+  - "https://zagjs.com/components/react/toast"
+---
+
+# @techsio/ui-kit Toast Usage
+
+Use Toast for transient feedback after actions. Use StatusText for inline field
+messages and Dialog for blocking decisions.
+
+## Setup
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Toaster, useToast } from "@techsio/ui-kit/molecules/toast"
+
+function AppShell() {
+  return <Toaster />
+}
+
+function SaveButton() {
+  const toaster = useToast()
+
+  return (
+    <Button
+      onClick={() =>
+        toaster.create({
+          type: "success",
+          title: "Saved",
+          description: "Changes were saved.",
+        })
+      }
+    >
+      Save
+    </Button>
+  )
+}
+```
+
+Supported API:
+
+```text
+Toaster: portal renderer for global store
+useToast(): toaster store
+types styled by tokens: error | success | info | warning | loading
+store defaults: bottom-end, gap 16, offsets 24px
+```
+
+## Core Patterns
+
+### Mount Toaster once
+
+Place `Toaster` in the app shell/layout, not in each button or form.
+
+### Use for operation feedback
+
+CRUD success, failed save, queued operation, or copied-to-clipboard fit Toast.
+
+### Keep messages short
+
+Use title and optional description. Long guidance belongs inline or in Dialog.
+
+## Common Mistakes
+
+### HIGH Local alert div
+
+Wrong:
+
+```tsx
+{saved && <div className="fixed bottom-4 right-4 bg-green-600">Saved</div>}
+```
+
+Correct:
+
+```tsx
+const toaster = useToast()
+
+return <Button onClick={() => toaster.create({ type: "success", title: "Saved" })}>Save</Button>
+```
+
+Source: libs/ui/src/molecules/toast.tsx
+
+### HIGH Toaster inside repeated component
+
+Wrong:
+
+```tsx
+function SaveButton() { return <><Toaster /><Button /></> }
+```
+
+Correct:
+
+```tsx
+function AppShell() { return <Toaster /> }
+```
+
+Source: https://zagjs.com/components/react/toast
+
+### HIGH Inline toast styling
+
+Wrong:
+
+```tsx
+<div className="bg-green-600 text-white shadow-lg">Saved</div>
+```
+
+Correct:
+
+```tsx
+<Button onClick={() => toaster.create({ type: "success", title: "Saved" })}>Save</Button>
+```
+
+Source: libs/ui/src/tokens/components/molecules/_toast.css
+
+## Validation Commands
+
+```sh
+rg -n "fixed bottom|toast\\.success|<Toaster|useToast\\(\\)" apps
+rg -n "bg-green-600|bg-red-600|role=\"alert\"" apps
+rg -n "<Toaster[\\s\\S]{0,200}<Button|function .*Button[\\s\\S]{0,400}<Toaster" apps -U
+```

--- a/libs/ui/agent-plugin/skills/tooltip-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/tooltip-usage/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: tooltip-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit Tooltip for
+  supplemental hover/focus help using the Zag.js tooltip wrapper, supported
+  timing, placement, interaction, controlled state, and token styling props.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - app-token-overrides
+sources:
+  - "libs/ui/src/atoms/tooltip.tsx"
+  - "libs/ui/src/tokens/components/atoms/_tooltip.css"
+  - "libs/ui/stories/atoms/tooltip.stories.tsx"
+  - "libs/ui/src/atoms/figma/tooltip.figma.tsx"
+  - "https://zagjs.com/components/react/tooltip"
+---
+
+# @techsio/ui-kit Tooltip Usage
+
+Use Tooltip for short supplemental information on hover/focus. Do not use it
+for required instructions, blocking errors, or primary content.
+
+## Setup
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Tooltip } from "@techsio/ui-kit/atoms/tooltip"
+
+<Tooltip content="Search products" placement="top">
+  <Button aria-label="Search" icon="icon-[mdi--magnify]" />
+</Tooltip>
+```
+
+Supported UI-kit props:
+
+```text
+content: ReactNode
+size: sm | md | lg
+variant: default | outline
+openDelay, closeDelay, interactive, defaultOpen, open, onOpenChange, disabled
+closeOnEscape, closeOnPointerDown, closeOnScroll, closeOnClick
+placement, gutter, offset, flip, sameWidth, boundary, listeners, strategy
+```
+
+## Core Patterns
+
+### Use for supplemental help only
+
+```tsx
+<Tooltip content="The SKU is visible to warehouse staff.">
+  <Button theme="unstyled" aria-label="SKU help" icon="icon-[mdi--help-circle-outline]" />
+</Tooltip>
+```
+
+If the text is required to complete the task, render visible help text instead.
+
+### Prefer component triggers
+
+```tsx
+<Tooltip content="Delete product">
+  <Button variant="danger" aria-label="Delete product" icon="icon-[mdi--trash-can-outline]" />
+</Tooltip>
+```
+
+Use UI-kit Button/Icon props for triggers instead of native buttons.
+
+### Use Zag positioning props through the wrapper
+
+```tsx
+<Tooltip
+  content="Copied"
+  placement="bottom-end"
+  openDelay={100}
+  closeDelay={150}
+>
+  <Button>Copy</Button>
+</Tooltip>
+```
+
+The wrapper maps placement/timing/dismiss behavior to the Zag machine.
+
+## Common Mistakes
+
+### HIGH Native title tooltip
+
+Wrong:
+
+```tsx
+<Button title="Delete product">Delete</Button>
+```
+
+Correct:
+
+```tsx
+<Tooltip content="Delete product">
+  <Button>Delete</Button>
+</Tooltip>
+```
+
+Source: libs/ui/src/atoms/tooltip.tsx
+
+### HIGH Custom hover popover
+
+Wrong:
+
+```tsx
+<div onMouseEnter={open} className="relative">
+  <button>Help</button>
+  {open && <div className="absolute rounded bg-black p-2 text-white">Help</div>}
+</div>
+```
+
+Correct:
+
+```tsx
+<Tooltip content="Help">
+  <Button>Help</Button>
+</Tooltip>
+```
+
+Source: https://zagjs.com/components/react/tooltip
+
+### HIGH Inline tooltip appearance
+
+Wrong:
+
+```tsx
+<Tooltip content="Help" className="bg-black text-white rounded px-2" />
+```
+
+Correct:
+
+```tsx
+<Tooltip content="Help" variant="default" size="md" />
+```
+
+Use `_tooltip.css` or app token overrides for visual changes.
+
+Source: libs/ui/src/tokens/components/atoms/_tooltip.css
+
+### MEDIUM Critical information hidden in tooltip
+
+Wrong:
+
+```tsx
+<Tooltip content="Password must contain 12 characters">
+  <Input type="password" />
+</Tooltip>
+```
+
+Correct:
+
+```tsx
+<FormInput
+  type="password"
+  helperText="Password must contain 12 characters."
+/>
+```
+
+Visible field help should not depend on hover/focus discovery.
+
+## Validation Commands
+
+```sh
+rg -n "title=\"|onMouseEnter|onMouseLeave" apps
+rg -n "<Tooltip[^>]*className=.*(bg-|text-|rounded-|px-|py-)" apps
+rg -U -n "<Tooltip[\\s\\S]{0,240}<button\\b" apps
+rg -n "openDelay|closeDelay|placement|interactive|closeOn" apps
+```

--- a/libs/ui/agent-plugin/skills/tree-view-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/tree-view-usage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: tree-view-usage
+description: >
+  Use after component-usage-ux when an app needs @techsio/ui-kit TreeView for
+  hierarchical data with Zag.js tree-view behavior, node collection, branch and
+  item parts, selection behavior, icons, indentation, expansion, selection, and
+  keyboard/typeahead support.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-usage-ux
+  - zag-compound-components
+  - app-token-overrides
+sources:
+  - "libs/ui/src/molecules/tree-view.tsx"
+  - "libs/ui/src/tokens/components/molecules/_tree-view.css"
+  - "libs/ui/stories/molecules/tree-view.stories.tsx"
+  - "libs/ui/src/molecules/figma/tree-view.figma.tsx"
+  - "https://zagjs.com/components/react/tree-view"
+---
+
+# @techsio/ui-kit TreeView Usage
+
+Use TreeView for hierarchical navigation or selection. Do not flatten trees
+into custom nested lists when keyboard navigation/selection matters.
+
+## Setup
+
+```tsx
+<TreeView data={nodes} selectionMode="single" defaultExpandedValue={["catalog"]}>
+  <TreeView.Label>Catalog</TreeView.Label>
+  <TreeView.Tree>
+    {nodes.map((node, index) => <TreeView.Node key={node.id} node={node} indexPath={[index]} />)}
+  </TreeView.Tree>
+</TreeView>
+```
+
+Supported root props:
+
+```text
+data: TreeNode[]
+selectionBehavior: all | leaf-only | custom
+selectionMode: single | multiple
+expandedValue/defaultExpandedValue, selectedValue/defaultSelectedValue
+focusedValue, expandOnClick, typeahead
+onExpandedChange, onSelectionChange, onFocusChange
+size: sm | md | lg
+```
+
+## Core Patterns
+
+### Use TreeView.Node for default rendering
+
+The default node component composes branch/item parts, icons, indent guides,
+hover handlers, branch indicators, and recursive children.
+
+### Choose selectionBehavior deliberately
+
+Use `leaf-only` for file/category pickers where branches only expand. Use
+`custom` when some nodes carry `selectable: false`.
+
+### Keep data IDs stable
+
+`id` drives Zag node value. Do not use array index as node id.
+
+## Common Mistakes
+
+### HIGH Custom nested list tree
+
+Wrong:
+
+```tsx
+<ul>{nodes.map((n) => <li onClick={() => select(n)}>{n.name}</li>)}</ul>
+```
+
+Correct:
+
+```tsx
+<TreeView data={nodes}><TreeView.Tree>{nodes.map((n, i) => <TreeView.Node node={n} indexPath={[i]} />)}</TreeView.Tree></TreeView>
+```
+
+Source: libs/ui/src/molecules/tree-view.tsx
+
+### HIGH Index as id
+
+Wrong:
+
+```tsx
+{ id: String(index), name: category.name }
+```
+
+Correct:
+
+```tsx
+{ id: category.slug, name: category.name }
+```
+
+Source: https://zagjs.com/components/react/tree-view
+
+### HIGH Inline tree node styling
+
+Wrong:
+
+```tsx
+<TreeView.Item className="pl-4 hover:bg-gray-100" />
+```
+
+Correct:
+
+```tsx
+<TreeView.Node node={node} indexPath={indexPath} />
+```
+
+Source: libs/ui/src/tokens/components/molecules/_tree-view.css
+
+## Validation Commands
+
+```sh
+rg -U -n "<ul[\\s\\S]{0,400}(children|nodes|tree)|<TreeView\\.Item[^>]*className=.*(pl-|bg-|hover:)" apps
+rg -n "id: String\\(index\\)|id: index|selectionBehavior=\"(branches|leaves)\"" apps
+rg -U -P -n "<TreeView(?![\\s\\S]{0,500}<TreeView\\.Tree)" apps
+```

--- a/libs/ui/agent-plugin/skills/ui-component-usage/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-component-usage/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: ui-component-usage
+description: >
+  Router for using @techsio/ui-kit components in apps (correct imports, variants, tokens,
+  UX rules). Use when implementing app UI with the kit rather than developing the kit
+  itself. Invoke explicitly with $ui-component-usage <component>.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit component usage (router)
+
+Per-component usage guides are bundled with this plugin as `<component>-usage` skills —
+this skill only routes there. Do NOT guess props: read the matching guide, then the
+component types from the installed package.
+
+## Order of reading
+
+1. `component-usage-ux` skill — global usage/UX rules (always first)
+2. `<component>-usage` skill — the specific component
+3. If styling/overrides are needed: `app-token-overrides` skill
+   (app-side tokens; never patch the kit from an app)
+
+## Available per-component guides
+
+accordion, badge, breadcrumb, button, carousel, checkbox, color-select, combobox, dialog,
+footer, form-checkbox, form-input, form-numeric-input, form-textarea, gallery, header, icon,
+image, input, label, link, link-button, menu, numeric-input, pagination, phone-input,
+popover, product-card, radio-card, radio-group, rating, search-form, select, skeleton,
+slider, status-text, steps, switch, table, tabs, textarea, toast, tooltip, tree-view
+— each bundled as the `<name>-usage` skill.
+
+## Import pattern
+
+```ts
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Select } from "@techsio/ui-kit/molecules/select"
+```
+
+Token CSS in the app entry: `@techsio/ui-kit/tokens` (tokens only) or
+`@techsio/ui-kit/tokens-with-tailwind`; app bootstrap per the bundled
+`app-token-initialization` skill.
+
+## Rules of thumb
+
+- Never rebuild something the kit ships — a data grid is the kit `Table`, not `<table>`.
+- Style via kit variants + semantic token classes; no arbitrary Tailwind values.
+- New requirement the kit can't express → file it as kit work ($ui-new-component), don't
+  fork the component into the app.

--- a/libs/ui/agent-plugin/skills/ui-figma-sync/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-figma-sync/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: ui-figma-sync
+description: >
+  Keep @techsio/ui-kit and Figma in sync: Code Connect (*.figma.tsx) mappings, Figma
+  variable naming/aliasing, and the token export pipeline. Use after a component's public
+  API or visuals changed. Invoke explicitly with $ui-figma-sync.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit ↔ Figma sync
+
+Code is the source of truth; Figma mirrors the code token hierarchy. Deep guidance:
+the bundled `figma-sync-handoff` skill + the "Figma Sync Rules" section of
+`libs/ui/AGENTS.md`.
+
+## Code Connect
+
+- Mapping file per component: `libs/ui/src/<level>/<name>.figma.tsx`
+  (config: `libs/ui/figma.config.json`, alias `@libs/ui/* → src/*`).
+- Validate: `pnpm --dir libs/ui figma:connect:parse`
+- Publish (needs Figma auth; only when explicitly asked):
+  `pnpm --dir libs/ui figma:connect:publish`
+
+## Figma variables
+
+- Hierarchy mirrors code: primitives → semantic aliases → component aliases; component
+  variables alias upward, never hold raw values when an upper token exists.
+- Names: `property/component/cssProperty/variant/state`, omitting non-varying segments —
+  `color/button/bg/primary/hover`, `spacing/form-field/gap`.
+- Explicit scopes (never ALL_SCOPES); code syntax set to the real custom property
+  (`var(--color-button-bg-primary)`).
+- Export/merge pipeline: `.agents/skills/figma-token-binding/scripts/` — regenerates
+  `src/tokens/figma/variables.css` + `brand-overrides.css`; never hand-edit those.
+
+## Checklist when a component changed
+
+1. Props added/renamed → update `<name>.figma.tsx` and re-parse.
+2. New tokens → mirror as Figma variables with correct aliasing + scopes.
+3. Visual change → flag for a fresh Figma screenshot/spec check (figma MCP:
+   `get_design_context` / `get_screenshot`).

--- a/libs/ui/agent-plugin/skills/ui-kit-publish-readiness/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-kit-publish-readiness/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: ui-kit-publish-readiness
+description: >
+  Use before releasing or packaging @techsio/ui-kit. Checks RSLib build,
+  package subpath exports, publint, token validators, Storybook build/a11y,
+  component screenshots, files array, and semantic-release CI constraints.
+type: lifecycle
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-consistency-validation
+sources:
+  - "libs/ui/package.json"
+  - "libs/ui/project.json"
+  - "libs/ui/rslib.config.ts"
+  - "libs/ui/release.config.mjs"
+  - "libs/ui/scripts/storybook-a11y.sh"
+  - "libs/ui/scripts/storybook-a11y-summary.mjs"
+  - "libs/ui/scripts/run-component-tests.mjs"
+---
+
+# @techsio/ui-kit Publish Readiness Checklist
+
+Run this before publishing or when package-level changes could affect
+consumers.
+
+## Package Checks
+
+### Check: package exports are subpath-based
+
+Expected:
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+import { Dialog } from "@techsio/ui-kit/molecules/dialog"
+```
+
+Fail condition: examples or docs import from `@techsio/ui-kit` root.
+Fix: use the exported atoms/molecules/organisms/templates subpaths.
+
+### Check: token CSS entrypoints are public
+
+Expected:
+
+```css
+@import "@techsio/ui-kit/tokens";
+@import "@techsio/ui-kit/tokens-with-tailwind";
+```
+
+Fail condition: an app deep-imports `@techsio/ui-kit/src/tokens/...`.
+Fix: use package exports or adjust package exports intentionally.
+
+### Check: release runs only in CI
+
+Expected:
+
+```sh
+GITHUB_ACTIONS=true pnpm --dir libs/ui semantic-release
+```
+
+Fail condition: local `semantic-release` is expected to publish.
+Fix: release is restricted by `release.config.mjs` to GitHub Actions.
+
+## Validation Commands
+
+```sh
+pnpm --dir libs/ui validate:tokens
+bunx nx run ui:build
+pnpm --dir libs/ui build:storybook
+pnpm --dir libs/ui storybook:a11y
+pnpm --dir libs/ui test:components
+pnpm --dir libs/ui figma:connect:parse
+```
+
+Run the full set only for release readiness. For normal changes, run the
+focused subset from `component-consistency-validation`.
+
+## Common Mistakes
+
+### HIGH Expecting root package imports
+
+Wrong:
+
+```tsx
+import { Button } from "@techsio/ui-kit"
+```
+
+Correct:
+
+```tsx
+import { Button } from "@techsio/ui-kit/atoms/button"
+```
+
+The package exports wildcard subpaths, not a root barrel.
+
+Source: libs/ui/package.json
+
+### HIGH Running semantic-release locally
+
+Wrong:
+
+```sh
+pnpm --dir libs/ui semantic-release
+```
+
+Correct:
+
+```text
+Let GitHub Actions run semantic-release on master/main.
+```
+
+`release.config.mjs` throws unless `GITHUB_ACTIONS === "true"`.
+
+Source: libs/ui/release.config.mjs
+
+### MEDIUM Skipping build after export changes
+
+Wrong:
+
+```text
+Change package.json exports and skip build.
+```
+
+Correct:
+
+```sh
+bunx nx run ui:build
+```
+
+RSLib and publint checks catch package structure and export mistakes.
+
+Source: libs/ui/rslib.config.ts
+
+## Pre-Release Summary
+
+- [ ] Subpath imports verified
+- [ ] Token entrypoints verified
+- [ ] `validate:tokens` run
+- [ ] `ui:build` run
+- [ ] Storybook/a11y checked when visuals changed
+- [ ] Code Connect parse checked when Figma mappings changed

--- a/libs/ui/agent-plugin/skills/ui-kit-workflow-orchestrator/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-kit-workflow-orchestrator/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: ui-kit-workflow-orchestrator
+description: >
+  Use first when a task could touch @techsio/ui-kit in libs/ui or an apps/*
+  consumer. Routes component authoring, app usage, token work, Storybook,
+  validation, framework adapters, Figma handoff, and Intent skill maintenance
+  without crossing library/app scope accidentally.
+type: lifecycle
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/skills/_artifacts/domain_map.yaml"
+  - "libs/ui/skills/_artifacts/skill_spec.md"
+  - "libs/ui/skills/_artifacts/skill_tree.yaml"
+---
+
+# @techsio/ui-kit Workflow Orchestrator
+
+Load this before deciding how to work with `@techsio/ui-kit`. It separates
+library authoring in `libs/ui` from app adoption in `apps/*`.
+
+## Routing Setup
+
+Classify the task first.
+
+```text
+Change inside libs/ui component source, token CSS, or stories
+-> component-authoring
+-> tailwind-token-authoring if CSS tokens change
+-> storybook-authoring if stories change
+-> component-consistency-validation before handoff
+-> figma-sync-handoff if public component API or visuals changed
+
+Change inside apps/* that consumes @techsio/ui-kit
+-> component-usage-ux
+-> load the exact per-component *-usage skill
+-> app-token-overrides for visual differences
+-> framework-consumer-integration for NextLink/NextImage or other adapters
+-> app-ui-kit-audit before handoff
+```
+
+## Core Patterns
+
+### Keep libs/ui and apps/* work separate
+
+```text
+libs/ui task:
+  change shared component API, tokens, stories, validation, package exports
+
+apps/* task:
+  choose existing UI-kit component, pass valid props, map app visuals through tokens
+```
+
+Cross the boundary only when app work exposes a real UI-kit API or token gap.
+
+### Use component-usage-ux as a router
+
+```text
+Need a destructive action button
+-> component-usage-ux
+-> button-usage
+-> app-token-overrides only if Button tokens cannot express the app visual
+```
+
+Do not make `component-usage-ux` decide every prop by itself. It routes to the
+component-specific skill.
+
+### Treat Figma as a handoff
+
+```text
+New public component or visual/API change
+-> figma-sync-handoff
+-> point to .agents/skills/component-to-figma/SKILL.md
+```
+
+Do not edit Figma automatically from ordinary UI-kit skills.
+
+### Recommend validation by touched area
+
+```sh
+bunx biome check --write libs/ui/src/atoms/button.tsx
+pnpm --dir libs/ui validate:tokens
+bunx nx run ui:build
+```
+
+Run narrow checks by default. Ask the maintainer before broader Storybook,
+a11y, or screenshot runs unless the task already requires them.
+
+## Common Mistakes
+
+### HIGH Crossing library and app scope
+
+Wrong:
+
+```text
+An app page needs different Button padding.
+Rewrite libs/ui/src/atoms/button.tsx immediately.
+```
+
+Correct:
+
+```text
+Check Button props and tokens first.
+Use app-token-overrides.
+Escalate to component-authoring only if the UI kit has an API gap.
+```
+
+This keeps app-specific design from becoming a shared library regression.
+
+Source: libs/ui/skills/_artifacts/consumer_app_usage_rules.md
+
+### HIGH Skipping follow-up skills
+
+Wrong:
+
+```text
+Add src/molecules/tree-view.tsx changes and stop.
+```
+
+Correct:
+
+```text
+Run component-authoring.
+Update Storybook if behavior or examples changed.
+Run component-consistency-validation.
+Use figma-sync-handoff for public API or visual changes.
+```
+
+Component work in this repo normally spans TSX, CSS tokens, stories, and
+validation.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Solving data fetching in UI skills
+
+Wrong:
+
+```text
+Rewrite app loader/query logic while choosing Dialog and Button props.
+```
+
+Correct:
+
+```text
+Keep the UI-kit skill focused on component choice, presentation state, tokens,
+and accessibility. Leave data fetching to app-specific skills.
+```
+
+The maintainer scope for these skills is UI/UX, not app data flow.
+
+Source: libs/ui/skills/_artifacts/domain_map.yaml
+
+## Validation Commands
+
+```sh
+node -e 'const fs=require("node:fs"); const YAML=require("yaml"); YAML.parse(fs.readFileSync("libs/ui/skills/_artifacts/skill_tree.yaml","utf8"))'
+bunx biome check --write libs/ui/skills/ui-kit-workflow-orchestrator/SKILL.md
+```

--- a/libs/ui/agent-plugin/skills/ui-new-component/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-new-component/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: ui-new-component
+description: >
+  Scaffold a new @techsio/ui-kit component in libs/ui. Use when asked to create a new
+  atom, molecule, organism, or template — walks through component source with tv(),
+  token CSS, story, and Figma follow-up. Invoke explicitly with $ui-new-component <name>.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# New ui-kit component
+
+Deep guidance lives in the bundled `component-authoring` skill — read it before writing
+code. This skill is the checklist and file map.
+
+## 1. Classify
+
+- **atom** — single element, no Zag machine (`src/atoms/`)
+- **molecule** — interactive/compound, usually a Zag.js machine (`src/molecules/`,
+  read the bundled `zag-compound-components` skill)
+- **organism** — page-level section (`src/organisms/`)
+- **template** — composition example only (`src/templates/`)
+
+## 2. Create exactly these files (kebab-case, flat, no index.ts)
+
+| File | Purpose |
+| --- | --- |
+| `libs/ui/src/<level>/<name>.tsx` | Component. `tv()` from `../utils`, component token classes only, `ref?: Ref<T>` prop (no forwardRef), `type` not `interface`, named export. |
+| `libs/ui/src/tokens/components/<level>/_<name>.css` | Two-layer tokens in `@theme static` (reference → derived `-bg/-fg/-border`). Register the import in `src/tokens/components/components.css`. |
+| `libs/ui/stories/<level>/<name>.stories.tsx` | CSF3 story — delegate to `$ui-story` / ui-storybook-writer. |
+| `libs/ui/src/<level>/<name>.figma.tsx` | Code Connect mapping — may be deferred; say so explicitly. |
+
+Subpath exports (`./atoms/*`, `./molecules/*`, …) are wildcard — no package.json change needed
+unless you introduce a new level.
+
+## 3. State styling
+
+Data attributes only: `data-disabled:` (boolean shorthand), `data-[state=open]:`,
+`data-[validation=error]:` (enumerated). Form-like controls reuse `form-control-base` from
+`src/tokens/components/_form-control.css`.
+
+## 4. Verify (mandatory)
+
+Run `$ui-validate` (or spawn the `ui-qa-validator` agent):
+`bunx nx run ui-kit:build` → `pnpm --dir libs/ui validate:tokens` →
+`bunx biome check --write <files>` → stories render in `bunx nx run ui-kit:storybook`.

--- a/libs/ui/agent-plugin/skills/ui-release-check/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-release-check/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: ui-release-check
+description: >
+  Check @techsio/ui-kit publish readiness before merging: exports map, files whitelist,
+  semantic-release commit types, build output, and breaking-change review. Invoke
+  explicitly with $ui-release-check.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit release check
+
+Deep guidance: the bundled `ui-kit-publish-readiness` skill. Releases run via
+semantic-release (`libs/ui/release.config.mjs`) from CI (`.github/workflows/ui-release.yml`)
+— never publish manually.
+
+## Checklist
+
+1. **Build is publishable**: `bunx nx run ui-kit:build` succeeds; rslib emits
+   `dist/{atoms,molecules,organisms,templates,theme}/*.js` + `dist/src/**/*.d.ts`
+   (publint runs as part of the build via rsbuild-plugin-publint).
+2. **Exports map intact**: every public component is reachable through the package.json
+   wildcard subpaths (`@techsio/ui-kit/atoms/*`, `/molecules/*`, …); token CSS entries
+   (`./tokens`, `./tokens-with-tailwind`, `./theme.css`, `./tokens/*`) untouched unless
+   deliberately versioned.
+3. **`files` whitelist**: `dist` + `src/tokens` — new runtime assets outside these two won't
+   ship; add them consciously.
+4. **Commit types drive the version**: `fix:` → patch, `feat:` → minor,
+   `BREAKING CHANGE:`/`!` → major. Renamed/removed props, token renames, and changed
+   data-attributes are BREAKING — check the diff for them explicitly.
+5. **Peer range**: React >= 19.2 — verify nothing added requires newer peers silently.
+6. **Quality gate passed**: `$ui-validate` for the final HEAD.
+
+Report: proposed semver bump + justification, any breaking surface found, and whether the
+changelog entry (generated from commits) will read sensibly.

--- a/libs/ui/agent-plugin/skills/ui-story/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-story/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ui-story
+description: >
+  Write or update Storybook stories for a @techsio/ui-kit component (CSF3, Storybook 10,
+  autodocs). Use when a component is added or its API changes. Invoke explicitly with
+  $ui-story <component>.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit stories
+
+Deep guidance: the bundled `storybook-authoring` skill. Copy the structure of an
+existing story (`libs/ui/stories/atoms/button.stories.tsx`) rather than inventing one.
+
+## Rules
+
+- Location: `libs/ui/stories/<level>/<name>.stories.tsx` — stories are NOT colocated.
+- Use kit components over native HTML; semantic token classes over hardcoded Tailwind
+  (`bg-danger p-100 gap-50`, never `bg-red-500 p-2 gap-1`).
+- Story order, only for what the component supports:
+  1. `Playground` (always) 2. `Variants` 3. `Sizes` 4. `States` 5. component-specific.
+- `VariantContainer` / `VariantGroup` from `stories/helpers/` for matrices;
+  `fn()` from `storybook/test` for handlers.
+- Controls only for props with visible effect (no `id`, `ref`, internal callbacks).
+
+## Verify
+
+```sh
+bunx nx run ui-kit:storybook              # renders clean
+pnpm --dir libs/ui test:components        # visual snapshots (update only intentionally)
+pnpm --dir libs/ui storybook:a11y         # a11y sweep for new components
+```

--- a/libs/ui/agent-plugin/skills/ui-theme-brand/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-theme-brand/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: ui-theme-brand
+description: >
+  Add or edit a brand theme (light/dark pair) for @techsio/ui-kit — either via the Figma
+  variables pipeline or fully in code ("vibe" a theme). Use for brand colors, data-theme
+  switching, or theme overrides. Invoke explicitly with $ui-theme-brand.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit brand theming
+
+Architecture: brands × color-scheme runtime switching via `better-themes`, `data-theme`
+attribute + `.light`/`.dark`/`.reverse` classes. Existing brands: base (default), `neo`,
+`cyber` — each with a light/dark pair. Full picture: `libs/ui/THEME-FLOW.md`.
+
+## Two ways to create a brand
+
+**1. Figma pipeline (default, when the brand is designed in Figma)**
+- Brand variables are exported per mode to `libs/ui/src/tokens/figma/<brand>/variables.css`
+  and `<brand>-dark/variables.css`.
+- Merge with the scripts in `.agents/skills/figma-token-binding/scripts/`
+  (`merge-figma-themes.mjs` emits `figma/variables.css` + `figma/brand-overrides.css`).
+- Never hand-edit the two generated files.
+
+**2. Code-authored / "vibed" brand (no Figma yet)**
+- Follow `.agents/skills/vibe-theme/` — scaffold with `scaffold-brand.mjs` (copies the base
+  brand), edit ONLY primitives and re-aliases, validate with `validate-brand.mjs`, then merge.
+- Register the brand in `libs/ui/src/theme/theme-config.ts`; it must be toggle-selectable,
+  never the new default.
+
+## Rules
+
+- A brand changes primitive values and re-aliases — never component-layer structure.
+- Brand overrides land under `[data-theme="<brand>"]` selectors in `brand-overrides.css`
+  (generated).
+- App-level (non-kit) overrides belong in the consuming app via the bundled
+  `app-token-overrides` skill, not in the kit.
+
+## Verify
+
+`pnpm --dir libs/ui validate:tokens`, then flip through brands/modes in Storybook
+(`bunx nx run ui-kit:storybook` — two toolbar switches: brand + color scheme) and run
+`pnpm --dir libs/ui test:components` if visuals of the default brand could be affected.

--- a/libs/ui/agent-plugin/skills/ui-tokens/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-tokens/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ui-tokens
+description: >
+  Work with @techsio/ui-kit design tokens: add or change component token CSS, understand
+  the token cascade, shared form-control/icon-button utilities, and run token validation.
+  Use for any change under libs/ui/src/tokens/. Invoke explicitly with $ui-tokens.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit token work
+
+Deep guidance: the bundled `tailwind-token-authoring` skill and, in-repo,
+`libs/ui/token-contribution.md`. Pipeline overview: `libs/ui/THEME-FLOW.md`.
+
+## Cascade (defined in `src/tokens/_tokens-base.css`)
+
+primitives (`_base/_colors/_spacing/_typography/_layout.css`)
+→ `_semantic.css`
+→ component tokens (`components/components.css` → `components/<level>/_<name>.css`)
+→ `figma/variables.css` (generated — never hand-edit)
+→ `figma/brand-overrides.css` (generated — brand themes under `[data-theme="…"]`)
+
+## Rules
+
+- `@theme static` blocks; two layers always — reference (`--color-button-primary`) then
+  derived (`--color-button-bg-primary`); derived must end `-bg`/`-fg`/`-border`.
+- Prefixes: `--color- --spacing- --padding- --gap- --text- --font-weight- --radius-
+  --border-width- --shadow- --opacity-`. Border widths: `--border-width-<component>`.
+- Component code consumes ONLY component token classes; semantic tokens are for stories.
+- Shared utilities: `form-control-base` (`_form-control.css`) for control chrome,
+  `_icon-button.css` (sizes 16/20/24, shared bg-pill) for icon sub-buttons.
+- Validation states: `data-[validation=error|success|warning]` — combobox is the canonical
+  pattern.
+- New token file must be imported in `components/components.css` or it silently does nothing.
+
+## Validate
+
+```sh
+pnpm --dir libs/ui validate:tokens        # usage + definitions
+pnpm --dir libs/ui check:unused-tokens    # after removals/renames
+```

--- a/libs/ui/agent-plugin/skills/ui-validate/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-validate/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ui-validate
+description: >
+  Run the full @techsio/ui-kit quality gate before commit/push: build, token validation,
+  biome on changed files, tailwind lint, visual tests, consistency checklist. Use as the
+  last step of any libs/ui change. Invoke explicitly with $ui-validate.
+metadata:
+  plugin: techsio-ui-kit-ai
+  library: "@techsio/ui-kit"
+---
+
+# ui-kit quality gate
+
+Run in order, from repo root. Stop and report on first failure.
+
+```sh
+bunx nx run ui-kit:build
+pnpm --dir libs/ui validate:tokens
+bunx biome check --write <changed files>     # NEVER "biome check ."
+pnpm --dir libs/ui lint:tailwind             # when class names changed
+pnpm --dir libs/ui test:components           # when markup/CSS changed
+```
+
+Then review the change against the bundled `component-consistency-validation` skill:
+
+- React 19 `ref` prop, no `forwardRef`; `type` not `interface`; named exports, no barrels
+- `tv()` with component token classes only (no semantic tokens, no arbitrary values)
+- Two-layer tokens registered in `components/components.css`
+- Data-attribute state styling (`data-disabled:`, `data-[state=…]:`, `data-[validation=…]:`)
+- Story exists and follows the Playground/Variants/Sizes/States order
+- `*.figma.tsx` present or explicitly deferred in the summary
+
+Visual snapshot diffs are findings — update with
+`pnpm --dir libs/ui test:components:update` only when the visual change is intended, and say
+so in the summary.
+
+## On success — mark the push gate
+
+```sh
+git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"
+```
+
+The plugin's pre-push hook blocks `git push` of libs/ui changes until this marker matches HEAD.
+
+## Known CI trap
+
+`herbatica:lint` is red on master (9 pre-existing errors) and any UI diff makes herbatika
+"affected" — that failure is not caused by UI work. Never modify apps/herbatika from a UI task.

--- a/libs/ui/agent-plugin/skills/ui-validate/SKILL.md
+++ b/libs/ui/agent-plugin/skills/ui-validate/SKILL.md
@@ -40,7 +40,10 @@ so in the summary.
 git rev-parse HEAD > "$(git rev-parse --absolute-git-dir)/ui-validate-passed"
 ```
 
-The plugin's pre-push hook blocks `git push` of libs/ui changes until this marker matches HEAD.
+The plugin installs a real git `pre-push` hook that rejects any push whose commits touch
+`libs/ui` until this marker matches the pushed ref's tip. Git gives that hook the exact refs and
+SHAs, so no form of `git push` (aliases, `--all`, `--mirror`, refspecs, config) evades it — and
+`--no-verify` is refused separately. Any new commit invalidates the marker, so validate last.
 
 ## Known CI trap
 

--- a/libs/ui/agent-plugin/skills/zag-compound-components/SKILL.md
+++ b/libs/ui/agent-plugin/skills/zag-compound-components/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: zag-compound-components
+description: >
+  Use when creating or refactoring @techsio/ui-kit interactive components with
+  Zag.js machine/connect APIs, normalizeProps, React context, compound
+  Component.Subcomponent assignments, slots, adapter props, and data attribute
+  state styling.
+type: core
+library: "@techsio/ui-kit"
+library_version: "0.3.2"
+requires:
+  - component-authoring
+  - tailwind-token-authoring
+sources:
+  - "libs/ui/AGENTS.md"
+  - "libs/ui/src/molecules/accordion.tsx"
+  - "libs/ui/src/molecules/carousel.tsx"
+  - "libs/ui/src/molecules/select.tsx"
+  - "libs/ui/src/molecules/tree-view.tsx"
+  - "libs/ui/src/organisms/header.tsx"
+  - "https://chakra-ui.com/docs/components/accordion"
+  - "https://chakra-ui.com/docs/components/menu"
+  - "https://github.com/TechsioCZ/new-engine/issues/295"
+---
+
+This skill builds on `component-authoring` and `tailwind-token-authoring`. Read
+them first for component slice and token rules.
+
+# @techsio/ui-kit Zag Compound Components
+
+Use this for interactive components in `libs/ui`.
+
+## Setup
+
+Minimum Zag-backed root:
+
+```tsx
+import * as accordion from "@zag-js/accordion"
+import { normalizeProps, useMachine } from "@zag-js/react"
+import { createContext, useContext, useId, type ReactNode } from "react"
+import { tv } from "../utils"
+
+const styles = tv({
+  slots: {
+    root: "rounded-accordion bg-accordion-bg",
+    trigger: "data-disabled:cursor-not-allowed data-[state=open]:bg-accordion-bg-open",
+  },
+})
+
+type AccordionApi = ReturnType<typeof accordion.connect>
+const AccordionContext = createContext<AccordionApi | null>(null)
+
+function useAccordionContext() {
+  const api = useContext(AccordionContext)
+  if (!api) throw new Error("Accordion components must be used within Accordion.Root")
+  return api
+}
+
+export function Accordion({ children }: { children: ReactNode }) {
+  const service = useMachine(accordion.machine, { id: useId() })
+  const api = accordion.connect(service, normalizeProps)
+  const { root } = styles()
+
+  return (
+    <AccordionContext.Provider value={api}>
+      <div {...api.getRootProps()} className={root()}>
+        {children}
+      </div>
+    </AccordionContext.Provider>
+  )
+}
+```
+
+## Core Patterns
+
+### Check Chakra compound structure before naming parts
+
+```tsx
+<Accordion.Root>
+  <Accordion.Item>
+    <Accordion.ItemTrigger>
+      <Accordion.ItemIndicator />
+    </Accordion.ItemTrigger>
+    <Accordion.ItemContent>
+      <Accordion.ItemBody />
+    </Accordion.ItemContent>
+  </Accordion.Item>
+</Accordion.Root>
+```
+
+Before inventing subcomponent names, compare the proposed API with Chakra UI
+v3 compound patterns such as Accordion and Menu. Keep the local API aligned
+with `Root`, `Trigger`, `Content`, `Item`, `Indicator`, `Positioner`, and
+similarly scoped names when they match the component anatomy.
+
+### Spread Zag props on the matching part
+
+```tsx
+Carousel.Next = function CarouselNext() {
+  const { api } = useCarouselContext()
+  return <Button {...api.getNextTriggerProps()} icon="token-icon-carousel-next" />
+}
+```
+
+Let Zag own ARIA, keyboard, disabled state, and event handlers.
+
+### Guard every compound context
+
+```tsx
+function useCarouselContext() {
+  const context = useContext(CarouselContext)
+  if (!context) {
+    throw new Error("Carousel components must be used within Carousel.Root")
+  }
+  return context
+}
+```
+
+The error should name the component and required root.
+
+### Assign subcomponents directly
+
+```tsx
+export function Carousel(props: CarouselRootProps) {
+  return <CarouselRoot {...props} />
+}
+
+Carousel.Slides = function CarouselSlides(props: CarouselSlidesProps) {
+  return <div {...props} />
+}
+```
+
+Do not export an object of subcomponents as the main API.
+
+### Style state through data attributes
+
+```tsx
+const tabs = tv({
+  slots: {
+    trigger: "data-selected:bg-tabs-trigger-bg-selected data-disabled:opacity-disabled",
+  },
+})
+```
+
+Use boolean shorthand such as `data-disabled:` and bracket syntax for
+enumerated values such as `data-[state=open]:`.
+
+## Common Mistakes
+
+### HIGH Manual ARIA instead of Zag props
+
+Wrong:
+
+```tsx
+<button aria-expanded={open} onKeyDown={handleKeyDown}>
+  Toggle
+</button>
+```
+
+Correct:
+
+```tsx
+<button {...api.getTriggerProps({ value: item.value })}>
+  Toggle
+</button>
+```
+
+Manual ARIA usually misses keyboard or focus behavior already encoded in the
+Zag machine.
+
+Source: libs/ui/AGENTS.md
+
+### HIGH Subcomponent outside root
+
+Wrong:
+
+```tsx
+<Carousel.Next />
+```
+
+Correct:
+
+```tsx
+<Carousel.Root slideCount={slides.length}>
+  <Carousel.Next />
+</Carousel.Root>
+```
+
+Compound children require the provider value created by the root.
+
+Source: libs/ui/src/molecules/carousel.tsx
+
+### MEDIUM Local state duplicates machine state
+
+Wrong:
+
+```tsx
+const [open, setOpen] = useState(false)
+return <button data-state={open ? "open" : "closed"} onClick={() => setOpen(!open)} />
+```
+
+Correct:
+
+```tsx
+const service = useMachine(accordion.machine, { id: useId() })
+const api = accordion.connect(service, normalizeProps)
+return <button {...api.getItemTriggerProps({ value: "details" })} />
+```
+
+Duplicating Zag state silently desynchronizes ARIA, keyboard behavior, and data
+attributes.
+
+Source: libs/ui/AGENTS.md
+
+### MEDIUM Compound taxonomy drift
+
+Wrong:
+
+```text
+Create a rigid FormCheckbox wrapper because a custom app layout is needed.
+```
+
+Correct:
+
+```text
+Prefer composable primitives and slots first. Add wrappers only after the
+component API cannot express the use case.
+```
+
+Issue 295 records the taxonomy direction: primitive compounds should be
+composable, while opinionated form wrappers stay separate.
+
+Source: https://github.com/TechsioCZ/new-engine/issues/295
+
+### MEDIUM Inventing nonstandard subcomponent names
+
+Wrong:
+
+```tsx
+TreeView.Panel = function TreeViewPanel() {
+  return <div />
+}
+```
+
+Correct:
+
+```tsx
+TreeView.Content = function TreeViewContent() {
+  return <div />
+}
+```
+
+Check Chakra Accordion/Menu anatomy before naming parts. Use familiar compound
+names when the role matches, and only diverge when the local component anatomy
+requires a clearer name.
+
+Source: https://chakra-ui.com/docs/components/accordion
+
+## Validation Commands
+
+```sh
+bunx biome check --write libs/ui/src/molecules/carousel.tsx
+bunx nx run ui:build
+pnpm --dir libs/ui validate:tokens
+pnpm --dir libs/ui build:storybook
+pnpm --dir libs/ui storybook:a11y
+```

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -92,6 +92,8 @@ packages:
   - '!apps/demo/**'
   - '!apps/e2e/**'
   - '!apps/typesense-demo/**'
+  # agent plugin is published separately, not a workspace package
+  - '!libs/ui/agent-plugin/**'
 
 syncInjectedDepsAfterScripts:
   - build


### PR DESCRIPTION
## Summary

Adds **techsio-ui-kit-ai** — an agent plugin for developing and consuming the `@techsio/ui-kit` design system. Built for **OpenAI Codex** (CLI, IDE extension, desktop app) and compatible with **Claude Code** (skills use the shared [Agent Skills](https://agentskills.io) standard; a `.claude-plugin/plugin.json` manifest is included).

Inspired by the Neuron FE AI plugin, scoped to design-system development only — no spec-driven workflow, just development skills and agents.

The plugin is **self-contained and intended to be published separately**; `libs/ui/agent-plugin` is only its authoring location. It is excluded from the pnpm workspace while it lives here.

## Contents

| Type | Count | Purpose |
| --- | --- | --- |
| Workflow skills | 8 | `$ui-new-component`, `$ui-tokens`, `$ui-story`, `$ui-validate`, `$ui-theme-brand`, `$ui-figma-sync`, `$ui-release-check`, `$ui-component-usage` |
| Bundled deep skills | 58 | Synced 1:1 from `libs/ui/skills/` (per-component `*-usage` guides, `component-authoring`, `tailwind-token-authoring`, …) |
| Subagents (Codex TOML) | 6 | `ui-design-system-expert`, `ui-component-dev`, `ui-token-stylist`, `ui-storybook-writer`, `ui-figma-connector`, `ui-qa-validator` |
| Hooks | 1 | Pre-push gate: blocks `git push` of `libs/ui` changes until `ui-validate` passed for HEAD |
| MCP servers | 3 | context7, figma, chrome-devtools |

`ui-design-system-expert` is the system-knowledge agent: atomic-design nesting/composition policy, token architecture and cascade, theming flow, component patterns (`tv()`, Zag compound, data-attribute states), and the validation pipeline. Consultative-first — it answers architecture questions and reviews changes rather than editing by default.

## Design notes

- **Thin plugin, deep repo skills.** `libs/ui/skills/` remains the single source of truth. The 8 authored skills are short routers into the bundled deep skills, keeping the token footprint small. `scripts/sync-skills.mjs` refreshes the bundle before each plugin release and fails on name collisions.
- **Codex spec (mid-2026).** Custom prompts (`~/.codex/prompts`) are deprecated — skills are the slash commands now (`$skill-name`). Subagents are TOML (`name`/`description`/`developer_instructions`, optional `model_reasoning_effort`, `sandbox_mode`), not markdown.
- **No pinned model names** in agents (they rot across model generations) — only reasoning effort.
- **Deterministic gates over agentic review** — the pre-push hook is a plain Node script; the QA agent runs and interprets the existing validators (`validate:tokens`, publint, Playwright snapshots).

## Testing

- JSON manifests, `hooks.json`, `package.json`, `marketplace` snippet: parse-checked
- All 6 agent TOMLs: parsed, required fields present
- All 66 `SKILL.md` files: frontmatter `name` matches directory name (agentskills.io requirement)
- Both scripts: `node --check`
- Pre-push hook: functionally tested in a throwaway git repo — allows non-push commands, allows pushes with no `libs/ui` changes, blocks a `libs/ui` push with exit 2, allows it after the HEAD marker is written
- No library code touched; no build/test targets affected

## Follow-ups (not in this PR)

- Move the folder to its own repo/marketplace and drop the `pnpm-workspace.yaml` exclusion
- Optional `agents/openai.yaml` per skill for Codex app UI metadata (icons, display names)
- Staleness check for the per-component `*-usage` skills against their `sources:` frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `techsio-ui-kit-ai` plugin for Codex and Claude Code.
  * Added specialised UI development, design-system, Storybook, Figma, token, QA and release-readiness agents.
  * Added comprehensive guidance for using UI kit components, design tokens, themes and framework integrations.
  * Added automatic skill synchronisation and a validation gate to help ensure UI changes meet quality requirements.

* **Documentation**
  * Added installation, workflow and maintenance documentation for the plugin and its bundled skills.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->